### PR TITLE
Rprint macros

### DIFF
--- a/extendr-api/src/args.rs
+++ b/extendr-api/src/args.rs
@@ -105,7 +105,7 @@ macro_rules! lang {
 mod tests {
     //use crate::args;
     use super::*;
-    use crate::{end_r, start_r};
+    use crate::start_r;
 
     #[test]
     fn test_args() {
@@ -123,6 +123,6 @@ mod tests {
         assert_eq!(args!(1+1), vec![("", Robj::from(2))]);
         assert_eq!(args!(1+1, 2), [("", Robj::from(2)), ("", Robj::from(2))]);
         assert_eq!(args!(a=1+1, b=2), [("a", Robj::from(2)), ("b", Robj::from(2))]);*/
-        end_r();
+        //end_r();
     }
 }

--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -311,4 +311,16 @@ mod tests {
             assert_eq!(new_borrowed(wrap__return_f64()), Robj::from(123.));
         }
     }
+
+    #[test]
+    fn r_output_test() {
+        let fifo = lang!("fifo", Robj::from("")).eval().unwrap();
+        let fifo = unsafe { fifo.get() };
+        println!("{:?}", fifo);
+        lang!("sink", fifo).eval_blind();
+        rprintln!("Hello world");
+        lang!("sink").eval_blind();
+        let result : Robj = lang!("readLines", fifo).eval_blind();
+        assert_eq!(result, Robj::from("Hello world"));
+    }
 }

--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -83,6 +83,9 @@ pub use libR_sys::R_registerRoutines;
 pub use libR_sys::R_useDynamicSymbols;
 pub use libR_sys::SEXP;
 
+use libR_sys::*;
+use std::ffi::CString;
+
 /// Generic dynamic error type.
 pub type AnyError = Box<dyn std::error::Error + Send + Sync>;
 
@@ -126,6 +129,20 @@ pub unsafe fn register_call_methods(info: *mut libR_sys::DllInfo, methods: &[Cal
 //     eprintln!("[{}]", rcode);
 //     Robj::eval_string(rcode.as_str()).unwrap();
 // }
+
+pub fn print_r_output<T: Into<Vec<u8>>>(s: T) {
+    let cs = CString::new(s).expect("NulError");
+    unsafe {
+        Rprintf(cs.as_ptr());
+    }
+}
+
+pub fn print_r_error<T: Into<Vec<u8>>>(s: T) {
+    let cs = CString::new(s).expect("NulError");
+    unsafe {
+        REprintf(cs.as_ptr());
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -316,7 +316,6 @@ mod tests {
     fn r_output_test() {
         let fifo = lang!("fifo", Robj::from("")).eval().unwrap();
         let fifo = unsafe { fifo.get() };
-        println!("{:?}", fifo);
         lang!("sink", fifo).eval_blind();
         rprintln!("Hello world");
         lang!("sink").eval_blind();

--- a/extendr-api/src/rmacros.rs
+++ b/extendr-api/src/rmacros.rs
@@ -107,3 +107,53 @@ macro_rules! data_frame {
         lang!("data.frame", $($rest)*).eval_blind()
     };
 }
+
+/// Print via the R output stream.
+///
+/// Works like print! but integrates with R and respects
+/// redirection with functions like sink and capture.output
+#[macro_export]
+macro_rules! rprint {
+    () => {
+    };
+    ($($rest: tt)*) => {
+        print_r_output(format!($($rest)*));
+    };
+}
+
+/// Print with a newline via the R output stream.
+///
+/// Works like println! but integrates with R and respects
+/// redirection with functions like sink and capture.output
+#[macro_export]
+macro_rules! rprintln {
+    () => {
+        print_r_output("\n");
+    };
+    ($($rest: tt)*) => {
+        print_r_output(format!($($rest)*));
+        print_r_output("\n");
+    };
+}
+
+/// Print via the R error stream.
+#[macro_export]
+macro_rules! reprint {
+    () => {
+    };
+    ($($rest: tt)*) => {
+        print_r_error(format!($($rest)*));
+    };
+}
+
+/// Print with a newline via the R output stream.
+#[macro_export]
+macro_rules! reprintln {
+    () => {
+        print_r_error("\n");
+    };
+    ($($rest: tt)*) => {
+        print_r_error(format!($($rest)*));
+        print_r_error("\n");
+    };
+}

--- a/extendr-api/src/rmacros.rs
+++ b/extendr-api/src/rmacros.rs
@@ -110,8 +110,8 @@ macro_rules! data_frame {
 
 /// Print via the R output stream.
 ///
-/// Works like print! but integrates with R and respects
-/// redirection with functions like sink and capture.output
+/// Works like [`print!`] but integrates with R and respects
+/// redirection with functions like `sink()` and `capture.output()`
 #[macro_export]
 macro_rules! rprint {
     () => {
@@ -123,8 +123,8 @@ macro_rules! rprint {
 
 /// Print with a newline via the R output stream.
 ///
-/// Works like println! but integrates with R and respects
-/// redirection with functions like sink and capture.output
+/// Works like [`println!`] but integrates with R and respects
+/// redirection with functions like `sink()` and `capture.output()`
 #[macro_export]
 macro_rules! rprintln {
     () => {


### PR DESCRIPTION
Add a family of printing macros (resolves #36) 

There's an automated test in a separate commit.  I don't know how much value this is really adding, but was curious whether it was even possible, without resorting to extra helper scripts.  The answer is yes, but it's a little finicky.  Note that I had to remove a call to end_r elsewhere in the test suite because -- while R still mostly works after calling this -- its tmp directory no longer exists, so the fifo trick I used in the rprintln! test won't work.