### PR TITLE
bump version to 0.1.5 for both extendr-api and extendr-macros.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 # R CMD INSTALL produces these files.
 **/*.o
 **/*.so
+.Rproj.user

--- a/extendr-api/Cargo.toml
+++ b/extendr-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extendr-api"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["andy-thomason <andy@andythomason.com>"]
 edition = "2018"
 description = "Safe and user friendly bindings to the R programming language."
@@ -10,5 +10,5 @@ repository = "https://github.com/extendr/extendr"
 
 [dependencies]
 libR-sys = "0.1.9"
-extendr-macros = { path = "../extendr-macros", version="0.1.2" }
+extendr-macros = { path = "../extendr-macros", version="0.1.5" }
 ndarray = "0.13.1"

--- a/extendr-api/examples/R/hello/.Rbuildignore
+++ b/extendr-api/examples/R/hello/.Rbuildignore
@@ -2,3 +2,5 @@
 ^.*\.tar\.gz$
 ^target/
 ^.*\.so$
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/extendr-macros/Cargo.toml
+++ b/extendr-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extendr-macros"
-version = "0.1.2"
+version = "0.1.5"
 authors = ["andy-thomason <andy@andythomason.com>"]
 edition = "2018"
 description = "Generate bindings from R to Rust."


### PR DESCRIPTION
We need to bump the version of extendr-macros so we can update it on crates.io. I think it's best to keep the versions of extendr-api and extendr-macros the same at all times, so I've bumped them both to 0.1.5.