### PR TITLE
Uncomment R_useDynamicSymbols and R_forceSymbols

### DIFF
--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -120,8 +120,8 @@ pub unsafe fn register_call_methods(info: *mut libR_sys::DllInfo, methods: &[Cal
         std::ptr::null(),
         std::ptr::null(),
     );
-    //libR_sys::R_useDynamicSymbols(info, 0);
-    //libR_sys::R_forceSymbols(info, 1);
+    libR_sys::R_useDynamicSymbols(info, 0);
+    libR_sys::R_forceSymbols(info, 1);
 }
 
 // pub fn add_function_to_namespace(namespace: &str, fn_name: &str, wrap_name: &str) {


### PR DESCRIPTION
Are there any contexts why these lines are commented out?

https://github.com/extendr/extendr/blob/5ebf0ab1dfc6e9574fe80526dca97ecf8377223b/extendr-api/src/lib.rs#L123-L124

`R_useDynamicSymbols()` needs to be called to avoid this warning:

```
File ‘helloextendr/libs/helloextendr.so’:
  Found no call to: ‘R_useDynamicSymbols’

It is good practice to register native routines and to disable symbol search.
```
(<https://github.com/clauswilke/helloextendr/runs/1466322075?check_suite_focus=true#step:9:89>)

Calling `R_forceSymbols()` is not mandatory (so Rcpp and cpp11 don't use this), but it's recommended to use in combination with `R_useDynamicSymbols()`, so I included this in this here. 

> the `R_forceSymbols` call only allows `.C` etc calls which specify entry points by R objects such as `C_pansari` (and not by character strings)
> 
> ...snip...
> 
> Finally, if `R_init_mypkg` also calls `R_forceSymbols(dll, TRUE)`, only `.Call(C_reg)` will work (and not `.Call("reg")`). This is usually what we want
(<https://cran.r-project.org/doc/manuals/r-patched/R-exts.html#Registering-native-routines>)