### PR TITLE
Fix GH Actions status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Low-level R library bindings
 
-[![Github Actions Build Status](https://github.com/extendr/extendr/workflows/test/badge.svg)](https://github.com/extendr/extendr/actions)
+[![Github Actions Build Status](https://github.com/extendr/extendr/workflows/Tests/badge.svg)](https://github.com/extendr/extendr/actions)
 [![Crates.io](http://meritbadge.herokuapp.com/extendr-api)](https://crates.io/crates/extendr-api)
 [![Documentation](https://docs.rs/mio/badge.svg)](https://docs.rs/extendr-api)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
Apparently we have to use the value in the `name:` field if that's specified.