### PR TITLE
bumping libR-sys to 0.2.0 on crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,4 @@ members = [
 ]
 
 [patch.crates-io]
-#libR-sys = { git = "https://github.com/extendr/libR-sys" }
+libR-sys = { git = "https://github.com/extendr/libR-sys" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,4 @@ members = [
 ]
 
 [patch.crates-io]
-libR-sys = { git = "https://github.com/extendr/libR-sys" }
+#libR-sys = { git = "https://github.com/extendr/libR-sys" }

--- a/extendr-api/Cargo.toml
+++ b/extendr-api/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://extendr.github.io/extendr/extendr_api/index.html"
 repository = "https://github.com/extendr/extendr"
 
 [dependencies]
-libR-sys = "0.1.12"
+libR-sys = "0.2.0"
 extendr-macros = { path = "../extendr-macros", version="0.1.11" }
 extendr-engine = { path = "../extendr-engine", version="0.1.11" }
 ndarray = { version = "0.13.1", optional = true }

--- a/extendr-engine/Cargo.toml
+++ b/extendr-engine/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://extendr.github.io/extendr/extendr_engine/index.html"
 repository = "https://github.com/extendr/extendr"
 
 [dependencies]
-libR-sys = "0.1.12"
+libR-sys = "0.2.0"
 
 [features]
 default = []

--- a/tests/extendrtests/src/rust/Cargo.toml
+++ b/tests/extendrtests/src/rust/Cargo.toml
@@ -13,10 +13,10 @@ edition = "2018"
 crate-type = ["staticlib"]
 
 [dependencies]
-extendr-api = { path = "../../../../extendr-api" }
+extendr-api = "*"
 
 [patch.crates-io]
-#extendr-api = { git = "https://github.com/extendr/extendr" }
-#extendr-engine = { git = "https://github.com/extendr/extendr" }
-#extendr-macros = { git = "https://github.com/extendr/extendr" }
+extendr-api = { git = "https://github.com/extendr/extendr" }
+extendr-engine = { git = "https://github.com/extendr/extendr" }
+extendr-macros = { git = "https://github.com/extendr/extendr" }
 #libR-sys = { git = "https://github.com/extendr/libR-sys" }

--- a/tests/extendrtests/src/rust/Cargo.toml
+++ b/tests/extendrtests/src/rust/Cargo.toml
@@ -13,10 +13,10 @@ edition = "2018"
 crate-type = ["staticlib"]
 
 [dependencies]
-extendr-api = "*"
+extendr-api = { path = "../../../../extendr-api" }
 
 [patch.crates-io]
-extendr-api = { git = "https://github.com/extendr/extendr" }
-extendr-engine = { git = "https://github.com/extendr/extendr" }
-extendr-macros = { git = "https://github.com/extendr/extendr" }
-libR-sys = { git = "https://github.com/extendr/libR-sys" }
+#extendr-api = { git = "https://github.com/extendr/extendr" }
+#extendr-engine = { git = "https://github.com/extendr/extendr" }
+#extendr-macros = { git = "https://github.com/extendr/extendr" }
+#libR-sys = { git = "https://github.com/extendr/libR-sys" }


### PR DESCRIPTION
libR-sys 0.2.0 is now on crates.io.