### PR TITLE
Add extendr module to hello example

### DIFF
--- a/extendr-api/Cargo.toml
+++ b/extendr-api/Cargo.toml
@@ -10,5 +10,5 @@ repository = "https://github.com/extendr/extendr"
 
 [dependencies]
 libR-sys = "0.1.9"
-extendr-macros = { path = "../extendr-macros", version="0.1.2" }
+extendr-macros = { path = "../extendr-macros", version="0.1.3" }
 ndarray = "0.13.1"

--- a/extendr-api/examples/R/data/tests/test_data.R
+++ b/extendr-api/examples/R/data/tests/test_data.R
@@ -1,0 +1,21 @@
+
+library(data)
+
+input = list(
+    # scalars
+    an_integer = 123L,
+    a_number = 2.5,
+    a_string = "hello",
+    a_bool = TRUE,
+    a_list = list(a=1L, 2L, c=3L),
+
+    # vectors
+    an_integer_array = c(1L, 2L, 3L),
+    a_number_array = c(1., 2., 3.),
+    a_string_array = c("1", "2", "3"),
+    a_logical_array = c(TRUE, FALSE, TRUE)
+)
+
+stopifnot(
+    data(input)
+)

--- a/extendr-api/examples/R/hello/src/entrypoint.c
+++ b/extendr-api/examples/R/hello/src/entrypoint.c
@@ -4,7 +4,8 @@
 // the linker removing the static library.
 //
 // This will be removed in future versions with the module macro.
-void wrap__hello();
+void R_init_libhello();
 
-void *x = (void*)&wrap__hello;
+void *__dummy = (void*)&R_init_libhello;
+
 

--- a/extendr-api/examples/R/hello/src/lib.rs
+++ b/extendr-api/examples/R/hello/src/lib.rs
@@ -7,5 +7,6 @@ fn hello() -> &'static str {
 
 // Macro to generate exports
 extendr_module! {
+    mod hello;
     fn hello;
 }

--- a/extendr-api/examples/R/hello/src/lib.rs
+++ b/extendr-api/examples/R/hello/src/lib.rs
@@ -5,3 +5,7 @@ fn hello() -> &'static str {
     "hello"
 }
 
+// Macro to generate exports
+extendr_module! {
+    fn hello;
+}

--- a/extendr-macros/Cargo.toml
+++ b/extendr-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extendr-macros"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["andy-thomason <andy@andythomason.com>"]
 edition = "2018"
 description = "Generate bindings from R to Rust."


### PR DESCRIPTION
With the new macro system, we can add modules to libraries.

This is currently in the classes example, but not in the hello example.
