### PR TITLE
Use saved R_HOME value from libR-sys.

### DIFF
--- a/extendr-api/Cargo.toml
+++ b/extendr-api/Cargo.toml
@@ -9,5 +9,5 @@ documentation = "https://extendr.github.io/extendr/index.html"
 repository = "https://github.com/extendr/extendr"
 
 [dependencies]
-libR-sys = "0.1.3"
+libR-sys = "0.1.5"
 extendr-macros = "0.1.0"

--- a/extendr-api/build.rs
+++ b/extendr-api/build.rs
@@ -1,0 +1,5 @@
+use std::env;
+
+fn main() {
+    println!("cargo:rustc-env=R_HOME={}", env::var("DEP_R_R_HOME").unwrap());
+}

--- a/extendr-api/src/engine.rs
+++ b/extendr-api/src/engine.rs
@@ -28,8 +28,8 @@ pub fn start_r() {
             // TODO: get the default home dir from libR-sys.
             if cfg!(unix) {
                 if std::env::var("R_HOME").is_err() {
-                    // env! gets the build-time R_HOME made in build.rs
-                    std::env::set_var("R_HOME", "/usr/lib/R");
+                    // env! gets the build-time R_HOME stored by libR-sys
+                    std::env::set_var("R_HOME", env!("R_HOME"));
                 }
             }
     


### PR DESCRIPTION
(Depends on https://github.com/extendr/libR-sys/pull/2)

Increases the chances of things working out of the box by avoiding hard-coding a default value of R_HOME, and getting it from libR-sys instead.  Tested on Fedora and MacOS/homebrew.