### PR TITLE
Move the link of the dev doc on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Low-level R library bindings
 
 [![Github Actions Build Status](https://github.com/extendr/extendr/workflows/Tests/badge.svg)](https://github.com/extendr/extendr/actions)
 [![Crates.io](http://meritbadge.herokuapp.com/extendr-api)](https://crates.io/crates/extendr-api)
-[![Documentation](https://docs.rs/extendr-api/badge.svg)](https://docs.rs/extendr-api)([dev](https://extendr.github.io/extendr/extendr_api/))
+[![Documentation](https://docs.rs/extendr-api/badge.svg)](https://docs.rs/extendr-api)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 [![Logo](https://github.com/extendr/extendr/raw/master/extendr-logo-256.png)](https://github.com/extendr/extendr/raw/master/extendr-logo-256.png)
@@ -154,3 +154,7 @@ We are happy about any contributions!
 To get started you can take a look at our [Github issues](https://github.com/extendr/extendr/issues).
 
 You can also get in contact via our [Discord server](https://discord.gg/7hmApuc)!
+
+### Development
+
+The documentation for the latest development version is available here: <https://extendr.github.io/extendr/extendr_api/>


### PR DESCRIPTION
This PR addresses @clauswilke's comment: https://github.com/extendr/extendr/pull/53#issuecomment-735554410.

I added "Development" section in "Contribution" and move the link there. Feel free to suggest a nicer location!