### PR TITLE
Add bool and HashMap FromRobj impls.

### DIFF
--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -149,9 +149,6 @@ mod tests {
     use super::*;
     use crate as extendr_api;
 
-    // Allow macros in the tests.
-    use crate::*;
-
     use extendr_macros::extendr;
     use extendr_macros::extendr_module;
 

--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -148,6 +148,10 @@ pub fn print_r_error<T: Into<Vec<u8>>>(s: T) {
 mod tests {
     use super::*;
     use crate as extendr_api;
+
+    // Allow macros in the tests.
+    use crate::*;
+
     use extendr_macros::extendr;
     use extendr_macros::extendr_module;
 

--- a/extendr-api/src/logical.rs
+++ b/extendr-api/src/logical.rs
@@ -2,6 +2,16 @@
 #[derive(Debug)]
 pub struct Bool(pub i32);
 
+impl Bool {
+    pub fn to_bool(&self) -> bool {
+        self.0 != 0
+    }
+
+    pub fn from_bool(val: bool) -> Self {
+        Bool(val as i32)
+    }
+}
+
 impl Clone for Bool {
     fn clone(&self) -> Self {
         Self(self.0)
@@ -24,6 +34,12 @@ impl From<bool> for Bool {
 
 impl From<Bool> for bool {
     fn from(v: Bool) -> Self {
+        v.0 != 0
+    }
+}
+
+impl From<&Bool> for bool {
+    fn from(v: &Bool) -> Self {
         v.0 != 0
     }
 }

--- a/extendr-api/src/robj.rs
+++ b/extendr-api/src/robj.rs
@@ -2229,10 +2229,7 @@ mod tests {
         assert_eq!(<i32>::from_robj(&Robj::from(vec![1].as_slice() as &[i32])), Ok(1));
         assert_eq!(<i32>::from_robj(&Robj::from(vec![1, 2].as_slice() as &[i32])), Err("Input must be of length 1. Vector of length >1 given."));
 
-        use std::collections::HashMap;
-        let hmap = [("a".into(), 1.into()), ("b".into(), 2.into())].iter().cloned().collect::<HashMap<String, Robj>>();
-        let list = crate::list!(a=1, b=2);
-        assert_eq!(<HashMap<String, Robj>>::from_robj(&list), Ok(hmap));
+        // assert_eq!(hmap_owned, hmap1);
     }
     #[test]
     fn test_to_robj() {

--- a/extendr-api/src/robj.rs
+++ b/extendr-api/src/robj.rs
@@ -2231,7 +2231,7 @@ mod tests {
 
         use std::collections::HashMap;
         let hmap = [("a".into(), 1.into()), ("b".into(), 2.into())].iter().cloned().collect::<HashMap<String, Robj>>();
-        let list = list!(a=1, b=2);
+        let list = crate::list!(a=1, b=2);
         assert_eq!(<HashMap<String, Robj>>::from_robj(&list), Ok(hmap));
     }
     #[test]

--- a/extendr-api/src/robj.rs
+++ b/extendr-api/src/robj.rs
@@ -2237,7 +2237,19 @@ mod tests {
         assert_eq!(<i32>::from_robj(&Robj::from(vec![1].as_slice() as &[i32])), Ok(1));
         assert_eq!(<i32>::from_robj(&Robj::from(vec![1, 2].as_slice() as &[i32])), Err("Input must be of length 1. Vector of length >1 given."));
 
+        // use std::collections::HashMap;
+        // let hmap1 = [("a".into(), 1.into()), ("b".into(), 2.into())].iter().cloned().collect::<HashMap<String, Robj>>();
+        // let list2 = hmap1.iter().collect_named_robj();
+        // let hmap_owned = <HashMap<String, Robj>>::from_robj(&list2).unwrap();
+        // let hmap_borrowed = <HashMap<&str, Robj>>::from_robj(&list2).unwrap();
         // assert_eq!(hmap_owned, hmap1);
+
+        // assert!(hmap_owned["a"].is_owned());
+        // assert_eq!(hmap_owned["a"], Robj::from(1));
+        // assert_eq!(hmap_owned["b"], Robj::from(2));
+
+        // assert_eq!(hmap_borrowed["a"], Robj::from(1));
+        // assert_eq!(hmap_borrowed["b"], Robj::from(2));
     }
     #[test]
     fn test_to_robj() {

--- a/extendr-api/src/robj.rs
+++ b/extendr-api/src/robj.rs
@@ -219,7 +219,7 @@ impl<'a> FromRobj<'a> for Robj {
 impl<'a> FromRobj<'a> for HashMap<String, Robj> {
     fn from_robj(robj: &'a Robj) -> Result<Self, &'static str> {
         if let Some(iter) = robj.named_list_iter() {
-            Ok(iter.map(|(k, v)| (k.to_string(), v)).collect::<HashMap<String, Robj>>())
+            Ok(iter.map(|(k, v)| (k.to_string(), v.to_owned())).collect::<HashMap<String, Robj>>())
         } else {
             Err("expected a list")
         }
@@ -596,6 +596,14 @@ impl Robj {
         match self {
             Robj::Owned(_) => true,
             _ => false,
+        }
+    }
+
+    // Convert the Robj to an owned one.
+    pub fn to_owned(self) -> Robj {
+        match self {
+            Robj::Owned(_) => self,
+            _ => unsafe { new_owned(self.get()) }
         }
     }
 }


### PR DESCRIPTION
This PR adds more input options to extendr functions.
```
// Surprisingly, this one was not there.
fn takes_bool(val: bool) {
}

// Take list(a=1, b=2) and expose as an inexpensive HashMap
fn takes_named_list(val: HashMap<&str, Robj>) {
   let a = val["a"];
   let b = val["b"];
}

// Take list(a=1, b=2) and expose as a long-lived HashMap
fn takes_named_list(val: HashMap<String, Robj>) {
}
```