### PR TITLE
Add panic handling to wrappers.

### DIFF
--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -124,6 +124,22 @@ pub unsafe fn register_call_methods(info: *mut libR_sys::DllInfo, methods: &[Cal
     libR_sys::R_forceSymbols(info, 1);
 }
 
+/// This function is use by the wrapper logic to catch
+/// panics on return.
+pub fn handle_panic<F>(err_str: &str, f: F) -> SEXP
+where
+    F : FnOnce() -> SEXP,
+    F : std::panic::UnwindSafe
+{
+    match std::panic::catch_unwind(f) {
+        Ok(res) => res,
+        Err(_) => {
+            unsafe { libR_sys::Rf_error(err_str.as_ptr() as * const std::os::raw::c_char); }
+            unreachable!("handle_panic unreachable")
+        }
+    }
+}
+
 // pub fn add_function_to_namespace(namespace: &str, fn_name: &str, wrap_name: &str) {
 //     let rcode = format!("{}::{} <- function(...) .Call(\"{}\", ...)", namespace, fn_name, wrap_name);
 //     eprintln!("[{}]", rcode);

--- a/extendr-api/src/robj.rs
+++ b/extendr-api/src/robj.rs
@@ -2133,6 +2133,7 @@ type NamedListIter = std::iter::Zip<StrIter, VecIter>;
 mod tests {
     use extendr_engine::*;
     use super::*;
+    use crate::engine::*;
 
     #[test]
     fn test_debug() {

--- a/extendr-api/src/robj.rs
+++ b/extendr-api/src/robj.rs
@@ -2133,7 +2133,6 @@ type NamedListIter = std::iter::Zip<StrIter, VecIter>;
 mod tests {
     use extendr_engine::*;
     use super::*;
-    use crate::engine::*;
 
     #[test]
     fn test_debug() {

--- a/extendr-macros/src/lib.rs
+++ b/extendr-macros/src/lib.rs
@@ -182,15 +182,9 @@ fn generate_wrappers(_opts: &ExtendrOptions, wrappers: &mut Vec<ItemFn>, prefix:
             unsafe {
                 use extendr_api::FromRobj;
                 #( #convert_args )*
-                match std::panic::catch_unwind(||
+                extendr_api::handle_panic(#panic_str, ||
                     extendr_api::Robj::from(#call_name(#actual_args)).get()
-                ) {
-                    Ok(res) => res,
-                    Err(_) => {
-                        Rf_error(#panic_str.as_ptr() as * const std::os::raw::c_char);
-                        R_NilValue
-                    }
-                }
+                )
             }
         }
     ));


### PR DESCRIPTION
This PR adds a panic handler to each wrapped function.

It is difficult to test this at present, so I would appreciate if we could try *rextendr* with a function that panics to check the result.

In theory, it should convert a panic into a call to Rf_error and hence a valid R error message.
At present we do not handle and panic message, but this could be arranged.

The Rf_error message as stands is a static string coerced into Asciiz.
