### PR TITLE
Return an error when length > 1 of vector is passed to a scaler argument

### DIFF
--- a/extendr-api/src/robj.rs
+++ b/extendr-api/src/robj.rs
@@ -1834,6 +1834,11 @@ mod tests {
 
         let hello = Robj::from("hello");
         assert_eq!(<&str>::from_robj(&hello), Ok("hello"));
+
+        // conversion from a vector to a scalar value
+        assert_eq!(<i32>::from_robj(&Robj::from(vec![].as_slice() as &[i32])), Err("zero length vector"));
+        assert_eq!(<i32>::from_robj(&Robj::from(vec![1].as_slice() as &[i32])), Ok(1));
+        assert_eq!(<i32>::from_robj(&Robj::from(vec![1, 2].as_slice() as &[i32])), Err(">1 length vector"));
     }
     #[test]
     fn test_to_robj() {

--- a/extendr-api/src/robj.rs
+++ b/extendr-api/src/robj.rs
@@ -65,15 +65,15 @@ macro_rules! impl_prim_from_robj {
             fn from_robj(robj: &'a Robj) -> Result<Self, &'static str> {
                 if let Some(v) = robj.as_i32_slice() {
                     match v.len() {
-                        0 => Err("zero length vector"),
+                        0 => Err("Input must be of length 1. Vector of length zero given."),
                         1 => Ok(v[0] as Self),
-                        _ => Err(">1 length vector"),
+                        _ => Err("Input must be of length 1. Vector of length >1 given."),
                     }
                 } else if let Some(v) = robj.as_f64_slice() {
                     match v.len() {
-                        0 => Err("zero length vector"),
+                        0 => Err("Input must be of length 1. Vector of length zero given."),
                         1 => Ok(v[0] as Self),
-                        _ => Err(">1 length vector"),
+                        _ => Err("Input must be of length 1. Vector of length >1 given."),
                     }
                 } else {
                     Err("unable to convert R object to primitive")
@@ -1836,9 +1836,9 @@ mod tests {
         assert_eq!(<&str>::from_robj(&hello), Ok("hello"));
 
         // conversion from a vector to a scalar value
-        assert_eq!(<i32>::from_robj(&Robj::from(vec![].as_slice() as &[i32])), Err("zero length vector"));
+        assert_eq!(<i32>::from_robj(&Robj::from(vec![].as_slice() as &[i32])), Err("Input must be of length 1. Vector of length zero given."));
         assert_eq!(<i32>::from_robj(&Robj::from(vec![1].as_slice() as &[i32])), Ok(1));
-        assert_eq!(<i32>::from_robj(&Robj::from(vec![1, 2].as_slice() as &[i32])), Err(">1 length vector"));
+        assert_eq!(<i32>::from_robj(&Robj::from(vec![1, 2].as_slice() as &[i32])), Err("Input must be of length 1. Vector of length >1 given."));
     }
     #[test]
     fn test_to_robj() {

--- a/extendr-api/src/robj.rs
+++ b/extendr-api/src/robj.rs
@@ -64,16 +64,16 @@ macro_rules! impl_prim_from_robj {
         impl<'a> FromRobj<'a> for $t {
             fn from_robj(robj: &'a Robj) -> Result<Self, &'static str> {
                 if let Some(v) = robj.as_i32_slice() {
-                    if v.len() == 0 {
-                        Err("zero length vector")
-                    } else {
-                        Ok(v[0] as Self)
+                    match v.len() {
+                        0 => Err("zero length vector"),
+                        1 => Ok(v[0] as Self),
+                        _ => Err(">1 length vector"),
                     }
                 } else if let Some(v) = robj.as_f64_slice() {
-                    if v.len() == 0 {
-                        Err("zero length vector")
-                    } else {
-                        Ok(v[0] as Self)
+                    match v.len() {
+                        0 => Err("zero length vector"),
+                        1 => Ok(v[0] as Self),
+                        _ => Err(">1 length vector"),
                     }
                 } else {
                     Err("unable to convert R object to primitive")


### PR DESCRIPTION
Fix some part of #64

``` r
library(rextendr)

rust_function(
  code = "fn one_float(input: f64) -> f64 {
    5.*input
  }",
  patch.crates_io = c(
    'extendr-api = { path = "/home/yutani/repo/extendr/extendr-api" }',
    'extendr-macros = { git = "https://github.com/extendr/extendr" }'
  )
)
#> build directory: /tmp/RtmpVtIB3g/file7a70ee5a29f
#> Prebuild libR bindings are not available. Run `install_libR_bindings()` to improve future build times.

one_float(numeric(0))
#> Error in one_float(numeric(0)): zero length vector
one_float(numeric(1))
#> [1] 0
one_float(numeric(2))
#> Error in one_float(numeric(2)): >1 length vector
```

<sup>Created on 2020-12-08 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

(I'm yet to figure out how to write tests for this...)