### PR TITLE
Replaced 'fifo' with 'textConnection' in 'r_ouput_test'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,15 @@ jobs:
           export LD_LIBRARY_PATH=${R_HOME}/lib
           cargo test -- --nocapture --test-threads=1
 
+      # Installing 'msys2' on Windows only
+      - uses: msys2/setup-msys2@v2
+        if: runner.os == 'Windows'
+        with:
+          msystem: MINGW64
+          path-type: inherit
+          release: false
+          update: false
+
       - name: Build (Windows)
         if: runner.os == 'Windows'
         run: cargo build --target x86_64-pc-windows-gnu

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,16 +75,12 @@ jobs:
       - name: Build (Windows)
         if: runner.os == 'Windows'
         run: cargo build --target x86_64-pc-windows-gnu
-        env:
-          LIBCLANG_PATH: C:\msys64\mingw64\bin
-        shell: msys2
-      
+        shell: msys2 {0}
+
       - name: Run tests (Windows)
         if: runner.os == 'Windows'
         run: cargo test --target x86_64-pc-windows-gnu -- --nocapture --test-threads=1
-        env:
-          LIBCLANG_PATH: C:\msys64\mingw64\bin
-        shell: msys2
+        shell: msys2 {0}
 
       - name: Query dependencies for integration testing
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
           path-type: inherit
           release: false
           update: false
-          
+
       - uses: r-lib/actions/setup-r@v1
         with:
           r-version: ${{ matrix.config.r }}
@@ -77,12 +77,14 @@ jobs:
         run: cargo build --target x86_64-pc-windows-gnu
         env:
           LIBCLANG_PATH: C:\msys64\mingw64\bin
+        shell: msys2
       
       - name: Run tests (Windows)
         if: runner.os == 'Windows'
         run: cargo test --target x86_64-pc-windows-gnu -- --nocapture --test-threads=1
         env:
           LIBCLANG_PATH: C:\msys64\mingw64\bin
+        shell: msys2
 
       - name: Query dependencies for integration testing
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,12 +65,9 @@ jobs:
         if: runner.os == 'Windows'
         run: cargo build --target x86_64-pc-windows-gnu
 
-## Tests don't currently succeed on Windows
-## The following test hangs: tests::r_output_test
-## See: https://github.com/extendr/extendr/issues/67
-#      - name: Run tests (Windows)
-#        if: runner.os == 'Windows'
-#        run: cargo test -- --nocapture --test-threads=1
+      - name: Run tests (Windows)
+        if: runner.os == 'Windows'
+        run: cargo test --target x86_64-pc-windows-gnu -- --nocapture --test-threads=1
 
       - name: Query dependencies for integration testing
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,16 @@ jobs:
           rustup target add x86_64-pc-windows-gnu
           rustup target add i686-pc-windows-gnu
 
+      # Installing 'msys2' on Windows only
+      - name: Set up 'msys2' for Windows
+        uses: msys2/setup-msys2@v2
+        if: runner.os == 'Windows'
+        with:
+          msystem: MINGW64
+          path-type: inherit
+          release: false
+          update: false
+          
       - uses: r-lib/actions/setup-r@v1
         with:
           r-version: ${{ matrix.config.r }}
@@ -61,22 +71,18 @@ jobs:
           export LD_LIBRARY_PATH=${R_HOME}/lib
           cargo test -- --nocapture --test-threads=1
 
-      # Installing 'msys2' on Windows only
-      - uses: msys2/setup-msys2@v2
-        if: runner.os == 'Windows'
-        with:
-          msystem: MINGW64
-          path-type: inherit
-          release: false
-          update: false
 
       - name: Build (Windows)
         if: runner.os == 'Windows'
         run: cargo build --target x86_64-pc-windows-gnu
-
+        env:
+          LIBCLANG_PATH: C:\msys64\mingw64\bin
+      
       - name: Run tests (Windows)
         if: runner.os == 'Windows'
         run: cargo test --target x86_64-pc-windows-gnu -- --nocapture --test-threads=1
+        env:
+          LIBCLANG_PATH: C:\msys64\mingw64\bin
 
       - name: Query dependencies for integration testing
         run: |


### PR DESCRIPTION
Addresses an issue (#67) with `fifo` on `Windows`, which appears to hang indefinitely.
`fifo` is replaced with `textConnection`, but the overall logic of the test is preserved.