### PR TITLE
implement From<String> for Robj.

### DIFF
--- a/extendr-api/src/robj.rs
+++ b/extendr-api/src/robj.rs
@@ -1351,6 +1351,14 @@ impl<'a> From<&'a str> for Robj {
     }
 }
 
+/// Convert a String to an Robj string array object.
+impl From<String> for Robj {
+    fn from(val: String) -> Self {
+        Robj::from(&*val)
+    }
+}
+
+/// Convert an array of string refs to an Robj string array object.
 impl<'a> From<&'a [&str]> for Robj {
     fn from(vals: &'a [&str]) -> Self {
         unsafe {
@@ -1565,6 +1573,8 @@ mod tests {
         assert_eq!(format!("{:?}", Robj::from(1)), "1");
         assert_eq!(format!("{:?}", Robj::from(1.)), "1.0");
         assert_eq!(format!("{:?}", Robj::from("hello")), "[\"hello\"]");
+        let s = "hello".to_string();
+        assert_eq!(format!("{:?}", Robj::from(s)), "[\"hello\"]");
 
         // Vectors
         assert_eq!(format!("{:?}", Robj::from(&[1, 2, 3][..])), "[1, 2, 3]");


### PR DESCRIPTION
This PR fixes #39 by implementing `From<String> for Robj`.

@andy-thomason I first tried your suggested approach of implementing `From<AsRef<str>>` but the compiler complained about conflicting implementations of the `From` trait. (I believe it'd be conflicting with `From<SEXP> for Robj`.) So explicitly implementing this trait just for `String` seems the way to go.