### PR TITLE
Deploy the dev version of docs to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,12 +15,8 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - name: Install dependencies
-        run: sudo apt-get install r-base-dev llvm-3.9-dev libclang-3.9-dev
       - name: Docs
         run: cargo doc --workspace --no-deps
-        env:
-          LIBCLANG_PATH: /usr/lib/llvm-3.9/lib
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,28 @@
+name: Documents
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  docs:
+    name: Deploy the dev version of documents to GitHub Pages
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Install dependencies
+        run: sudo apt-get install r-base-dev llvm-3.9-dev libclang-3.9-dev
+      - name: Docs
+        run: cargo doc --workspace --no-deps
+        env:
+          LIBCLANG_PATH: /usr/lib/llvm-3.9/lib
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./target/doc

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   docs:
     name: Deploy the dev version of documents to GitHub Pages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   test_linux:
     name: Run tests (Linux)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
@@ -20,16 +20,10 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust-version }}
-      - name: Install dependencies
-        run: sudo apt-get install r-base-dev llvm-3.9-dev libclang-3.9-dev
       - name: Build
         run: cargo build
-        env:
-          LIBCLANG_PATH: /usr/lib/llvm-3.9/lib
       - name: Run tests
         run: cargo test -- --nocapture --test-threads=1
-        env:
-          LIBCLANG_PATH: /usr/lib/llvm-3.9/lib
 
   test_macos:
     name: Run tests (macOS)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Low-level R library bindings
 
 [![Github Actions Build Status](https://github.com/extendr/extendr/workflows/Tests/badge.svg)](https://github.com/extendr/extendr/actions)
 [![Crates.io](http://meritbadge.herokuapp.com/extendr-api)](https://crates.io/crates/extendr-api)
-[![Documentation](https://docs.rs/mio/badge.svg)](https://docs.rs/extendr-api)
+[![Documentation](https://docs.rs/extendr-api/badge.svg)](https://docs.rs/extendr-api)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 [![Logo](https://github.com/extendr/extendr/raw/master/extendr-logo-256.png)](https://github.com/extendr/extendr/raw/master/extendr-logo-256.png)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Low-level R library bindings
 
 [![Github Actions Build Status](https://github.com/extendr/extendr/workflows/Tests/badge.svg)](https://github.com/extendr/extendr/actions)
 [![Crates.io](http://meritbadge.herokuapp.com/extendr-api)](https://crates.io/crates/extendr-api)
-[![Documentation](https://docs.rs/extendr-api/badge.svg)](https://docs.rs/extendr-api)
+[![Documentation](https://docs.rs/extendr-api/badge.svg)](https://docs.rs/extendr-api)([dev](https://extendr.github.io/extendr/extendr_api/))
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 [![Logo](https://github.com/extendr/extendr/raw/master/extendr-logo-256.png)](https://github.com/extendr/extendr/raw/master/extendr-logo-256.png)


### PR DESCRIPTION
Since docs.rs serves only the published version, providing dev docs on GitHub Pages is useful. This is not what every Rust crate does, but many packages does e.g. [diesel](https://github.com/diesel-rs/diesel) and [servo](https://github.com/servo/servo). You can view the example here: https://yutannihilation.github.io/extendr/extendr_api/

Some things I'm not sure are:

* Where to place the link to the docs: GitHub Pages doesn't have the badge
* How to generate the index page nicely: it seems rustdoc already has this functionality, but it's not available in stable `cargo doc` (c.f. https://github.com/rust-lang/cargo/issues/8229#issuecomment-633153513). Should I generate the docs by using nightly?