### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,30 +28,16 @@ jobs:
           # - {os: windows-latest, r: 'devel', rust-version: 'stable-msvc'}
           # - {os: windows-latest, r: 'oldrel', rust-version: 'stable-msvc'}
 
-          # Windows jobs with x86_64 Rust toolchain build for x86_64 only
-          # R integration tests are run with 64-bit R version and '--no-multiarch' flag
-          # - {os: windows-latest, r: 'release', rust-version: 'stable-x86_64-pc-windows-msvc'}
-          # - {os: windows-latest, r: 'release', rust-version: 'nightly-x86_64-pc-windows-msvc'}
-          # - {os: windows-latest, r: 'devel', rust-version: 'stable-x86_64-pc-windows-msvc'}
-          # - {os: windows-latest, r: 'oldrel', rust-version: 'stable-x86_64-pc-windows-msvc'}
-
-          # Windows jobs with i686 Rust toolchain build for i686 only
-          # R integration tests are run with 32-bit R version and '--no-multiarch' flag
-          # - {os: windows-latest, r: 'release', rust-version: 'stable-i686-pc-windows-msvc'}
-          # - {os: windows-latest, r: 'release', rust-version: 'nightly-i686-pc-windows-msvc'}
-          # - {os: windows-latest, r: 'devel', rust-version: 'stable-i686-pc-windows-msvc'}
-          # - {os: windows-latest, r: 'oldrel', rust-version: 'stable-i686-pc-windows-msvc'}
-
           - {os: macOS-latest,   r: 'release', rust-version: 'stable'}
           # - {os: macOS-latest,   r: 'release', rust-version: 'nightly'}
           # - {os: macOS-latest,   r: 'devel', rust-version: 'stable'}
           # - {os: macOS-latest,   r: 'oldrel', rust-version: 'stable'}
 
           - {os: ubuntu-20.04,   r: 'release', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          # - {os: ubuntu-20.04,   r: 'release', rust-version: 'nightly', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: ubuntu-20.04,   r: 'release', rust-version: 'nightly', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
           # R-devel requires LD_LIBRARY_PATH
-          # - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}   
-          # - {os: ubuntu-20.04,   r: 'oldrel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}   
+          - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}   
+          - {os: ubuntu-20.04,   r: 'oldrel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}   
 
 
 
@@ -181,7 +167,7 @@ jobs:
         id: r_integration_tests
         env:
           _R_CHECK_CRAN_INCOMING_REMOTE_: false
-        run: rcmdcheck::rcmdcheck(path = "tests/extendrtests", args = c("--no-manual", "--as-cran", ifelse(grepl("^default$|^.*,.*$", Sys.getenv("BUILD_TARGETS")), "", "--no-multiarch")), error_on = "warning", check_dir = "check")
+        run: rcmdcheck::rcmdcheck(path = "tests/extendrtests", args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
         shell: Rscript {0}
         
       - name: Upload check results from R integration tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,13 +22,13 @@ jobs:
       matrix:
         config:
           
-          # - {os: windows-latest, r: 'release', rust-version: 'stable-x86_64-pc-windows-msvc', msystem: "MINGW64"}
+          - {os: windows-latest, r: 'release', rust-version: 'stable-x86_64-pc-windows-msvc', msystem: "MINGW64"}
           # - {os: windows-latest, r: 'release', rust-version: 'nightly-x86_64-pc-windows-msvc', msystem: "MINGW64"}
           # - {os: windows-latest, r: 'devel', rust-version: 'stable-x86_64-pc-windows-msvc', msystem: "MINGW64"}
           # - {os: windows-latest, r: 'oldrel', rust-version: 'stable-x86_64-pc-windows-msvc', msystem: "MINGW64"}
 
 
-          # - {os: windows-latest, r: 'release', rust-version: 'stable-i686-pc-windows-msvc', msystem: "MINGW32"}
+          - {os: windows-latest, r: 'release', rust-version: 'stable-i686-pc-windows-msvc', msystem: "MINGW32"}
           # - {os: windows-latest, r: 'release', rust-version: 'nightly-i686-pc-windows-msvc', msystem: "MINGW32"}
           # - {os: windows-latest, r: 'devel', rust-version: 'stable-i686-pc-windows-msvc', msystem: "MINGW32"}
           # - {os: windows-latest, r: 'oldrel', rust-version: 'stable-i686-pc-windows-msvc', msystem: "MINGW32"}
@@ -71,27 +71,50 @@ jobs:
         uses: r-lib/actions/setup-r@v1
         with:
           r-version: ${{ matrix.config.r }}
+      
+      # This step is only needed for Windows
+      - name: Set up MSYS2 for Windows
+        if: startsWith(runner.os, 'Windows')
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.config.msystem }}
+          path-type: inherit
+          release: false
+          update: false
+
+      # All configurations for Windows go here
+      # `Rust` toolchain is used to determine target architecture
+      # Alternatively, `if:` conditions can be used
+      - name: Configure Windows
+        if: startsWith(runner.os, 'Windows')
+        # 1. Add appropriate *-gnu target
+        # 2. Set CARGO_BUILD_FLAGS to the `rust` target
+        run: |
+          if ($env:RUST_TOOLCHAIN -like "*x86_64*") {
+            rustup target add x86_64-pc-windows-gnu ;
+            echo "CARGO_BUILD_FLAGS=--target=x86_64-pc-windows-gnu" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append ;
+            echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+            echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\x64"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+          }
+          if ($env:RUST_TOOLCHAIN -like "*i686*") {
+            rustup target add i686-pc-windows-gnu ;
+            echo "CARGO_BUILD_FLAGS=--target=i686-pc-windows-gnu" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append ;
+            echo "C:\msys64\mingw32\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+            echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\i386"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+          }
+        env: 
+          RUST_TOOLCHAIN: ${{ matrix.config.rust-version }}
 
       - name: Set up Pandoc
         uses: r-lib/actions/setup-pandoc@v1
       
       - name: Build
-        run: cargo build
+        run: cargo build -vv $env:CARGO_BUILD_FLAGS
 
       - name: Run tests
         run: |
-          cargo test -- --nocapture --test-threads=1
+          cargo test -vv $env:CARGO_BUILD_FLAGS -- --nocapture --test-threads=1
 
-
-      # - name: Build (Windows)
-      #   if: runner.os == 'Windows'
-      #   run: cargo build --target x86_64-pc-windows-gnu
-      #   shell: msys2 {0}
-
-      # - name: Run tests (Windows)
-      #   if: runner.os == 'Windows'
-      #   run: cargo test --target x86_64-pc-windows-gnu -- --nocapture --test-threads=1
-      #   shell: msys2 {0}
 
       # - name: Query dependencies for integration testing
       #   run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,198 +11,198 @@ on:
       - master
 
 jobs:
-# All tests under this job are run with pre-computed libR-sys bindings.
-  tests_no_bindgen:
-    runs-on: ${{ matrix.config.os }}
-
-    name: ${{ matrix.config.os }} (R-${{ matrix.config.r }} rust-${{ matrix.config.rust-version }})
-            
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - {os: windows-latest, r: 'release', rust-version: 'stable-msvc'}
-
-          - {os: windows-latest, r: 'release', rust-version: 'stable-x86_64-pc-windows-msvc'}
-          - {os: windows-latest, r: 'release', rust-version: 'nightly-x86_64-pc-windows-msvc'}
-          - {os: windows-latest, r: 'devel', rust-version: 'stable-x86_64-pc-windows-msvc'}
-          - {os: windows-latest, r: 'oldrel', rust-version: 'stable-x86_64-pc-windows-msvc'}
-
-
-          - {os: windows-latest, r: 'release', rust-version: 'stable-i686-pc-windows-msvc'}
-          - {os: windows-latest, r: 'release', rust-version: 'nightly-i686-pc-windows-msvc'}
-          - {os: windows-latest, r: 'devel', rust-version: 'stable-i686-pc-windows-msvc'}
-          - {os: windows-latest, r: 'oldrel', rust-version: 'stable-i686-pc-windows-msvc'}
-
-
-          - {os: macOS-latest,   r: 'release', rust-version: 'stable'}
-          - {os: macOS-latest,   r: 'release', rust-version: 'nightly'}
-          - {os: macOS-latest,   r: 'devel', rust-version: 'stable'}
-          - {os: macOS-latest,   r: 'oldrel', rust-version: 'stable'}
-
-
-          - {os: ubuntu-20.04,   r: 'release', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          - {os: ubuntu-20.04,   r: 'release', rust-version: 'nightly', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          # R-devel requires LD_LIBRARY_PATH
-          - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}   
-          - {os: ubuntu-20.04,   r: 'oldrel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}   
-
-
-
-    env:
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      RSPM: ${{ matrix.config.rspm }}
-      BUILD_TARGETS: default
-    
-    # PowerShell core is available on all platforms and can be used to unify scripts
-    defaults:
-      run:
-        shell: pwsh
-
-    steps:
-      - uses: actions/checkout@v2
-      
-      - name: Set up Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.config.rust-version }}
-          default: true
-          components: rustfmt, clippy
-      
-      - name: Set up R
-        uses: r-lib/actions/setup-r@v1
-        with:
-          r-version: ${{ matrix.config.r }}
-      
-      # This step is only needed for Windows
-      - name: Set up MSYS2 for Windows
-        if: startsWith(runner.os, 'Windows')
-        uses: msys2/setup-msys2@v2
-        with:
-          path-type: inherit
-          release: false
-          update: false
-
-      # All configurations for Windows go here
-      # `Rust` toolchain is used to determine target architecture
-      - name: Configure Windows
-        if: startsWith(runner.os, 'Windows')
-        # 1. Add appropriate *-gnu target
-        # 2. Set CARGO_BUILD_FLAGS to the `rust` target
-        run: |
-          $targets=@()
-          if ($env:RUST_TOOLCHAIN -notlike "*x86_64*") {
-            rustup target add i686-pc-windows-gnu ;
-            $targets+="i686-pc-windows-gnu"
-            echo "C:\msys64\mingw32\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
-            echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\i386"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
-          }
-          if ($env:RUST_TOOLCHAIN -notlike "*i686*") {
-            rustup target add x86_64-pc-windows-gnu ;
-            $targets+="x86_64-pc-windows-gnu"
-            echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
-            echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\x64"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
-          }
-          echo "BUILD_TARGETS=$($targets -join ',')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append ;
-        env: 
-          RUST_TOOLCHAIN: ${{ matrix.config.rust-version }}
-
-      # This is required for ubuntu r-devel
-      # 'Del alias:R' removes 'R' alias which prevents running R 
-      - name: Configure Linux
-        if: runner.os == 'linux'
-        run: |
-          Del alias:R
-          echo "LD_LIBRARY_PATH=$(R -s -e 'cat(normalizePath(R.home()))')/lib" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
-      - name: Set up Pandoc
-        uses: r-lib/actions/setup-pandoc@v1
-      
-      - name: Build
-        run: |
-          cargo update
-          foreach($target in ($env:BUILD_TARGETS).Split(',')) {cargo build -vv $(if($target -ne 'default') {"--target=$target"} ) }
-
-      - name: Run tests
-        run: |
-          foreach($target in ($env:BUILD_TARGETS).Split(',')) {cargo test -vv $(if($target -ne 'default') {"--target=$target"} ) -- --nocapture --test-threads=1}
-
-
-
-      - name: Query dependencies for integration testing
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(pkgdir = "tests/extendrtests", dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
-
-      - name: Cache installed R packages
-        # if: runner.os != 'Windows'
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
-
-      - name: Install R dependencies for integration testing
-        run: |
-          remotes::install_deps(pkgdir = "tests/extendrtests", dependencies = TRUE)
-          remotes::install_cran("rcmdcheck")
-        shell: Rscript {0}
-        
-      - name: Run R integration tests
-        id: r_integration_tests
-        env:
-          _R_CHECK_CRAN_INCOMING_REMOTE_: false
-        run: rcmdcheck::rcmdcheck(path = "tests/extendrtests", args = c("--no-manual", "--as-cran", ifelse(grepl("default|^.*,.*$", Sys.getenv("BUILD_TARGETS")), "", "--no-multiarch")), error_on = "warning", check_dir = "check")
-        shell: Rscript {0}
-        
-      - name: Upload check results from R integration tests
-        if: failure()
-        uses: actions/upload-artifact@main
-        with:
-          name:  ${{ matrix.config.os }}-R-${{ matrix.config.r }}-rust-${{ matrix.config.rust-version }}
-          path: check
-
-
-# All tests under this job are run with R devel and freshly generated bindings.
-  # tests_R_devel_bindgen:
+  # # All tests under this job are run with pre-computed libR-sys bindings.
+  # tests_no_bindgen:
   #   runs-on: ${{ matrix.config.os }}
 
-  #   name: ${{ matrix.config.os }} w/ bindgen (R-${{ matrix.config.r }} rust-${{ matrix.config.rust-version }})
+  #   name: ${{ matrix.config.os }} (R-${{ matrix.config.r }} rust-${{ matrix.config.rust-version }})
             
   #   strategy:
   #     fail-fast: false
   #     matrix:
   #       config:
-  #         - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+  #         - {os: windows-latest, r: 'release', rust-version: 'stable-msvc'}
+
+  #         - {os: windows-latest, r: 'release', rust-version: 'stable-x86_64-pc-windows-msvc'}
+  #         - {os: windows-latest, r: 'release', rust-version: 'nightly-x86_64-pc-windows-msvc'}
+  #         - {os: windows-latest, r: 'devel', rust-version: 'stable-x86_64-pc-windows-msvc'}
+  #         - {os: windows-latest, r: 'oldrel', rust-version: 'stable-x86_64-pc-windows-msvc'}
+
+
+  #         - {os: windows-latest, r: 'release', rust-version: 'stable-i686-pc-windows-msvc'}
+  #         - {os: windows-latest, r: 'release', rust-version: 'nightly-i686-pc-windows-msvc'}
+  #         - {os: windows-latest, r: 'devel', rust-version: 'stable-i686-pc-windows-msvc'}
+  #         - {os: windows-latest, r: 'oldrel', rust-version: 'stable-i686-pc-windows-msvc'}
+
+
+  #         - {os: macOS-latest,   r: 'release', rust-version: 'stable'}
+  #         - {os: macOS-latest,   r: 'release', rust-version: 'nightly'}
+  #         - {os: macOS-latest,   r: 'devel', rust-version: 'stable'}
+  #         - {os: macOS-latest,   r: 'oldrel', rust-version: 'stable'}
+
+
+  #         - {os: ubuntu-20.04,   r: 'release', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+  #         - {os: ubuntu-20.04,   r: 'release', rust-version: 'nightly', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+  #         # R-devel requires LD_LIBRARY_PATH
+  #         - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}   
+  #         - {os: ubuntu-20.04,   r: 'oldrel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}   
+
+
 
   #   env:
   #     R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
   #     RSPM: ${{ matrix.config.rspm }}
+  #     BUILD_TARGETS: default
+    
+  #   # PowerShell core is available on all platforms and can be used to unify scripts
+  #   defaults:
+  #     run:
+  #       shell: pwsh
 
   #   steps:
   #     - uses: actions/checkout@v2
       
-  #     - uses: actions-rs/toolchain@v1
+  #     - name: Set up Rust
+  #       uses: actions-rs/toolchain@v1
   #       with:
   #         toolchain: ${{ matrix.config.rust-version }}
-
-  #     - uses: r-lib/actions/setup-r@v1
+  #         default: true
+  #         components: rustfmt, clippy
+      
+  #     - name: Set up R
+  #       uses: r-lib/actions/setup-r@v1
   #       with:
   #         r-version: ${{ matrix.config.r }}
       
+  #     # This step is only needed for Windows
+  #     - name: Set up MSYS2 for Windows
+  #       if: startsWith(runner.os, 'Windows')
+  #       uses: msys2/setup-msys2@v2
+  #       with:
+  #         path-type: inherit
+  #         release: false
+  #         update: false
+
+  #     # All configurations for Windows go here
+  #     # `Rust` toolchain is used to determine target architecture
+  #     - name: Configure Windows
+  #       if: startsWith(runner.os, 'Windows')
+  #       # 1. Add appropriate *-gnu target
+  #       # 2. Set CARGO_BUILD_FLAGS to the `rust` target
+  #       run: |
+  #         $targets=@()
+  #         if ($env:RUST_TOOLCHAIN -notlike "*x86_64*") {
+  #           rustup target add i686-pc-windows-gnu ;
+  #           $targets+="i686-pc-windows-gnu"
+  #           echo "C:\msys64\mingw32\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+  #           echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\i386"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+  #         }
+  #         if ($env:RUST_TOOLCHAIN -notlike "*i686*") {
+  #           rustup target add x86_64-pc-windows-gnu ;
+  #           $targets+="x86_64-pc-windows-gnu"
+  #           echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+  #           echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\x64"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+  #         }
+  #         echo "BUILD_TARGETS=$($targets -join ',')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append ;
+  #       env: 
+  #         RUST_TOOLCHAIN: ${{ matrix.config.rust-version }}
+
+  #     # This is required for ubuntu r-devel
+  #     # 'Del alias:R' removes 'R' alias which prevents running R 
+  #     - name: Configure Linux
+  #       if: runner.os == 'linux'
+  #       run: |
+  #         Del alias:R
+  #         echo "LD_LIBRARY_PATH=$(R -s -e 'cat(normalizePath(R.home()))')/lib" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+  #     - name: Set up Pandoc
+  #       uses: r-lib/actions/setup-pandoc@v1
+      
   #     - name: Build
   #       run: |
-  #         cargo build --manifest-path extendr-api/Cargo.toml --features tests-all
-  #         cargo build --manifest-path extendr-engine/Cargo.toml --features tests-all
+  #         cargo update
+  #         foreach($target in ($env:BUILD_TARGETS).Split(',')) {cargo build -vv $(if($target -ne 'default') {"--target=$target"} ) }
 
   #     - name: Run tests
   #       run: |
-  #         export R_HOME=`R -s -e 'cat(R.home())'`
-  #         export LD_LIBRARY_PATH=${R_HOME}/lib
-  #         cargo test --manifest-path extendr-engine/Cargo.toml --features tests-all -- --nocapture --test-threads=1
-  #         cargo test --manifest-path extendr-api/Cargo.toml --features tests-all -- --nocapture --test-threads=1
-  #         cargo test --manifest-path extendr-api/Cargo.toml --features tests-minimal -- --nocapture --test-threads=1
-  #         cargo test --manifest-path extendr-macros/Cargo.toml -- --nocapture --test-threads=1
+  #         foreach($target in ($env:BUILD_TARGETS).Split(',')) {cargo test -vv $(if($target -ne 'default') {"--target=$target"} ) -- --nocapture --test-threads=1}
+
+
+
+  #     - name: Query dependencies for integration testing
+  #       run: |
+  #         install.packages('remotes')
+  #         saveRDS(remotes::dev_package_deps(pkgdir = "tests/extendrtests", dependencies = TRUE), ".github/depends.Rds", version = 2)
+  #         writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+  #       shell: Rscript {0}
+
+  #     - name: Cache installed R packages
+  #       # if: runner.os != 'Windows'
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: ${{ env.R_LIBS_USER }}
+  #         key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+  #         restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+
+  #     - name: Install R dependencies for integration testing
+  #       run: |
+  #         remotes::install_deps(pkgdir = "tests/extendrtests", dependencies = TRUE)
+  #         remotes::install_cran("rcmdcheck")
+  #       shell: Rscript {0}
+        
+  #     - name: Run R integration tests
+  #       id: r_integration_tests
+  #       env:
+  #         _R_CHECK_CRAN_INCOMING_REMOTE_: false
+  #       run: rcmdcheck::rcmdcheck(path = "tests/extendrtests", args = c("--no-manual", "--as-cran", ifelse(grepl("default|^.*,.*$", Sys.getenv("BUILD_TARGETS")), "", "--no-multiarch")), error_on = "warning", check_dir = "check")
+  #       shell: Rscript {0}
+        
+  #     - name: Upload check results from R integration tests
+  #       if: failure()
+  #       uses: actions/upload-artifact@main
+  #       with:
+  #         name:  ${{ matrix.config.os }}-R-${{ matrix.config.r }}-rust-${{ matrix.config.rust-version }}
+  #         path: check
+
+
+# All tests under this job are run with R devel and freshly generated bindings.
+  tests_R_devel_bindgen:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} w/ bindgen (R-${{ matrix.config.r }} rust-${{ matrix.config.rust-version }})
+            
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+
+    env:
+      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      RSPM: ${{ matrix.config.rspm }}
+
+    steps:
+      - uses: actions/checkout@v2
+      
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.config.rust-version }}
+
+      - uses: r-lib/actions/setup-r@v1
+        with:
+          r-version: ${{ matrix.config.r }}
+      
+      - name: Build
+        run: |
+          cargo build --manifest-path extendr-api/Cargo.toml --features tests-all
+          cargo build --manifest-path extendr-engine/Cargo.toml --features tests-all
+
+      - name: Run tests
+        run: |
+          export R_HOME=`R -s -e 'cat(R.home())'`
+          export LD_LIBRARY_PATH=${R_HOME}/lib
+          cargo test --manifest-path extendr-engine/Cargo.toml --features tests-all -- --nocapture --test-threads=1
+          cargo test --manifest-path extendr-api/Cargo.toml --features tests-all -- --nocapture --test-threads=1
+          cargo test --manifest-path extendr-api/Cargo.toml --features tests-minimal -- --nocapture --test-threads=1
+          cargo test --manifest-path extendr-macros/Cargo.toml -- --nocapture --test-threads=1
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,7 +110,7 @@ jobs:
       # This is required for ubuntu r-devel
       # 'Del alias:R' removes 'R' alias which prevents running R 
       - name: Configure Linux
-        if: starsWith(runner.os, 'linux')
+        if: startsWith(runner.os, 'linux')
         run: |
           Del alias:R
           echo "LD_LIBRARY_PATH=$(R -s -e 'cat(normalizePath(R.home()))')/lib" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,158 +11,157 @@ on:
       - master
 
 jobs:
-  # # All tests under this job are run with pre-computed libR-sys bindings.
-  # tests_no_bindgen:
-  #   runs-on: ${{ matrix.config.os }}
+  # All tests under this job are run with pre-computed libR-sys bindings.
+  tests_no_bindgen:
+    runs-on: ${{ matrix.config.os }}
 
-  #   name: ${{ matrix.config.os }} (R-${{ matrix.config.r }} rust-${{ matrix.config.rust-version }})
+    name: ${{ matrix.config.os }} (R-${{ matrix.config.r }} rust-${{ matrix.config.rust-version }})
             
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       config:
-  #         - {os: windows-latest, r: 'release', rust-version: 'stable-msvc'}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: windows-latest, r: 'release', rust-version: 'stable-msvc'}
+          - {os: windows-latest, r: 'release', rust-version: 'nightly-x86_64-pc-windows-msvc'}
+          - {os: windows-latest, r: 'devel', rust-version: 'stable-msvc'}
+          - {os: windows-latest, r: 'oldrel', rust-version: 'stable-msvc'}
 
-  #         - {os: windows-latest, r: 'release', rust-version: 'stable-x86_64-pc-windows-msvc'}
-  #         - {os: windows-latest, r: 'release', rust-version: 'nightly-x86_64-pc-windows-msvc'}
-  #         - {os: windows-latest, r: 'devel', rust-version: 'stable-x86_64-pc-windows-msvc'}
-  #         - {os: windows-latest, r: 'oldrel', rust-version: 'stable-x86_64-pc-windows-msvc'}
+          # - {os: windows-latest, r: 'release', rust-version: 'stable-x86_64-pc-windows-msvc'}
+          # - {os: windows-latest, r: 'release', rust-version: 'nightly-x86_64-pc-windows-msvc'}
+          # - {os: windows-latest, r: 'devel', rust-version: 'stable-x86_64-pc-windows-msvc'}
+          # - {os: windows-latest, r: 'oldrel', rust-version: 'stable-x86_64-pc-windows-msvc'}
 
+          # - {os: windows-latest, r: 'release', rust-version: 'stable-i686-pc-windows-msvc'}
+          # - {os: windows-latest, r: 'release', rust-version: 'nightly-i686-pc-windows-msvc'}
+          # - {os: windows-latest, r: 'devel', rust-version: 'stable-i686-pc-windows-msvc'}
+          # - {os: windows-latest, r: 'oldrel', rust-version: 'stable-i686-pc-windows-msvc'}
 
-  #         - {os: windows-latest, r: 'release', rust-version: 'stable-i686-pc-windows-msvc'}
-  #         - {os: windows-latest, r: 'release', rust-version: 'nightly-i686-pc-windows-msvc'}
-  #         - {os: windows-latest, r: 'devel', rust-version: 'stable-i686-pc-windows-msvc'}
-  #         - {os: windows-latest, r: 'oldrel', rust-version: 'stable-i686-pc-windows-msvc'}
+          - {os: macOS-latest,   r: 'release', rust-version: 'stable'}
+          - {os: macOS-latest,   r: 'release', rust-version: 'nightly'}
+          - {os: macOS-latest,   r: 'devel', rust-version: 'stable'}
+          - {os: macOS-latest,   r: 'oldrel', rust-version: 'stable'}
 
-
-  #         - {os: macOS-latest,   r: 'release', rust-version: 'stable'}
-  #         - {os: macOS-latest,   r: 'release', rust-version: 'nightly'}
-  #         - {os: macOS-latest,   r: 'devel', rust-version: 'stable'}
-  #         - {os: macOS-latest,   r: 'oldrel', rust-version: 'stable'}
-
-
-  #         - {os: ubuntu-20.04,   r: 'release', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-  #         - {os: ubuntu-20.04,   r: 'release', rust-version: 'nightly', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-  #         # R-devel requires LD_LIBRARY_PATH
-  #         - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}   
-  #         - {os: ubuntu-20.04,   r: 'oldrel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}   
+          - {os: ubuntu-20.04,   r: 'release', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: ubuntu-20.04,   r: 'release', rust-version: 'nightly', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          # R-devel requires LD_LIBRARY_PATH
+          - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}   
+          - {os: ubuntu-20.04,   r: 'oldrel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}   
 
 
 
-  #   env:
-  #     R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-  #     RSPM: ${{ matrix.config.rspm }}
-  #     BUILD_TARGETS: default
+    env:
+      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      RSPM: ${{ matrix.config.rspm }}
+      BUILD_TARGETS: default
     
-  #   # PowerShell core is available on all platforms and can be used to unify scripts
-  #   defaults:
-  #     run:
-  #       shell: pwsh
+    # PowerShell core is available on all platforms and can be used to unify scripts
+    defaults:
+      run:
+        shell: pwsh
 
-  #   steps:
-  #     - uses: actions/checkout@v2
+    steps:
+      - uses: actions/checkout@v2
       
-  #     - name: Set up Rust
-  #       uses: actions-rs/toolchain@v1
-  #       with:
-  #         toolchain: ${{ matrix.config.rust-version }}
-  #         default: true
-  #         components: rustfmt, clippy
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.config.rust-version }}
+          default: true
+          components: rustfmt, clippy
       
-  #     - name: Set up R
-  #       uses: r-lib/actions/setup-r@v1
-  #       with:
-  #         r-version: ${{ matrix.config.r }}
+      - name: Set up R
+        uses: r-lib/actions/setup-r@v1
+        with:
+          r-version: ${{ matrix.config.r }}
       
-  #     # This step is only needed for Windows
-  #     - name: Set up MSYS2 for Windows
-  #       if: startsWith(runner.os, 'Windows')
-  #       uses: msys2/setup-msys2@v2
-  #       with:
-  #         path-type: inherit
-  #         release: false
-  #         update: false
+      # This step is only needed for Windows
+      - name: Set up MSYS2 for Windows
+        if: startsWith(runner.os, 'Windows')
+        uses: msys2/setup-msys2@v2
+        with:
+          path-type: inherit
+          release: false
+          update: false
 
-  #     # All configurations for Windows go here
-  #     # `Rust` toolchain is used to determine target architecture
-  #     - name: Configure Windows
-  #       if: startsWith(runner.os, 'Windows')
-  #       # 1. Add appropriate *-gnu target
-  #       # 2. Set CARGO_BUILD_FLAGS to the `rust` target
-  #       run: |
-  #         $targets=@()
-  #         if ($env:RUST_TOOLCHAIN -notlike "*x86_64*") {
-  #           rustup target add i686-pc-windows-gnu ;
-  #           $targets+="i686-pc-windows-gnu"
-  #           echo "C:\msys64\mingw32\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
-  #           echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\i386"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
-  #         }
-  #         if ($env:RUST_TOOLCHAIN -notlike "*i686*") {
-  #           rustup target add x86_64-pc-windows-gnu ;
-  #           $targets+="x86_64-pc-windows-gnu"
-  #           echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
-  #           echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\x64"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
-  #         }
-  #         echo "BUILD_TARGETS=$($targets -join ',')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append ;
-  #       env: 
-  #         RUST_TOOLCHAIN: ${{ matrix.config.rust-version }}
+      # All configurations for Windows go here
+      # `Rust` toolchain is used to determine target architecture
+      - name: Configure Windows
+        if: startsWith(runner.os, 'Windows')
+        # 1. Add appropriate *-gnu target
+        # 2. Set CARGO_BUILD_FLAGS to the `rust` target
+        run: |
+          $targets=@()
+          if ($env:RUST_TOOLCHAIN -notlike "*x86_64*") {
+            rustup target add i686-pc-windows-gnu ;
+            $targets+="i686-pc-windows-gnu"
+            echo "C:\msys64\mingw32\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+            echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\i386"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+          }
+          if ($env:RUST_TOOLCHAIN -notlike "*i686*") {
+            rustup target add x86_64-pc-windows-gnu ;
+            $targets+="x86_64-pc-windows-gnu"
+            echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+            echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\x64"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+          }
+          echo "BUILD_TARGETS=$($targets -join ',')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append ;
+        env: 
+          RUST_TOOLCHAIN: ${{ matrix.config.rust-version }}
 
-  #     # This is required for ubuntu r-devel
-  #     # 'Del alias:R' removes 'R' alias which prevents running R 
-  #     - name: Configure Linux
-  #       if: runner.os == 'linux'
-  #       run: |
-  #         Del alias:R
-  #         echo "LD_LIBRARY_PATH=$(R -s -e 'cat(normalizePath(R.home()))')/lib" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      # This is required for ubuntu r-devel
+      # 'Del alias:R' removes 'R' alias which prevents running R 
+      - name: Configure Linux
+        if: starsWith(runner.os, 'linux')
+        run: |
+          Del alias:R
+          echo "LD_LIBRARY_PATH=$(R -s -e 'cat(normalizePath(R.home()))')/lib" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-  #     - name: Set up Pandoc
-  #       uses: r-lib/actions/setup-pandoc@v1
+      - name: Set up Pandoc
+        uses: r-lib/actions/setup-pandoc@v1
       
-  #     - name: Build
-  #       run: |
-  #         cargo update
-  #         foreach($target in ($env:BUILD_TARGETS).Split(',')) {cargo build -vv $(if($target -ne 'default') {"--target=$target"} ) }
+      - name: Build
+        run: |
+          cargo update
+          foreach($target in ($env:BUILD_TARGETS).Split(',')) {cargo build -vv $(if($target -ne 'default') {"--target=$target"} ) }
 
-  #     - name: Run tests
-  #       run: |
-  #         foreach($target in ($env:BUILD_TARGETS).Split(',')) {cargo test -vv $(if($target -ne 'default') {"--target=$target"} ) -- --nocapture --test-threads=1}
+      - name: Run tests
+        run: |
+          foreach($target in ($env:BUILD_TARGETS).Split(',')) {cargo test -vv $(if($target -ne 'default') {"--target=$target"} ) -- --nocapture --test-threads=1}
 
 
 
-  #     - name: Query dependencies for integration testing
-  #       run: |
-  #         install.packages('remotes')
-  #         saveRDS(remotes::dev_package_deps(pkgdir = "tests/extendrtests", dependencies = TRUE), ".github/depends.Rds", version = 2)
-  #         writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-  #       shell: Rscript {0}
+      - name: Query dependencies for integration testing
+        run: |
+          install.packages('remotes')
+          saveRDS(remotes::dev_package_deps(pkgdir = "tests/extendrtests", dependencies = TRUE), ".github/depends.Rds", version = 2)
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+        shell: Rscript {0}
 
-  #     - name: Cache installed R packages
-  #       # if: runner.os != 'Windows'
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: ${{ env.R_LIBS_USER }}
-  #         key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-  #         restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+      - name: Cache installed R packages
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
 
-  #     - name: Install R dependencies for integration testing
-  #       run: |
-  #         remotes::install_deps(pkgdir = "tests/extendrtests", dependencies = TRUE)
-  #         remotes::install_cran("rcmdcheck")
-  #       shell: Rscript {0}
+      - name: Install R dependencies for integration testing
+        run: |
+          remotes::install_deps(pkgdir = "tests/extendrtests", dependencies = TRUE)
+          remotes::install_cran("rcmdcheck")
+        shell: Rscript {0}
         
-  #     - name: Run R integration tests
-  #       id: r_integration_tests
-  #       env:
-  #         _R_CHECK_CRAN_INCOMING_REMOTE_: false
-  #       run: rcmdcheck::rcmdcheck(path = "tests/extendrtests", args = c("--no-manual", "--as-cran", ifelse(grepl("default|^.*,.*$", Sys.getenv("BUILD_TARGETS")), "", "--no-multiarch")), error_on = "warning", check_dir = "check")
-  #       shell: Rscript {0}
+      - name: Run R integration tests
+        id: r_integration_tests
+        env:
+          _R_CHECK_CRAN_INCOMING_REMOTE_: false
+        run: rcmdcheck::rcmdcheck(path = "tests/extendrtests", args = c("--no-manual", "--as-cran", ifelse(grepl("default|^.*,.*$", Sys.getenv("BUILD_TARGETS")), "", "--no-multiarch")), error_on = "warning", check_dir = "check")
+        shell: Rscript {0}
         
-  #     - name: Upload check results from R integration tests
-  #       if: failure()
-  #       uses: actions/upload-artifact@main
-  #       with:
-  #         name:  ${{ matrix.config.os }}-R-${{ matrix.config.r }}-rust-${{ matrix.config.rust-version }}
-  #         path: check
+      - name: Upload check results from R integration tests
+        if: failure()
+        uses: actions/upload-artifact@main
+        with:
+          name:  ${{ matrix.config.os }}-R-${{ matrix.config.r }}-rust-${{ matrix.config.rust-version }}
+          path: check
 
 
 # All tests under this job are run with R devel and freshly generated bindings.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,26 +21,26 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          
-          - {os: windows-latest, r: 'release', rust-version: 'stable-x86_64-pc-windows-msvc', msystem: "MINGW64"}
+          - {os: windows-latest, r: 'release', rust-version: 'stable-msvc', msystem: "MINGW64"}
+          # - {os: windows-latest, r: 'release', rust-version: 'stable-x86_64-pc-windows-msvc', msystem: "MINGW64"}
           # - {os: windows-latest, r: 'release', rust-version: 'nightly-x86_64-pc-windows-msvc', msystem: "MINGW64"}
           # - {os: windows-latest, r: 'devel', rust-version: 'stable-x86_64-pc-windows-msvc', msystem: "MINGW64"}
           # - {os: windows-latest, r: 'oldrel', rust-version: 'stable-x86_64-pc-windows-msvc', msystem: "MINGW64"}
 
 
-          - {os: windows-latest, r: 'release', rust-version: 'stable-i686-pc-windows-msvc', msystem: "MINGW32"}
+          # - {os: windows-latest, r: 'release', rust-version: 'stable-i686-pc-windows-msvc', msystem: "MINGW32"}
           # - {os: windows-latest, r: 'release', rust-version: 'nightly-i686-pc-windows-msvc', msystem: "MINGW32"}
           # - {os: windows-latest, r: 'devel', rust-version: 'stable-i686-pc-windows-msvc', msystem: "MINGW32"}
           # - {os: windows-latest, r: 'oldrel', rust-version: 'stable-i686-pc-windows-msvc', msystem: "MINGW32"}
 
 
-          - {os: macOS-latest,   r: 'release', rust-version: 'stable'}
+          # - {os: macOS-latest,   r: 'release', rust-version: 'stable'}
           # - {os: macOS-latest,   r: 'release', rust-version: 'nightly'}
           # - {os: macOS-latest,   r: 'devel', rust-version: 'stable'}
           # - {os: macOS-latest,   r: 'oldrel', rust-version: 'stable'}
 
 
-          - {os: ubuntu-20.04,   r: 'release', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          # - {os: ubuntu-20.04,   r: 'release', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
           # - {os: ubuntu-20.04,   r: 'release', rust-version: 'nightly', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
           # # R-devel requires LD_LIBRARY_PATH
           # - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}   
@@ -51,6 +51,7 @@ jobs:
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}
+      BUILD_TARGETS: default
     
     # PowerShell core is available on all platforms and can be used to unify scripts
     defaults:
@@ -84,24 +85,25 @@ jobs:
 
       # All configurations for Windows go here
       # `Rust` toolchain is used to determine target architecture
-      # Alternatively, `if:` conditions can be used
       - name: Configure Windows
         if: startsWith(runner.os, 'Windows')
         # 1. Add appropriate *-gnu target
         # 2. Set CARGO_BUILD_FLAGS to the `rust` target
         run: |
-          if ($env:RUST_TOOLCHAIN -like "*x86_64*") {
-            rustup target add x86_64-pc-windows-gnu ;
-            echo "CARGO_BUILD_FLAGS=--target=x86_64-pc-windows-gnu" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append ;
-            echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
-            echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\x64"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
-          }
-          if ($env:RUST_TOOLCHAIN -like "*i686*") {
+          $targets=@()
+          if ($env:RUST_TOOLCHAIN -notlike "*x86_64*") {
             rustup target add i686-pc-windows-gnu ;
-            echo "CARGO_BUILD_FLAGS=--target=i686-pc-windows-gnu" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append ;
+            $targets+="i686-pc-windows-gnu"
             echo "C:\msys64\mingw32\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
             echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\i386"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
           }
+          if ($env:RUST_TOOLCHAIN -notlike "*i686*") {
+            rustup target add x86_64-pc-windows-gnu ;
+            $targets+="x86_64-pc-windows-gnu"
+            echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+            echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\x64"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+          }
+          echo "BUILD_TARGETS=$($targets -join ',')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append ;
         env: 
           RUST_TOOLCHAIN: ${{ matrix.config.rust-version }}
 
@@ -109,47 +111,49 @@ jobs:
         uses: r-lib/actions/setup-pandoc@v1
       
       - name: Build
-        run: cargo build -vv $env:CARGO_BUILD_FLAGS
+        run: |
+          foreach($target in ($env:BUILD_TARGETS).Split(',')) {cargo build -vv $(if($target -ne 'default') {"--target=$target"} ) }
 
       - name: Run tests
         run: |
-          cargo test -vv $env:CARGO_BUILD_FLAGS -- --nocapture --test-threads=1
+          foreach($target in ($env:BUILD_TARGETS).Split(',')) {cargo test -vv $(if($target -ne 'default') {"--target=$target"} ) -- --nocapture --test-threads=1}
 
 
-      - name: Query dependencies for integration testing
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(pkgdir = "tests/extendrtests", dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
 
-      - name: Cache installed R packages
-        # if: runner.os != 'Windows'
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+      # - name: Query dependencies for integration testing
+      #   run: |
+      #     install.packages('remotes')
+      #     saveRDS(remotes::dev_package_deps(pkgdir = "tests/extendrtests", dependencies = TRUE), ".github/depends.Rds", version = 2)
+      #     writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+      #   shell: Rscript {0}
 
-      - name: Install R dependencies for integration testing
-        run: |
-          remotes::install_deps(pkgdir = "tests/extendrtests", dependencies = TRUE)
-          remotes::install_cran("rcmdcheck")
-        shell: Rscript {0}
+      # - name: Cache installed R packages
+      #   # if: runner.os != 'Windows'
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: ${{ env.R_LIBS_USER }}
+      #     key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+      #     restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+
+      # - name: Install R dependencies for integration testing
+      #   run: |
+      #     remotes::install_deps(pkgdir = "tests/extendrtests", dependencies = TRUE)
+      #     remotes::install_cran("rcmdcheck")
+      #   shell: Rscript {0}
         
-      - name: Run R integration tests
-        id: r_integration_tests
-        env:
-          _R_CHECK_CRAN_INCOMING_REMOTE_: false
-        run: rcmdcheck::rcmdcheck(path = "tests/extendrtests", args = c("--no-manual", "--as-cran", "--no-multiarch"), error_on = "warning", check_dir = "check")
-        shell: Rscript {0}
+      # - name: Run R integration tests
+      #   id: r_integration_tests
+      #   env:
+      #     _R_CHECK_CRAN_INCOMING_REMOTE_: false
+      #   run: rcmdcheck::rcmdcheck(path = "tests/extendrtests", args = c("--no-manual", "--as-cran", Sys.getenv("R_CHECK_NO_MULTIARCH")), error_on = "warning", check_dir = "check")
+      #   shell: Rscript {0}
         
-      - name: Upload check results from R integration tests
-        if: failure()
-        uses: actions/upload-artifact@main
-        with:
-          name:  ${{ matrix.config.os }}-R-${{ matrix.config.r }}-rust-${{ matrix.config.rust-version }}
-          path: check
+      # - name: Upload check results from R integration tests
+      #   if: failure()
+      #   uses: actions/upload-artifact@main
+      #   with:
+      #     name:  ${{ matrix.config.os }}-R-${{ matrix.config.r }}-rust-${{ matrix.config.rust-version }}
+      #     path: check
 
 
 # All tests under this job are run with R devel and freshly generated bindings.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,102 +60,102 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v1
       
-      - name: Build (not Windows)
-        if: runner.os != 'Windows'
-        run: cargo build
+      # - name: Build (not Windows)
+      #   if: runner.os != 'Windows'
+      #   run: cargo build
 
-      - name: Run tests (not Windows)
-        if: runner.os != 'Windows'
-        run: |
-          export R_HOME=`R -s -e 'cat(R.home())'`
-          export LD_LIBRARY_PATH=${R_HOME}/lib
-          cargo test -- --nocapture --test-threads=1
+      # - name: Run tests (not Windows)
+      #   if: runner.os != 'Windows'
+      #   run: |
+      #     export R_HOME=`R -s -e 'cat(R.home())'`
+      #     export LD_LIBRARY_PATH=${R_HOME}/lib
+      #     cargo test -- --nocapture --test-threads=1
 
 
-      - name: Build (Windows)
-        if: runner.os == 'Windows'
-        run: cargo build --target x86_64-pc-windows-gnu
-        shell: msys2 {0}
+      # - name: Build (Windows)
+      #   if: runner.os == 'Windows'
+      #   run: cargo build --target x86_64-pc-windows-gnu
+      #   shell: msys2 {0}
 
-      - name: Run tests (Windows)
-        if: runner.os == 'Windows'
-        run: cargo test --target x86_64-pc-windows-gnu -- --nocapture --test-threads=1
-        shell: msys2 {0}
+      # - name: Run tests (Windows)
+      #   if: runner.os == 'Windows'
+      #   run: cargo test --target x86_64-pc-windows-gnu -- --nocapture --test-threads=1
+      #   shell: msys2 {0}
 
-      - name: Query dependencies for integration testing
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(pkgdir = "tests/extendrtests", dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
+      # - name: Query dependencies for integration testing
+      #   run: |
+      #     install.packages('remotes')
+      #     saveRDS(remotes::dev_package_deps(pkgdir = "tests/extendrtests", dependencies = TRUE), ".github/depends.Rds", version = 2)
+      #     writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+      #   shell: Rscript {0}
 
-      - name: Cache installed R packages
-        if: runner.os != 'Windows'
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+      # - name: Cache installed R packages
+      #   if: runner.os != 'Windows'
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: ${{ env.R_LIBS_USER }}
+      #     key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+      #     restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
 
-      - name: Install R dependencies for integration testing
-        run: |
-          remotes::install_deps(pkgdir = "tests/extendrtests", dependencies = TRUE)
-          remotes::install_cran("rcmdcheck")
-        shell: Rscript {0}
+      # - name: Install R dependencies for integration testing
+      #   run: |
+      #     remotes::install_deps(pkgdir = "tests/extendrtests", dependencies = TRUE)
+      #     remotes::install_cran("rcmdcheck")
+      #   shell: Rscript {0}
         
-      - name: Run R integration tests
-        id: r_integration_tests
-        env:
-          _R_CHECK_CRAN_INCOMING_REMOTE_: false
-        run: rcmdcheck::rcmdcheck(path = "tests/extendrtests", args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
-        shell: Rscript {0}
+      # - name: Run R integration tests
+      #   id: r_integration_tests
+      #   env:
+      #     _R_CHECK_CRAN_INCOMING_REMOTE_: false
+      #   run: rcmdcheck::rcmdcheck(path = "tests/extendrtests", args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
+      #   shell: Rscript {0}
         
-      - name: Upload check results from R integration tests
-        if: failure()
-        uses: actions/upload-artifact@main
-        with:
-          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
-          path: check
+      # - name: Upload check results from R integration tests
+      #   if: failure()
+      #   uses: actions/upload-artifact@main
+      #   with:
+      #     name: ${{ runner.os }}-r${{ matrix.config.r }}-results
+      #     path: check
 
 
 # All tests under this job are run with R devel and freshly generated bindings.
-  tests_R_devel_bindgen:
-    runs-on: ${{ matrix.config.os }}
+  # tests_R_devel_bindgen:
+  #   runs-on: ${{ matrix.config.os }}
 
-    name: ${{ matrix.config.os }} w/ bindgen (R-${{ matrix.config.r }} rust-${{ matrix.config.rust-version }})
+  #   name: ${{ matrix.config.os }} w/ bindgen (R-${{ matrix.config.r }} rust-${{ matrix.config.rust-version }})
             
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       config:
+  #         - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
 
-    env:
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      RSPM: ${{ matrix.config.rspm }}
+  #   env:
+  #     R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+  #     RSPM: ${{ matrix.config.rspm }}
 
-    steps:
-      - uses: actions/checkout@v2
+  #   steps:
+  #     - uses: actions/checkout@v2
       
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.config.rust-version }}
+  #     - uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: ${{ matrix.config.rust-version }}
 
-      - uses: r-lib/actions/setup-r@v1
-        with:
-          r-version: ${{ matrix.config.r }}
+  #     - uses: r-lib/actions/setup-r@v1
+  #       with:
+  #         r-version: ${{ matrix.config.r }}
       
-      - name: Build
-        run: |
-          cargo build --manifest-path extendr-api/Cargo.toml --features tests-all
-          cargo build --manifest-path extendr-engine/Cargo.toml --features tests-all
+  #     - name: Build
+  #       run: |
+  #         cargo build --manifest-path extendr-api/Cargo.toml --features tests-all
+  #         cargo build --manifest-path extendr-engine/Cargo.toml --features tests-all
 
-      - name: Run tests
-        run: |
-          export R_HOME=`R -s -e 'cat(R.home())'`
-          export LD_LIBRARY_PATH=${R_HOME}/lib
-          cargo test --manifest-path extendr-engine/Cargo.toml --features tests-all -- --nocapture --test-threads=1
-          cargo test --manifest-path extendr-api/Cargo.toml --features tests-all -- --nocapture --test-threads=1
-          cargo test --manifest-path extendr-api/Cargo.toml --features tests-minimal -- --nocapture --test-threads=1
-          cargo test --manifest-path extendr-macros/Cargo.toml -- --nocapture --test-threads=1
+  #     - name: Run tests
+  #       run: |
+  #         export R_HOME=`R -s -e 'cat(R.home())'`
+  #         export LD_LIBRARY_PATH=${R_HOME}/lib
+  #         cargo test --manifest-path extendr-engine/Cargo.toml --features tests-all -- --nocapture --test-threads=1
+  #         cargo test --manifest-path extendr-api/Cargo.toml --features tests-all -- --nocapture --test-threads=1
+  #         cargo test --manifest-path extendr-api/Cargo.toml --features tests-minimal -- --nocapture --test-threads=1
+  #         cargo test --manifest-path extendr-macros/Cargo.toml -- --nocapture --test-threads=1
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
           # - {os: windows-latest, r: 'oldrel', rust-version: 'stable-i686-pc-windows-msvc', msystem: "MINGW32"}
 
 
-          # - {os: macOS-latest,   r: 'release', rust-version: 'stable'}
+          - {os: macOS-latest,   r: 'release', rust-version: 'stable'}
           # - {os: macOS-latest,   r: 'release', rust-version: 'nightly'}
           # - {os: macOS-latest,   r: 'devel', rust-version: 'stable'}
           # - {os: macOS-latest,   r: 'oldrel', rust-version: 'stable'}
@@ -60,35 +60,23 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       
-      - uses: actions-rs/toolchain@v1
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.config.rust-version }}
-
-      - name: Set up Rust targets on Windows
-        if: runner.os == 'Windows'
-        run: |
-          rustup target add x86_64-pc-windows-gnu
-          rustup target add i686-pc-windows-gnu
-
-      # Installing 'msys2' on Windows only
-      - name: Set up 'msys2' for Windows
-        uses: msys2/setup-msys2@v2
-        if: runner.os == 'Windows'
-        with:
-          msystem: MINGW64
-          path-type: inherit
-          release: false
-          update: false
-
-      - uses: r-lib/actions/setup-r@v1
+          default: true
+          components: rustfmt, clippy
+      
+      - name: Set up R
+        uses: r-lib/actions/setup-r@v1
         with:
           r-version: ${{ matrix.config.r }}
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - name: Set up Pandoc
+        uses: r-lib/actions/setup-pandoc@v1
       
-      # - name: Build (not Windows)
-      #   if: runner.os != 'Windows'
-      #   run: cargo build
+      - name: Build
+        run: cargo build
 
       # - name: Run tests (not Windows)
       #   if: runner.os != 'Windows'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -176,22 +176,37 @@ jobs:
       matrix:
         config:
           - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: macOS-latest,   r: 'devel', rust-version: 'stable'}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}
+    
+    # PowerShell core is available on all platforms and can be used to unify scripts
+    defaults:
+      run:
+        shell: pwsh
 
     steps:
       - uses: actions/checkout@v2
       
-      - uses: actions-rs/toolchain@v1
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.config.rust-version }}
+          default: true
 
-      - uses: r-lib/actions/setup-r@v1
+      - name: Set up R
+        uses: r-lib/actions/setup-r@v1
         with:
           r-version: ${{ matrix.config.r }}
       
+      - name: Configure Linux
+        if: runner.os == 'linux'
+        run: |
+          Del alias:R
+          echo "LD_LIBRARY_PATH=$(R -s -e 'cat(normalizePath(R.home()))')/lib" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Build
         run: |
           cargo build --manifest-path extendr-api/Cargo.toml --features tests-all
@@ -199,8 +214,6 @@ jobs:
 
       - name: Run tests
         run: |
-          export R_HOME=`R -s -e 'cat(R.home())'`
-          export LD_LIBRARY_PATH=${R_HOME}/lib
           cargo test --manifest-path extendr-engine/Cargo.toml --features tests-all -- --nocapture --test-threads=1
           cargo test --manifest-path extendr-api/Cargo.toml --features tests-all -- --nocapture --test-threads=1
           cargo test --manifest-path extendr-api/Cargo.toml --features tests-minimal -- --nocapture --test-threads=1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,13 +141,13 @@ jobs:
       # Required by Windows builds, does not affect other platforms
       - name: Build
         run: |
-          foreach($target in ($env:BUILD_TARGETS).Split(',')) {cargo build -vv $(if($target -ne 'default') {"--target=$target"} ) }
+          foreach($target in ($env:BUILD_TARGETS).Split(',')) {cargo build -v $(if($target -ne 'default') {"--target=$target"} ) }
 
       # For each target in the BUILD_TARGETS comma-separated list, run cargo test with appropriate target
       # Required by Windows builds, does not affect other platforms
       - name: Run tests
         run: |
-          foreach($target in ($env:BUILD_TARGETS).Split(',')) {cargo test -vv $(if($target -ne 'default') {"--target=$target"} ) -- --nocapture --test-threads=1}
+          foreach($target in ($env:BUILD_TARGETS).Split(',')) {cargo test -v $(if($target -ne 'default') {"--target=$target"} ) -- --nocapture --test-threads=1}
 
 
       - name: Query dependencies for integration testing
@@ -268,13 +268,13 @@ jobs:
 
       - name: Build
         run: |
-          cargo build $env:CARGO_BUILD_FLAGS --manifest-path extendr-api/Cargo.toml --features tests-all
-          cargo build $env:CARGO_BUILD_FLAGS --manifest-path extendr-engine/Cargo.toml --features tests-all
+          cargo build $env:CARGO_BUILD_FLAGS -v --manifest-path extendr-api/Cargo.toml --features tests-all
+          cargo build $env:CARGO_BUILD_FLAGS -v --manifest-path extendr-engine/Cargo.toml --features tests-all
 
       - name: Run tests
         run: |
-          cargo test $env:CARGO_BUILD_FLAGS --manifest-path extendr-engine/Cargo.toml --features tests-all -- --nocapture --test-threads=1
-          cargo test $env:CARGO_BUILD_FLAGS --manifest-path extendr-api/Cargo.toml --features tests-all -- --nocapture --test-threads=1
-          cargo test $env:CARGO_BUILD_FLAGS --manifest-path extendr-api/Cargo.toml --features tests-minimal -- --nocapture --test-threads=1
-          cargo test $env:CARGO_BUILD_FLAGS --manifest-path extendr-macros/Cargo.toml -- --nocapture --test-threads=1
+          cargo test $env:CARGO_BUILD_FLAGS -v --manifest-path extendr-engine/Cargo.toml --features tests-all -- --nocapture --test-threads=1
+          cargo test $env:CARGO_BUILD_FLAGS -v --manifest-path extendr-api/Cargo.toml --features tests-all -- --nocapture --test-threads=1
+          cargo test $env:CARGO_BUILD_FLAGS -v --manifest-path extendr-api/Cargo.toml --features tests-minimal -- --nocapture --test-threads=1
+          cargo test $env:CARGO_BUILD_FLAGS -v --manifest-path extendr-macros/Cargo.toml -- --nocapture --test-threads=1
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,16 +21,22 @@ jobs:
       fail-fast: false
       matrix:
         config:
+          # Windows jobs with unspecific Rust architecture build for both i686 and x86_64 
+          # R integration tests are also executed for both architectures
           - {os: windows-latest, r: 'release', rust-version: 'stable-msvc'}
-          - {os: windows-latest, r: 'release', rust-version: 'nightly-x86_64-pc-windows-msvc'}
+          - {os: windows-latest, r: 'release', rust-version: 'nightly-msvc'}
           - {os: windows-latest, r: 'devel', rust-version: 'stable-msvc'}
           - {os: windows-latest, r: 'oldrel', rust-version: 'stable-msvc'}
 
+          # Windows jobs with x86_64 Rust toolchain build for x86_64 only
+          # R integration tests are run with 64-bit R version and '--no-multiarch' flag
           # - {os: windows-latest, r: 'release', rust-version: 'stable-x86_64-pc-windows-msvc'}
           # - {os: windows-latest, r: 'release', rust-version: 'nightly-x86_64-pc-windows-msvc'}
           # - {os: windows-latest, r: 'devel', rust-version: 'stable-x86_64-pc-windows-msvc'}
           # - {os: windows-latest, r: 'oldrel', rust-version: 'stable-x86_64-pc-windows-msvc'}
 
+          # Windows jobs with i686 Rust toolchain build for i686 only
+          # R integration tests are run with 32-bit R version and '--no-multiarch' flag
           # - {os: windows-latest, r: 'release', rust-version: 'stable-i686-pc-windows-msvc'}
           # - {os: windows-latest, r: 'release', rust-version: 'nightly-i686-pc-windows-msvc'}
           # - {os: windows-latest, r: 'devel', rust-version: 'stable-i686-pc-windows-msvc'}
@@ -52,6 +58,14 @@ jobs:
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}
+
+      # This environment variable enables support for pseudo multi-target cargo builds.
+      # Current stable Rust does not support multi-targeting,
+      # see https://github.com/rust-lang/cargo/issues/8176
+      # The variable is treated as a comma-separated list of valid Rust targets.
+      # 'default' value emits no '--target' flag.
+      # E.g.: BUILD_TARGETS=i686-pc-windows-gnu,x86_64-pc-windows-gnu builds two times,
+      # each time providing '--target=*-pc-windows-gnu' flag to cargo.
       BUILD_TARGETS: default
     
     # PowerShell core is available on all platforms and can be used to unify scripts
@@ -84,11 +98,16 @@ jobs:
           update: false
 
       # All configurations for Windows go here
-      # `Rust` toolchain is used to determine target architecture
+      # If 'rust-version' has no architecture id, both if conditions are executed
+      # Otherwise, only one condition is met
+      # $targets variable is used to build targets list used later for cargo build/test
+      # The order of if blocks favors x86_64 over i686 paths, which is optimal for multi-targeting
       - name: Configure Windows
         if: startsWith(runner.os, 'Windows')
-        # 1. Add appropriate *-gnu target
-        # 2. Set CARGO_BUILD_FLAGS to the `rust` target
+        # 1. Add rust target
+        # 2. Add target name to the $targets variable
+        # 3. Add mingw32/mingw64 bin folders to PATH
+        # 4. Add R x64/i386 folders to PATH
         run: |
           $targets=@()
           if ($env:RUST_TOOLCHAIN -notlike "*x86_64*") {
@@ -118,15 +137,17 @@ jobs:
       - name: Set up Pandoc
         uses: r-lib/actions/setup-pandoc@v1
       
+      # For each target in the BUILD_TARGETS comma-separated list, run cargo build with appropriate target
+      # Required by Windows builds, does not affect other platforms
       - name: Build
         run: |
-          cargo update
           foreach($target in ($env:BUILD_TARGETS).Split(',')) {cargo build -vv $(if($target -ne 'default') {"--target=$target"} ) }
 
+      # For each target in the BUILD_TARGETS comma-separated list, run cargo test with appropriate target
+      # Required by Windows builds, does not affect other platforms
       - name: Run tests
         run: |
           foreach($target in ($env:BUILD_TARGETS).Split(',')) {cargo test -vv $(if($target -ne 'default') {"--target=$target"} ) -- --nocapture --test-threads=1}
-
 
 
       - name: Query dependencies for integration testing
@@ -149,11 +170,13 @@ jobs:
           remotes::install_cran("rcmdcheck")
         shell: Rscript {0}
         
+      # Windows: modified PATH will launch 32-bit Rscript if the build targets only i686/i386, so no conflict will arise
+      # Rust pseudo multi-targeting: R CMD CHECK receives an extra argument '--no-multiarch' if BUILD_TARGETS is not 'default' and does not contain any commas
       - name: Run R integration tests
         id: r_integration_tests
         env:
           _R_CHECK_CRAN_INCOMING_REMOTE_: false
-        run: rcmdcheck::rcmdcheck(path = "tests/extendrtests", args = c("--no-manual", "--as-cran", ifelse(grepl("default|^.*,.*$", Sys.getenv("BUILD_TARGETS")), "", "--no-multiarch")), error_on = "warning", check_dir = "check")
+        run: rcmdcheck::rcmdcheck(path = "tests/extendrtests", args = c("--no-manual", "--as-cran", ifelse(grepl("^default$|^.*,.*$", Sys.getenv("BUILD_TARGETS")), "", "--no-multiarch")), error_on = "warning", check_dir = "check")
         shell: Rscript {0}
         
       - name: Upload check results from R integration tests
@@ -213,15 +236,13 @@ jobs:
           update: false
 
       # All configurations for Windows go here
-      # `Rust` toolchain is used to determine target architecture
-      # Alternatively, `if:` conditions can be used
+      # Rust toolchain is used to determine target architecture
       - name: Configure Windows
         if: runner.os == 'Windows'
         # 1. Add appropriate *-gnu target
         # 2. Set CARGO_BUILD_FLAGS to the `rust` target
-        # 3. Configure path to `libclang`
-        # 4. Add path to `mingw32`/`mingw64` -- otherwise library is linked to `rtools`
-        # 5. Add path to R's `i386`/`x64`  -- to solve `x86` build/test issue
+        # 3. Add path to `mingw32`/`mingw64` -- otherwise library is linked to `rtools`
+        # 4. Add path to R's `i386`/`x64`  -- to solve `x86` build/test issue
         run: |
           if ($env:RUST_TOOLCHAIN -like "*x86_64*") {
             rustup target add x86_64-pc-windows-gnu ;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -175,8 +175,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          # - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          # - {os: macOS-latest,   r: 'devel', rust-version: 'stable'}
+          - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: macOS-latest,   r: 'devel', rust-version: 'stable'}
           - {os: windows-latest, r: 'devel', rust-version: 'stable-x86_64-pc-windows-msvc'}
           - {os: windows-latest, r: 'devel', rust-version: 'stable-i686-pc-windows-msvc'}
 
@@ -245,10 +245,6 @@ jobs:
         run: |
           Del alias:R
           echo "LD_LIBRARY_PATH=$(R -s -e 'cat(normalizePath(R.home()))')/lib" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
-      - name: Debug
-        run: |
-          echo $env:CARGO_BUILD_FLAGS
 
       - name: Build
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,31 +21,31 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: 'release', rust-version: 'stable-msvc', msystem: "MINGW64"}
-          
-          - {os: windows-latest, r: 'release', rust-version: 'stable-x86_64-pc-windows-msvc', msystem: "MINGW64"}
-          # - {os: windows-latest, r: 'release', rust-version: 'nightly-x86_64-pc-windows-msvc', msystem: "MINGW64"}
-          # - {os: windows-latest, r: 'devel', rust-version: 'stable-x86_64-pc-windows-msvc', msystem: "MINGW64"}
-          # - {os: windows-latest, r: 'oldrel', rust-version: 'stable-x86_64-pc-windows-msvc', msystem: "MINGW64"}
+          - {os: windows-latest, r: 'release', rust-version: 'stable-msvc'}
+
+          - {os: windows-latest, r: 'release', rust-version: 'stable-x86_64-pc-windows-msvc'}
+          - {os: windows-latest, r: 'release', rust-version: 'nightly-x86_64-pc-windows-msvc'}
+          - {os: windows-latest, r: 'devel', rust-version: 'stable-x86_64-pc-windows-msvc'}
+          - {os: windows-latest, r: 'oldrel', rust-version: 'stable-x86_64-pc-windows-msvc'}
 
 
-          - {os: windows-latest, r: 'release', rust-version: 'stable-i686-pc-windows-msvc', msystem: "MINGW32"}
-          # - {os: windows-latest, r: 'release', rust-version: 'nightly-i686-pc-windows-msvc', msystem: "MINGW32"}
-          # - {os: windows-latest, r: 'devel', rust-version: 'stable-i686-pc-windows-msvc', msystem: "MINGW32"}
-          # - {os: windows-latest, r: 'oldrel', rust-version: 'stable-i686-pc-windows-msvc', msystem: "MINGW32"}
+          - {os: windows-latest, r: 'release', rust-version: 'stable-i686-pc-windows-msvc'}
+          - {os: windows-latest, r: 'release', rust-version: 'nightly-i686-pc-windows-msvc'}
+          - {os: windows-latest, r: 'devel', rust-version: 'stable-i686-pc-windows-msvc'}
+          - {os: windows-latest, r: 'oldrel', rust-version: 'stable-i686-pc-windows-msvc'}
 
 
           - {os: macOS-latest,   r: 'release', rust-version: 'stable'}
-          # - {os: macOS-latest,   r: 'release', rust-version: 'nightly'}
-          # - {os: macOS-latest,   r: 'devel', rust-version: 'stable'}
-          # - {os: macOS-latest,   r: 'oldrel', rust-version: 'stable'}
+          - {os: macOS-latest,   r: 'release', rust-version: 'nightly'}
+          - {os: macOS-latest,   r: 'devel', rust-version: 'stable'}
+          - {os: macOS-latest,   r: 'oldrel', rust-version: 'stable'}
 
 
           - {os: ubuntu-20.04,   r: 'release', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          # - {os: ubuntu-20.04,   r: 'release', rust-version: 'nightly', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          # # R-devel requires LD_LIBRARY_PATH
-          # - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}   
-          # - {os: ubuntu-20.04,   r: 'oldrel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}   
+          - {os: ubuntu-20.04,   r: 'release', rust-version: 'nightly', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          # R-devel requires LD_LIBRARY_PATH
+          - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}   
+          - {os: ubuntu-20.04,   r: 'oldrel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}   
 
 
 
@@ -79,7 +79,6 @@ jobs:
         if: startsWith(runner.os, 'Windows')
         uses: msys2/setup-msys2@v2
         with:
-          msystem: ${{ matrix.config.msystem }}
           path-type: inherit
           release: false
           update: false
@@ -108,11 +107,20 @@ jobs:
         env: 
           RUST_TOOLCHAIN: ${{ matrix.config.rust-version }}
 
+      # This is required for ubuntu r-devel
+      # 'Del alias:R' removes 'R' alias which prevents running R 
+      - name: Configure Linux
+        if: runner.os == 'linux'
+        run: |
+          Del alias:R
+          echo "LD_LIBRARY_PATH=$(R -s -e 'cat(normalizePath(R.home()))')/lib" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Set up Pandoc
         uses: r-lib/actions/setup-pandoc@v1
       
       - name: Build
         run: |
+          cargo update
           foreach($target in ($env:BUILD_TARGETS).Split(',')) {cargo build -vv $(if($target -ne 'default') {"--target=$target"} ) }
 
       - name: Run tests
@@ -146,7 +154,7 @@ jobs:
         id: r_integration_tests
         env:
           _R_CHECK_CRAN_INCOMING_REMOTE_: false
-        run: rcmdcheck::rcmdcheck(path = "tests/extendrtests", args = c("--no-manual", "--as-cran", Sys.getenv("R_CHECK_NO_MULTIARCH")), error_on = "warning", check_dir = "check")
+        run: rcmdcheck::rcmdcheck(path = "tests/extendrtests", args = c("--no-manual", "--as-cran", ifelse(grepl("default|^.*,.*$", Sys.getenv("BUILD_TARGETS")), "", "--no-multiarch")), error_on = "warning", check_dir = "check")
         shell: Rscript {0}
         
       - name: Upload check results from R integration tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,6 +129,7 @@ jobs:
       - name: Build
         run: |
           foreach($target in ($env:BUILD_TARGETS).Split(',')) {
+            echo $target
             cargo build $(if($target -ne 'default') {"--target=$target"} ) 
           }
 
@@ -137,6 +138,7 @@ jobs:
       - name: Run tests
         run: |
           foreach($target in ($env:BUILD_TARGETS).Split(',')) {
+            echo $target
             cargo test $(if($target -ne 'default') {"--target=$target"} ) -- --nocapture --test-threads=1
           }
 
@@ -191,8 +193,6 @@ jobs:
           - {os: ubuntu-20.04,   r: 'devel', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
           - {os: macOS-latest,   r: 'devel', rust-version: 'stable'}
           - {os: windows-latest, r: 'devel', rust-version: 'stable-msvc'}
-          # - {os: windows-latest, r: 'devel', rust-version: 'stable-x86_64-pc-windows-msvc'}
-          # - {os: windows-latest, r: 'devel', rust-version: 'stable-i686-pc-windows-msvc'}
 
 
     env:
@@ -262,24 +262,30 @@ jobs:
       - name: Build
         run: |
           foreach($target in ($env:BUILD_TARGETS).Split(',')) {
+            echo $target
             cargo build --manifest-path extendr-api/Cargo.toml --features tests-all $(if($target -ne 'default') {"--target=$target"} ) 
           }
           foreach($target in ($env:BUILD_TARGETS).Split(',')) {
+            echo $target
             cargo build --manifest-path extendr-engine/Cargo.toml --features tests-all $(if($target -ne 'default') {"--target=$target"} ) 
           }
 
       - name: Run tests
         run: |
           foreach($target in ($env:BUILD_TARGETS).Split(',')) {
+            echo $target
             cargo test --manifest-path extendr-engine/Cargo.toml --features tests-all $(if($target -ne 'default') {"--target=$target"} ) -- --nocapture --test-threads=1 
           }
           foreach($target in ($env:BUILD_TARGETS).Split(',')) {
+            echo $target
             cargo test --manifest-path extendr-api/Cargo.toml --features tests-all $(if($target -ne 'default') {"--target=$target"} ) -- --nocapture --test-threads=1 
           }
           foreach($target in ($env:BUILD_TARGETS).Split(',')) {
+            echo $target
             cargo test --manifest-path extendr-api/Cargo.toml --features tests-minimal $(if($target -ne 'default') {"--target=$target"} ) -- --nocapture --test-threads=1
           }
           foreach($target in ($env:BUILD_TARGETS).Split(',')) {
+            echo $target
             cargo test --manifest-path extendr-macros/Cargo.toml  $(if($target -ne 'default') {"--target=$target"} ) -- --nocapture --test-threads=1
           }
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,6 +88,9 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
       
+      - name: Set up Pandoc
+        uses: r-lib/actions/setup-pandoc@v1
+      
       # This step is only needed for Windows
       - name: Set up MSYS2 for Windows
         if: startsWith(runner.os, 'Windows')
@@ -134,8 +137,6 @@ jobs:
           Del alias:R
           echo "LD_LIBRARY_PATH=$(R -s -e 'cat(normalizePath(R.home()))')/lib" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-      - name: Set up Pandoc
-        uses: r-lib/actions/setup-pandoc@v1
       
       # For each target in the BUILD_TARGETS comma-separated list, run cargo build with appropriate target
       # Required by Windows builds, does not affect other platforms

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,15 +21,41 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: 'release', rust-version: 'stable-x86_64-pc-windows-msvc'}
-          - {os: macOS-latest,   r: 'release', rust-version: 'stable'}
+          
+          # - {os: windows-latest, r: 'release', rust-version: 'stable-x86_64-pc-windows-msvc', msystem: "MINGW64"}
+          # - {os: windows-latest, r: 'release', rust-version: 'nightly-x86_64-pc-windows-msvc', msystem: "MINGW64"}
+          # - {os: windows-latest, r: 'devel', rust-version: 'stable-x86_64-pc-windows-msvc', msystem: "MINGW64"}
+          # - {os: windows-latest, r: 'oldrel', rust-version: 'stable-x86_64-pc-windows-msvc', msystem: "MINGW64"}
+
+
+          # - {os: windows-latest, r: 'release', rust-version: 'stable-i686-pc-windows-msvc', msystem: "MINGW32"}
+          # - {os: windows-latest, r: 'release', rust-version: 'nightly-i686-pc-windows-msvc', msystem: "MINGW32"}
+          # - {os: windows-latest, r: 'devel', rust-version: 'stable-i686-pc-windows-msvc', msystem: "MINGW32"}
+          # - {os: windows-latest, r: 'oldrel', rust-version: 'stable-i686-pc-windows-msvc', msystem: "MINGW32"}
+
+
+          # - {os: macOS-latest,   r: 'release', rust-version: 'stable'}
+          # - {os: macOS-latest,   r: 'release', rust-version: 'nightly'}
+          # - {os: macOS-latest,   r: 'devel', rust-version: 'stable'}
+          # - {os: macOS-latest,   r: 'oldrel', rust-version: 'stable'}
+
+
           - {os: ubuntu-20.04,   r: 'release', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          - {os: ubuntu-20.04,   r: 'release', rust-version: 'nightly', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'nightly', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          # - {os: ubuntu-20.04,   r: 'release', rust-version: 'nightly', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          # # R-devel requires LD_LIBRARY_PATH
+          # - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}   
+          # - {os: ubuntu-20.04,   r: 'oldrel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}   
+
+
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}
+    
+    # PowerShell core is available on all platforms and can be used to unify scripts
+    defaults:
+      run:
+        shell: pwsh
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,179 +12,183 @@ on:
 
 jobs:
   # All tests under this job are run with pre-computed libR-sys bindings.
-  # tests_no_bindgen:
-  #   runs-on: ${{ matrix.config.os }}
+  tests_no_bindgen:
+    runs-on: ${{ matrix.config.os }}
 
-  #   name: ${{ matrix.config.os }} (R-${{ matrix.config.r }} rust-${{ matrix.config.rust-version }})
+    name: ${{ matrix.config.os }} (R-${{ matrix.config.r }} rust-${{ matrix.config.rust-version }})
             
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       config:
-  #         # Windows jobs with unspecific Rust architecture build for both i686 and x86_64 
-  #         # R integration tests are also executed for both architectures
-  #         - {os: windows-latest, r: 'release', rust-version: 'stable-msvc'}
-  #         # - {os: windows-latest, r: 'release', rust-version: 'nightly-msvc'}
-  #         # - {os: windows-latest, r: 'devel', rust-version: 'stable-msvc'}
-  #         # - {os: windows-latest, r: 'oldrel', rust-version: 'stable-msvc'}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          # Windows jobs with unspecific Rust architecture build for both i686 and x86_64 
+          # R integration tests are also executed for both architectures
+          - {os: windows-latest, r: 'release', rust-version: 'stable-msvc'}
+          # - {os: windows-latest, r: 'release', rust-version: 'nightly-msvc'}
+          # - {os: windows-latest, r: 'devel', rust-version: 'stable-msvc'}
+          # - {os: windows-latest, r: 'oldrel', rust-version: 'stable-msvc'}
 
-  #         # Windows jobs with x86_64 Rust toolchain build for x86_64 only
-  #         # R integration tests are run with 64-bit R version and '--no-multiarch' flag
-  #         # - {os: windows-latest, r: 'release', rust-version: 'stable-x86_64-pc-windows-msvc'}
-  #         # - {os: windows-latest, r: 'release', rust-version: 'nightly-x86_64-pc-windows-msvc'}
-  #         # - {os: windows-latest, r: 'devel', rust-version: 'stable-x86_64-pc-windows-msvc'}
-  #         # - {os: windows-latest, r: 'oldrel', rust-version: 'stable-x86_64-pc-windows-msvc'}
+          # Windows jobs with x86_64 Rust toolchain build for x86_64 only
+          # R integration tests are run with 64-bit R version and '--no-multiarch' flag
+          # - {os: windows-latest, r: 'release', rust-version: 'stable-x86_64-pc-windows-msvc'}
+          # - {os: windows-latest, r: 'release', rust-version: 'nightly-x86_64-pc-windows-msvc'}
+          # - {os: windows-latest, r: 'devel', rust-version: 'stable-x86_64-pc-windows-msvc'}
+          # - {os: windows-latest, r: 'oldrel', rust-version: 'stable-x86_64-pc-windows-msvc'}
 
-  #         # Windows jobs with i686 Rust toolchain build for i686 only
-  #         # R integration tests are run with 32-bit R version and '--no-multiarch' flag
-  #         # - {os: windows-latest, r: 'release', rust-version: 'stable-i686-pc-windows-msvc'}
-  #         # - {os: windows-latest, r: 'release', rust-version: 'nightly-i686-pc-windows-msvc'}
-  #         # - {os: windows-latest, r: 'devel', rust-version: 'stable-i686-pc-windows-msvc'}
-  #         # - {os: windows-latest, r: 'oldrel', rust-version: 'stable-i686-pc-windows-msvc'}
+          # Windows jobs with i686 Rust toolchain build for i686 only
+          # R integration tests are run with 32-bit R version and '--no-multiarch' flag
+          # - {os: windows-latest, r: 'release', rust-version: 'stable-i686-pc-windows-msvc'}
+          # - {os: windows-latest, r: 'release', rust-version: 'nightly-i686-pc-windows-msvc'}
+          # - {os: windows-latest, r: 'devel', rust-version: 'stable-i686-pc-windows-msvc'}
+          # - {os: windows-latest, r: 'oldrel', rust-version: 'stable-i686-pc-windows-msvc'}
 
-  #         - {os: macOS-latest,   r: 'release', rust-version: 'stable'}
-  #         # - {os: macOS-latest,   r: 'release', rust-version: 'nightly'}
-  #         # - {os: macOS-latest,   r: 'devel', rust-version: 'stable'}
-  #         # - {os: macOS-latest,   r: 'oldrel', rust-version: 'stable'}
+          - {os: macOS-latest,   r: 'release', rust-version: 'stable'}
+          # - {os: macOS-latest,   r: 'release', rust-version: 'nightly'}
+          # - {os: macOS-latest,   r: 'devel', rust-version: 'stable'}
+          # - {os: macOS-latest,   r: 'oldrel', rust-version: 'stable'}
 
-  #         - {os: ubuntu-20.04,   r: 'release', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-  #         # - {os: ubuntu-20.04,   r: 'release', rust-version: 'nightly', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-  #         # R-devel requires LD_LIBRARY_PATH
-  #         # - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}   
-  #         # - {os: ubuntu-20.04,   r: 'oldrel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}   
+          - {os: ubuntu-20.04,   r: 'release', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          # - {os: ubuntu-20.04,   r: 'release', rust-version: 'nightly', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          # R-devel requires LD_LIBRARY_PATH
+          # - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}   
+          # - {os: ubuntu-20.04,   r: 'oldrel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}   
 
 
 
-  #   env:
-  #     R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-  #     RSPM: ${{ matrix.config.rspm }}
+    env:
+      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      RSPM: ${{ matrix.config.rspm }}
 
-  #     # This environment variable enables support for pseudo multi-target cargo builds.
-  #     # Current stable Rust does not support multi-targeting,
-  #     # see https://github.com/rust-lang/cargo/issues/8176
-  #     # The variable is treated as a comma-separated list of valid Rust targets.
-  #     # 'default' value emits no '--target' flag.
-  #     # E.g.: BUILD_TARGETS=i686-pc-windows-gnu,x86_64-pc-windows-gnu builds two times,
-  #     # each time providing '--target=*-pc-windows-gnu' flag to cargo.
-  #     BUILD_TARGETS: default
+      # This environment variable enables support for pseudo multi-target cargo builds.
+      # Current stable Rust does not support multi-targeting,
+      # see https://github.com/rust-lang/cargo/issues/8176
+      # The variable is treated as a comma-separated list of valid Rust targets.
+      # 'default' value emits no '--target' flag.
+      # E.g.: BUILD_TARGETS=i686-pc-windows-gnu,x86_64-pc-windows-gnu builds two times,
+      # each time providing '--target=*-pc-windows-gnu' flag to cargo.
+      BUILD_TARGETS: default
     
-  #   # PowerShell core is available on all platforms and can be used to unify scripts
-  #   defaults:
-  #     run:
-  #       shell: pwsh
+    # PowerShell core is available on all platforms and can be used to unify scripts
+    defaults:
+      run:
+        shell: pwsh
 
-  #   steps:
-  #     - uses: actions/checkout@v2
+    steps:
+      - uses: actions/checkout@v2
       
-  #     - name: Set up Rust
-  #       uses: actions-rs/toolchain@v1
-  #       with:
-  #         toolchain: ${{ matrix.config.rust-version }}
-  #         default: true
-  #         components: rustfmt, clippy
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.config.rust-version }}
+          default: true
+          components: rustfmt, clippy
       
-  #     - name: Set up R
-  #       uses: r-lib/actions/setup-r@v1
-  #       with:
-  #         r-version: ${{ matrix.config.r }}
+      - name: Set up R
+        uses: r-lib/actions/setup-r@v1
+        with:
+          r-version: ${{ matrix.config.r }}
       
-  #     # This step is only needed for Windows
-  #     - name: Set up MSYS2 for Windows
-  #       if: startsWith(runner.os, 'Windows')
-  #       uses: msys2/setup-msys2@v2
-  #       with:
-  #         path-type: inherit
-  #         release: false
-  #         update: false
+      # This step is only needed for Windows
+      - name: Set up MSYS2 for Windows
+        if: startsWith(runner.os, 'Windows')
+        uses: msys2/setup-msys2@v2
+        with:
+          path-type: inherit
+          release: false
+          update: false
 
-  #     # All configurations for Windows go here
-  #     # If 'rust-version' has no architecture id, both if conditions are executed
-  #     # Otherwise, only one condition is met
-  #     # $targets variable is used to build targets list used later for cargo build/test
-  #     # The order of if blocks favors x86_64 over i686 paths, which is optimal for multi-targeting
-  #     - name: Configure Windows
-  #       if: startsWith(runner.os, 'Windows')
-  #       # 1. Add rust target
-  #       # 2. Add target name to the $targets variable
-  #       # 3. Add mingw32/mingw64 bin folders to PATH
-  #       # 4. Add R x64/i386 folders to PATH
-  #       run: |
-  #         $targets=@()
-  #         if ($env:RUST_TOOLCHAIN -notlike "*x86_64*") {
-  #           rustup target add i686-pc-windows-gnu ;
-  #           $targets+="i686-pc-windows-gnu"
-  #           echo "C:\msys64\mingw32\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
-  #           echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\i386"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
-  #         }
-  #         if ($env:RUST_TOOLCHAIN -notlike "*i686*") {
-  #           rustup target add x86_64-pc-windows-gnu ;
-  #           $targets+="x86_64-pc-windows-gnu"
-  #           echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
-  #           echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\x64"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
-  #         }
-  #         echo "BUILD_TARGETS=$($targets -join ',')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append ;
-  #       env: 
-  #         RUST_TOOLCHAIN: ${{ matrix.config.rust-version }}
+      # All configurations for Windows go here
+      # If 'rust-version' has no architecture id, both if conditions are executed
+      # Otherwise, only one condition is met
+      # $targets variable is used to build targets list used later for cargo build/test
+      # The order of if blocks favors x86_64 over i686 paths, which is optimal for multi-targeting
+      - name: Configure Windows
+        if: startsWith(runner.os, 'Windows')
+        # 1. Add rust target
+        # 2. Add target name to the $targets variable
+        # 3. Add mingw32/mingw64 bin folders to PATH
+        # 4. Add R x64/i386 folders to PATH
+        run: |
+          $targets=@()
+          if ($env:RUST_TOOLCHAIN -notlike "*x86_64*") {
+            rustup target add i686-pc-windows-gnu ;
+            $targets+="i686-pc-windows-gnu"
+            echo "C:\msys64\mingw32\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+            echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\i386"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+          }
+          if ($env:RUST_TOOLCHAIN -notlike "*i686*") {
+            rustup target add x86_64-pc-windows-gnu ;
+            $targets+="x86_64-pc-windows-gnu"
+            echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+            echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\x64"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+          }
+          echo "BUILD_TARGETS=$($targets -join ',')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append ;
+        env: 
+          RUST_TOOLCHAIN: ${{ matrix.config.rust-version }}
 
-  #     # This is required for ubuntu r-devel
-  #     # 'Del alias:R' removes 'R' alias which prevents running R 
-  #     - name: Configure Linux
-  #       if: startsWith(runner.os, 'linux')
-  #       run: |
-  #         Del alias:R
-  #         echo "LD_LIBRARY_PATH=$(R -s -e 'cat(normalizePath(R.home()))')/lib" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      # This is required for ubuntu r-devel
+      # 'Del alias:R' removes 'R' alias which prevents running R 
+      - name: Configure Linux
+        if: startsWith(runner.os, 'linux')
+        run: |
+          Del alias:R
+          echo "LD_LIBRARY_PATH=$(R -s -e 'cat(normalizePath(R.home()))')/lib" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-  #     - name: Set up Pandoc
-  #       uses: r-lib/actions/setup-pandoc@v1
+      - name: Set up Pandoc
+        uses: r-lib/actions/setup-pandoc@v1
       
-  #     # For each target in the BUILD_TARGETS comma-separated list, run cargo build with appropriate target
-  #     # Required by Windows builds, does not affect other platforms
-  #     - name: Build
-  #       run: |
-  #         foreach($target in ($env:BUILD_TARGETS).Split(',')) {cargo build -v $(if($target -ne 'default') {"--target=$target"} ) }
+      # For each target in the BUILD_TARGETS comma-separated list, run cargo build with appropriate target
+      # Required by Windows builds, does not affect other platforms
+      - name: Build
+        run: |
+          foreach($target in ($env:BUILD_TARGETS).Split(',')) {
+            cargo build $(if($target -ne 'default') {"--target=$target"} ) 
+          }
 
-  #     # For each target in the BUILD_TARGETS comma-separated list, run cargo test with appropriate target
-  #     # Required by Windows builds, does not affect other platforms
-  #     - name: Run tests
-  #       run: |
-  #         foreach($target in ($env:BUILD_TARGETS).Split(',')) {cargo test -v $(if($target -ne 'default') {"--target=$target"} ) -- --nocapture --test-threads=1}
+      # For each target in the BUILD_TARGETS comma-separated list, run cargo test with appropriate target
+      # Required by Windows builds, does not affect other platforms
+      - name: Run tests
+        run: |
+          foreach($target in ($env:BUILD_TARGETS).Split(',')) {
+            cargo test $(if($target -ne 'default') {"--target=$target"} ) -- --nocapture --test-threads=1
+          }
 
 
-  #     - name: Query dependencies for integration testing
-  #       run: |
-  #         install.packages('remotes')
-  #         saveRDS(remotes::dev_package_deps(pkgdir = "tests/extendrtests", dependencies = TRUE), ".github/depends.Rds", version = 2)
-  #         writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-  #       shell: Rscript {0}
+      - name: Query dependencies for integration testing
+        run: |
+          install.packages('remotes')
+          saveRDS(remotes::dev_package_deps(pkgdir = "tests/extendrtests", dependencies = TRUE), ".github/depends.Rds", version = 2)
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+        shell: Rscript {0}
 
-  #     - name: Cache installed R packages
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: ${{ env.R_LIBS_USER }}
-  #         key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-  #         restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+      - name: Cache installed R packages
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
 
-  #     - name: Install R dependencies for integration testing
-  #       run: |
-  #         remotes::install_deps(pkgdir = "tests/extendrtests", dependencies = TRUE)
-  #         remotes::install_cran("rcmdcheck")
-  #       shell: Rscript {0}
+      - name: Install R dependencies for integration testing
+        run: |
+          remotes::install_deps(pkgdir = "tests/extendrtests", dependencies = TRUE)
+          remotes::install_cran("rcmdcheck")
+        shell: Rscript {0}
         
-  #     # Windows: modified PATH will launch 32-bit Rscript if the build targets only i686/i386, so no conflict will arise
-  #     # Rust pseudo multi-targeting: R CMD CHECK receives an extra argument '--no-multiarch' if BUILD_TARGETS is not 'default' and does not contain any commas
-  #     - name: Run R integration tests
-  #       id: r_integration_tests
-  #       env:
-  #         _R_CHECK_CRAN_INCOMING_REMOTE_: false
-  #       run: rcmdcheck::rcmdcheck(path = "tests/extendrtests", args = c("--no-manual", "--as-cran", ifelse(grepl("^default$|^.*,.*$", Sys.getenv("BUILD_TARGETS")), "", "--no-multiarch")), error_on = "warning", check_dir = "check")
-  #       shell: Rscript {0}
+      # Windows: modified PATH will launch 32-bit Rscript if the build targets only i686/i386, so no conflict will arise
+      # Rust pseudo multi-targeting: R CMD CHECK receives an extra argument '--no-multiarch' if BUILD_TARGETS is not 'default' and does not contain any commas
+      - name: Run R integration tests
+        id: r_integration_tests
+        env:
+          _R_CHECK_CRAN_INCOMING_REMOTE_: false
+        run: rcmdcheck::rcmdcheck(path = "tests/extendrtests", args = c("--no-manual", "--as-cran", ifelse(grepl("^default$|^.*,.*$", Sys.getenv("BUILD_TARGETS")), "", "--no-multiarch")), error_on = "warning", check_dir = "check")
+        shell: Rscript {0}
         
-  #     - name: Upload check results from R integration tests
-  #       if: failure()
-  #       uses: actions/upload-artifact@main
-  #       with:
-  #         name:  ${{ matrix.config.os }}-R-${{ matrix.config.r }}-rust-${{ matrix.config.rust-version }}
-  #         path: check
+      - name: Upload check results from R integration tests
+        if: failure()
+        uses: actions/upload-artifact@main
+        with:
+          name:  ${{ matrix.config.os }}-R-${{ matrix.config.r }}-rust-${{ matrix.config.rust-version }}
+          path: check
 
 
 # All tests under this job are run with R devel and freshly generated bindings.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,25 +22,26 @@ jobs:
       matrix:
         config:
           - {os: windows-latest, r: 'release', rust-version: 'stable-msvc', msystem: "MINGW64"}
-          # - {os: windows-latest, r: 'release', rust-version: 'stable-x86_64-pc-windows-msvc', msystem: "MINGW64"}
+          
+          - {os: windows-latest, r: 'release', rust-version: 'stable-x86_64-pc-windows-msvc', msystem: "MINGW64"}
           # - {os: windows-latest, r: 'release', rust-version: 'nightly-x86_64-pc-windows-msvc', msystem: "MINGW64"}
           # - {os: windows-latest, r: 'devel', rust-version: 'stable-x86_64-pc-windows-msvc', msystem: "MINGW64"}
           # - {os: windows-latest, r: 'oldrel', rust-version: 'stable-x86_64-pc-windows-msvc', msystem: "MINGW64"}
 
 
-          # - {os: windows-latest, r: 'release', rust-version: 'stable-i686-pc-windows-msvc', msystem: "MINGW32"}
+          - {os: windows-latest, r: 'release', rust-version: 'stable-i686-pc-windows-msvc', msystem: "MINGW32"}
           # - {os: windows-latest, r: 'release', rust-version: 'nightly-i686-pc-windows-msvc', msystem: "MINGW32"}
           # - {os: windows-latest, r: 'devel', rust-version: 'stable-i686-pc-windows-msvc', msystem: "MINGW32"}
           # - {os: windows-latest, r: 'oldrel', rust-version: 'stable-i686-pc-windows-msvc', msystem: "MINGW32"}
 
 
-          # - {os: macOS-latest,   r: 'release', rust-version: 'stable'}
+          - {os: macOS-latest,   r: 'release', rust-version: 'stable'}
           # - {os: macOS-latest,   r: 'release', rust-version: 'nightly'}
           # - {os: macOS-latest,   r: 'devel', rust-version: 'stable'}
           # - {os: macOS-latest,   r: 'oldrel', rust-version: 'stable'}
 
 
-          # - {os: ubuntu-20.04,   r: 'release', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: ubuntu-20.04,   r: 'release', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
           # - {os: ubuntu-20.04,   r: 'release', rust-version: 'nightly', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
           # # R-devel requires LD_LIBRARY_PATH
           # - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}   
@@ -120,40 +121,40 @@ jobs:
 
 
 
-      # - name: Query dependencies for integration testing
-      #   run: |
-      #     install.packages('remotes')
-      #     saveRDS(remotes::dev_package_deps(pkgdir = "tests/extendrtests", dependencies = TRUE), ".github/depends.Rds", version = 2)
-      #     writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-      #   shell: Rscript {0}
+      - name: Query dependencies for integration testing
+        run: |
+          install.packages('remotes')
+          saveRDS(remotes::dev_package_deps(pkgdir = "tests/extendrtests", dependencies = TRUE), ".github/depends.Rds", version = 2)
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+        shell: Rscript {0}
 
-      # - name: Cache installed R packages
-      #   # if: runner.os != 'Windows'
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: ${{ env.R_LIBS_USER }}
-      #     key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-      #     restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+      - name: Cache installed R packages
+        # if: runner.os != 'Windows'
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
 
-      # - name: Install R dependencies for integration testing
-      #   run: |
-      #     remotes::install_deps(pkgdir = "tests/extendrtests", dependencies = TRUE)
-      #     remotes::install_cran("rcmdcheck")
-      #   shell: Rscript {0}
+      - name: Install R dependencies for integration testing
+        run: |
+          remotes::install_deps(pkgdir = "tests/extendrtests", dependencies = TRUE)
+          remotes::install_cran("rcmdcheck")
+        shell: Rscript {0}
         
-      # - name: Run R integration tests
-      #   id: r_integration_tests
-      #   env:
-      #     _R_CHECK_CRAN_INCOMING_REMOTE_: false
-      #   run: rcmdcheck::rcmdcheck(path = "tests/extendrtests", args = c("--no-manual", "--as-cran", Sys.getenv("R_CHECK_NO_MULTIARCH")), error_on = "warning", check_dir = "check")
-      #   shell: Rscript {0}
+      - name: Run R integration tests
+        id: r_integration_tests
+        env:
+          _R_CHECK_CRAN_INCOMING_REMOTE_: false
+        run: rcmdcheck::rcmdcheck(path = "tests/extendrtests", args = c("--no-manual", "--as-cran", Sys.getenv("R_CHECK_NO_MULTIARCH")), error_on = "warning", check_dir = "check")
+        shell: Rscript {0}
         
-      # - name: Upload check results from R integration tests
-      #   if: failure()
-      #   uses: actions/upload-artifact@main
-      #   with:
-      #     name:  ${{ matrix.config.os }}-R-${{ matrix.config.r }}-rust-${{ matrix.config.rust-version }}
-      #     path: check
+      - name: Upload check results from R integration tests
+        if: failure()
+        uses: actions/upload-artifact@main
+        with:
+          name:  ${{ matrix.config.os }}-R-${{ matrix.config.r }}-rust-${{ matrix.config.rust-version }}
+          path: check
 
 
 # All tests under this job are run with R devel and freshly generated bindings.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,9 +24,9 @@ jobs:
           # Windows jobs with unspecific Rust architecture build for both i686 and x86_64 
           # R integration tests are also executed for both architectures
           - {os: windows-latest, r: 'release', rust-version: 'stable-msvc'}
-          - {os: windows-latest, r: 'release', rust-version: 'nightly-msvc'}
-          - {os: windows-latest, r: 'devel', rust-version: 'stable-msvc'}
-          - {os: windows-latest, r: 'oldrel', rust-version: 'stable-msvc'}
+          # - {os: windows-latest, r: 'release', rust-version: 'nightly-msvc'}
+          # - {os: windows-latest, r: 'devel', rust-version: 'stable-msvc'}
+          # - {os: windows-latest, r: 'oldrel', rust-version: 'stable-msvc'}
 
           # Windows jobs with x86_64 Rust toolchain build for x86_64 only
           # R integration tests are run with 64-bit R version and '--no-multiarch' flag
@@ -43,15 +43,15 @@ jobs:
           # - {os: windows-latest, r: 'oldrel', rust-version: 'stable-i686-pc-windows-msvc'}
 
           - {os: macOS-latest,   r: 'release', rust-version: 'stable'}
-          - {os: macOS-latest,   r: 'release', rust-version: 'nightly'}
-          - {os: macOS-latest,   r: 'devel', rust-version: 'stable'}
-          - {os: macOS-latest,   r: 'oldrel', rust-version: 'stable'}
+          # - {os: macOS-latest,   r: 'release', rust-version: 'nightly'}
+          # - {os: macOS-latest,   r: 'devel', rust-version: 'stable'}
+          # - {os: macOS-latest,   r: 'oldrel', rust-version: 'stable'}
 
           - {os: ubuntu-20.04,   r: 'release', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          - {os: ubuntu-20.04,   r: 'release', rust-version: 'nightly', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          # - {os: ubuntu-20.04,   r: 'release', rust-version: 'nightly', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
           # R-devel requires LD_LIBRARY_PATH
-          - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}   
-          - {os: ubuntu-20.04,   r: 'oldrel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}   
+          # - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}   
+          # - {os: ubuntu-20.04,   r: 'oldrel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}   
 
 
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -175,8 +175,10 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          - {os: macOS-latest,   r: 'devel', rust-version: 'stable'}
+          # - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          # - {os: macOS-latest,   r: 'devel', rust-version: 'stable'}
+          - {os: windows-latest, r: 'devel', rust-version: 'stable-x86_64-pc-windows-msvc'}
+          - {os: windows-latest, r: 'devel', rust-version: 'stable-i686-pc-windows-msvc'}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
@@ -201,21 +203,62 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
       
+
+      # This step is only needed for Windows
+      - name: Set up MSYS2 for Windows
+        if: startsWith(runner.os, 'Windows')
+        uses: msys2/setup-msys2@v2
+        with:
+          path-type: inherit
+          release: false
+          update: false
+
+      # All configurations for Windows go here
+      # `Rust` toolchain is used to determine target architecture
+      # Alternatively, `if:` conditions can be used
+      - name: Configure Windows
+        if: runner.os == 'Windows'
+        # 1. Add appropriate *-gnu target
+        # 2. Set CARGO_BUILD_FLAGS to the `rust` target
+        # 3. Configure path to `libclang`
+        # 4. Add path to `mingw32`/`mingw64` -- otherwise library is linked to `rtools`
+        # 5. Add path to R's `i386`/`x64`  -- to solve `x86` build/test issue
+        run: |
+          if ($env:RUST_TOOLCHAIN -like "*x86_64*") {
+            rustup target add x86_64-pc-windows-gnu ;
+            echo "CARGO_BUILD_FLAGS=--target=x86_64-pc-windows-gnu" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append ;
+            echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+            echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\x64"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+          }
+          if ($env:RUST_TOOLCHAIN -like "*i686*") {
+            rustup target add i686-pc-windows-gnu ;
+            echo "CARGO_BUILD_FLAGS=--target=i686-pc-windows-gnu" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append ;
+            echo "C:\msys64\mingw32\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+            echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\i386"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+
+          }
+        env: 
+          RUST_TOOLCHAIN: ${{ matrix.config.rust-version }}
+
       - name: Configure Linux
-        if: runner.os == 'linux'
+        if: startsWith(runner.os, 'linux')
         run: |
           Del alias:R
           echo "LD_LIBRARY_PATH=$(R -s -e 'cat(normalizePath(R.home()))')/lib" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
+      - name: Debug
+        run: |
+          echo $env:CARGO_BUILD_FLAGS
+
       - name: Build
         run: |
-          cargo build --manifest-path extendr-api/Cargo.toml --features tests-all
-          cargo build --manifest-path extendr-engine/Cargo.toml --features tests-all
+          cargo build $env:CARGO_BUILD_FLAGS --manifest-path extendr-api/Cargo.toml --features tests-all
+          cargo build $env:CARGO_BUILD_FLAGS --manifest-path extendr-engine/Cargo.toml --features tests-all
 
       - name: Run tests
         run: |
-          cargo test --manifest-path extendr-engine/Cargo.toml --features tests-all -- --nocapture --test-threads=1
-          cargo test --manifest-path extendr-api/Cargo.toml --features tests-all -- --nocapture --test-threads=1
-          cargo test --manifest-path extendr-api/Cargo.toml --features tests-minimal -- --nocapture --test-threads=1
-          cargo test --manifest-path extendr-macros/Cargo.toml -- --nocapture --test-threads=1
+          cargo test $env:CARGO_BUILD_FLAGS --manifest-path extendr-engine/Cargo.toml --features tests-all -- --nocapture --test-threads=1
+          cargo test $env:CARGO_BUILD_FLAGS --manifest-path extendr-api/Cargo.toml --features tests-all -- --nocapture --test-threads=1
+          cargo test $env:CARGO_BUILD_FLAGS --manifest-path extendr-api/Cargo.toml --features tests-minimal -- --nocapture --test-threads=1
+          cargo test $env:CARGO_BUILD_FLAGS --manifest-path extendr-macros/Cargo.toml -- --nocapture --test-threads=1
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,40 +116,40 @@ jobs:
           cargo test -vv $env:CARGO_BUILD_FLAGS -- --nocapture --test-threads=1
 
 
-      # - name: Query dependencies for integration testing
-      #   run: |
-      #     install.packages('remotes')
-      #     saveRDS(remotes::dev_package_deps(pkgdir = "tests/extendrtests", dependencies = TRUE), ".github/depends.Rds", version = 2)
-      #     writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-      #   shell: Rscript {0}
+      - name: Query dependencies for integration testing
+        run: |
+          install.packages('remotes')
+          saveRDS(remotes::dev_package_deps(pkgdir = "tests/extendrtests", dependencies = TRUE), ".github/depends.Rds", version = 2)
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+        shell: Rscript {0}
 
-      # - name: Cache installed R packages
-      #   if: runner.os != 'Windows'
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: ${{ env.R_LIBS_USER }}
-      #     key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-      #     restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+      - name: Cache installed R packages
+        # if: runner.os != 'Windows'
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
 
-      # - name: Install R dependencies for integration testing
-      #   run: |
-      #     remotes::install_deps(pkgdir = "tests/extendrtests", dependencies = TRUE)
-      #     remotes::install_cran("rcmdcheck")
-      #   shell: Rscript {0}
+      - name: Install R dependencies for integration testing
+        run: |
+          remotes::install_deps(pkgdir = "tests/extendrtests", dependencies = TRUE)
+          remotes::install_cran("rcmdcheck")
+        shell: Rscript {0}
         
-      # - name: Run R integration tests
-      #   id: r_integration_tests
-      #   env:
-      #     _R_CHECK_CRAN_INCOMING_REMOTE_: false
-      #   run: rcmdcheck::rcmdcheck(path = "tests/extendrtests", args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
-      #   shell: Rscript {0}
+      - name: Run R integration tests
+        id: r_integration_tests
+        env:
+          _R_CHECK_CRAN_INCOMING_REMOTE_: false
+        run: rcmdcheck::rcmdcheck(path = "tests/extendrtests", args = c("--no-manual", "--as-cran", "--no-multiarch"), error_on = "warning", check_dir = "check")
+        shell: Rscript {0}
         
-      # - name: Upload check results from R integration tests
-      #   if: failure()
-      #   uses: actions/upload-artifact@main
-      #   with:
-      #     name: ${{ runner.os }}-r${{ matrix.config.r }}-results
-      #     path: check
+      - name: Upload check results from R integration tests
+        if: failure()
+        uses: actions/upload-artifact@main
+        with:
+          name:  ${{ matrix.config.os }}-R-${{ matrix.config.r }}-rust-${{ matrix.config.rust-version }}
+          path: check
 
 
 # All tests under this job are run with R devel and freshly generated bindings.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,62 +12,203 @@ on:
 
 jobs:
   # All tests under this job are run with pre-computed libR-sys bindings.
-  tests_no_bindgen:
+  # tests_no_bindgen:
+  #   runs-on: ${{ matrix.config.os }}
+
+  #   name: ${{ matrix.config.os }} (R-${{ matrix.config.r }} rust-${{ matrix.config.rust-version }})
+            
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       config:
+  #         # Windows jobs with unspecific Rust architecture build for both i686 and x86_64 
+  #         # R integration tests are also executed for both architectures
+  #         - {os: windows-latest, r: 'release', rust-version: 'stable-msvc'}
+  #         # - {os: windows-latest, r: 'release', rust-version: 'nightly-msvc'}
+  #         # - {os: windows-latest, r: 'devel', rust-version: 'stable-msvc'}
+  #         # - {os: windows-latest, r: 'oldrel', rust-version: 'stable-msvc'}
+
+  #         # Windows jobs with x86_64 Rust toolchain build for x86_64 only
+  #         # R integration tests are run with 64-bit R version and '--no-multiarch' flag
+  #         # - {os: windows-latest, r: 'release', rust-version: 'stable-x86_64-pc-windows-msvc'}
+  #         # - {os: windows-latest, r: 'release', rust-version: 'nightly-x86_64-pc-windows-msvc'}
+  #         # - {os: windows-latest, r: 'devel', rust-version: 'stable-x86_64-pc-windows-msvc'}
+  #         # - {os: windows-latest, r: 'oldrel', rust-version: 'stable-x86_64-pc-windows-msvc'}
+
+  #         # Windows jobs with i686 Rust toolchain build for i686 only
+  #         # R integration tests are run with 32-bit R version and '--no-multiarch' flag
+  #         # - {os: windows-latest, r: 'release', rust-version: 'stable-i686-pc-windows-msvc'}
+  #         # - {os: windows-latest, r: 'release', rust-version: 'nightly-i686-pc-windows-msvc'}
+  #         # - {os: windows-latest, r: 'devel', rust-version: 'stable-i686-pc-windows-msvc'}
+  #         # - {os: windows-latest, r: 'oldrel', rust-version: 'stable-i686-pc-windows-msvc'}
+
+  #         - {os: macOS-latest,   r: 'release', rust-version: 'stable'}
+  #         # - {os: macOS-latest,   r: 'release', rust-version: 'nightly'}
+  #         # - {os: macOS-latest,   r: 'devel', rust-version: 'stable'}
+  #         # - {os: macOS-latest,   r: 'oldrel', rust-version: 'stable'}
+
+  #         - {os: ubuntu-20.04,   r: 'release', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+  #         # - {os: ubuntu-20.04,   r: 'release', rust-version: 'nightly', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+  #         # R-devel requires LD_LIBRARY_PATH
+  #         # - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}   
+  #         # - {os: ubuntu-20.04,   r: 'oldrel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}   
+
+
+
+  #   env:
+  #     R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+  #     RSPM: ${{ matrix.config.rspm }}
+
+  #     # This environment variable enables support for pseudo multi-target cargo builds.
+  #     # Current stable Rust does not support multi-targeting,
+  #     # see https://github.com/rust-lang/cargo/issues/8176
+  #     # The variable is treated as a comma-separated list of valid Rust targets.
+  #     # 'default' value emits no '--target' flag.
+  #     # E.g.: BUILD_TARGETS=i686-pc-windows-gnu,x86_64-pc-windows-gnu builds two times,
+  #     # each time providing '--target=*-pc-windows-gnu' flag to cargo.
+  #     BUILD_TARGETS: default
+    
+  #   # PowerShell core is available on all platforms and can be used to unify scripts
+  #   defaults:
+  #     run:
+  #       shell: pwsh
+
+  #   steps:
+  #     - uses: actions/checkout@v2
+      
+  #     - name: Set up Rust
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: ${{ matrix.config.rust-version }}
+  #         default: true
+  #         components: rustfmt, clippy
+      
+  #     - name: Set up R
+  #       uses: r-lib/actions/setup-r@v1
+  #       with:
+  #         r-version: ${{ matrix.config.r }}
+      
+  #     # This step is only needed for Windows
+  #     - name: Set up MSYS2 for Windows
+  #       if: startsWith(runner.os, 'Windows')
+  #       uses: msys2/setup-msys2@v2
+  #       with:
+  #         path-type: inherit
+  #         release: false
+  #         update: false
+
+  #     # All configurations for Windows go here
+  #     # If 'rust-version' has no architecture id, both if conditions are executed
+  #     # Otherwise, only one condition is met
+  #     # $targets variable is used to build targets list used later for cargo build/test
+  #     # The order of if blocks favors x86_64 over i686 paths, which is optimal for multi-targeting
+  #     - name: Configure Windows
+  #       if: startsWith(runner.os, 'Windows')
+  #       # 1. Add rust target
+  #       # 2. Add target name to the $targets variable
+  #       # 3. Add mingw32/mingw64 bin folders to PATH
+  #       # 4. Add R x64/i386 folders to PATH
+  #       run: |
+  #         $targets=@()
+  #         if ($env:RUST_TOOLCHAIN -notlike "*x86_64*") {
+  #           rustup target add i686-pc-windows-gnu ;
+  #           $targets+="i686-pc-windows-gnu"
+  #           echo "C:\msys64\mingw32\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+  #           echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\i386"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+  #         }
+  #         if ($env:RUST_TOOLCHAIN -notlike "*i686*") {
+  #           rustup target add x86_64-pc-windows-gnu ;
+  #           $targets+="x86_64-pc-windows-gnu"
+  #           echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+  #           echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\x64"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+  #         }
+  #         echo "BUILD_TARGETS=$($targets -join ',')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append ;
+  #       env: 
+  #         RUST_TOOLCHAIN: ${{ matrix.config.rust-version }}
+
+  #     # This is required for ubuntu r-devel
+  #     # 'Del alias:R' removes 'R' alias which prevents running R 
+  #     - name: Configure Linux
+  #       if: startsWith(runner.os, 'linux')
+  #       run: |
+  #         Del alias:R
+  #         echo "LD_LIBRARY_PATH=$(R -s -e 'cat(normalizePath(R.home()))')/lib" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+  #     - name: Set up Pandoc
+  #       uses: r-lib/actions/setup-pandoc@v1
+      
+  #     # For each target in the BUILD_TARGETS comma-separated list, run cargo build with appropriate target
+  #     # Required by Windows builds, does not affect other platforms
+  #     - name: Build
+  #       run: |
+  #         foreach($target in ($env:BUILD_TARGETS).Split(',')) {cargo build -v $(if($target -ne 'default') {"--target=$target"} ) }
+
+  #     # For each target in the BUILD_TARGETS comma-separated list, run cargo test with appropriate target
+  #     # Required by Windows builds, does not affect other platforms
+  #     - name: Run tests
+  #       run: |
+  #         foreach($target in ($env:BUILD_TARGETS).Split(',')) {cargo test -v $(if($target -ne 'default') {"--target=$target"} ) -- --nocapture --test-threads=1}
+
+
+  #     - name: Query dependencies for integration testing
+  #       run: |
+  #         install.packages('remotes')
+  #         saveRDS(remotes::dev_package_deps(pkgdir = "tests/extendrtests", dependencies = TRUE), ".github/depends.Rds", version = 2)
+  #         writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+  #       shell: Rscript {0}
+
+  #     - name: Cache installed R packages
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: ${{ env.R_LIBS_USER }}
+  #         key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+  #         restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+
+  #     - name: Install R dependencies for integration testing
+  #       run: |
+  #         remotes::install_deps(pkgdir = "tests/extendrtests", dependencies = TRUE)
+  #         remotes::install_cran("rcmdcheck")
+  #       shell: Rscript {0}
+        
+  #     # Windows: modified PATH will launch 32-bit Rscript if the build targets only i686/i386, so no conflict will arise
+  #     # Rust pseudo multi-targeting: R CMD CHECK receives an extra argument '--no-multiarch' if BUILD_TARGETS is not 'default' and does not contain any commas
+  #     - name: Run R integration tests
+  #       id: r_integration_tests
+  #       env:
+  #         _R_CHECK_CRAN_INCOMING_REMOTE_: false
+  #       run: rcmdcheck::rcmdcheck(path = "tests/extendrtests", args = c("--no-manual", "--as-cran", ifelse(grepl("^default$|^.*,.*$", Sys.getenv("BUILD_TARGETS")), "", "--no-multiarch")), error_on = "warning", check_dir = "check")
+  #       shell: Rscript {0}
+        
+  #     - name: Upload check results from R integration tests
+  #       if: failure()
+  #       uses: actions/upload-artifact@main
+  #       with:
+  #         name:  ${{ matrix.config.os }}-R-${{ matrix.config.r }}-rust-${{ matrix.config.rust-version }}
+  #         path: check
+
+
+# All tests under this job are run with R devel and freshly generated bindings.
+  tests_R_devel_bindgen:
     runs-on: ${{ matrix.config.os }}
 
-    name: ${{ matrix.config.os }} (R-${{ matrix.config.r }} rust-${{ matrix.config.rust-version }})
+    name: ${{ matrix.config.os }} w/ bindgen (R-${{ matrix.config.r }} rust-${{ matrix.config.rust-version }})
             
     strategy:
       fail-fast: false
       matrix:
         config:
-          # Windows jobs with unspecific Rust architecture build for both i686 and x86_64 
-          # R integration tests are also executed for both architectures
-          - {os: windows-latest, r: 'release', rust-version: 'stable-msvc'}
-          # - {os: windows-latest, r: 'release', rust-version: 'nightly-msvc'}
-          # - {os: windows-latest, r: 'devel', rust-version: 'stable-msvc'}
-          # - {os: windows-latest, r: 'oldrel', rust-version: 'stable-msvc'}
-
-          # Windows jobs with x86_64 Rust toolchain build for x86_64 only
-          # R integration tests are run with 64-bit R version and '--no-multiarch' flag
-          # - {os: windows-latest, r: 'release', rust-version: 'stable-x86_64-pc-windows-msvc'}
-          # - {os: windows-latest, r: 'release', rust-version: 'nightly-x86_64-pc-windows-msvc'}
+          - {os: ubuntu-20.04,   r: 'devel', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: macOS-latest,   r: 'devel', rust-version: 'stable'}
+          - {os: windows-latest, r: 'devel', rust-version: 'stable-msvc'}
           # - {os: windows-latest, r: 'devel', rust-version: 'stable-x86_64-pc-windows-msvc'}
-          # - {os: windows-latest, r: 'oldrel', rust-version: 'stable-x86_64-pc-windows-msvc'}
-
-          # Windows jobs with i686 Rust toolchain build for i686 only
-          # R integration tests are run with 32-bit R version and '--no-multiarch' flag
-          # - {os: windows-latest, r: 'release', rust-version: 'stable-i686-pc-windows-msvc'}
-          # - {os: windows-latest, r: 'release', rust-version: 'nightly-i686-pc-windows-msvc'}
           # - {os: windows-latest, r: 'devel', rust-version: 'stable-i686-pc-windows-msvc'}
-          # - {os: windows-latest, r: 'oldrel', rust-version: 'stable-i686-pc-windows-msvc'}
-
-          - {os: macOS-latest,   r: 'release', rust-version: 'stable'}
-          # - {os: macOS-latest,   r: 'release', rust-version: 'nightly'}
-          # - {os: macOS-latest,   r: 'devel', rust-version: 'stable'}
-          # - {os: macOS-latest,   r: 'oldrel', rust-version: 'stable'}
-
-          - {os: ubuntu-20.04,   r: 'release', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          # - {os: ubuntu-20.04,   r: 'release', rust-version: 'nightly', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          # R-devel requires LD_LIBRARY_PATH
-          # - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}   
-          # - {os: ubuntu-20.04,   r: 'oldrel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}   
-
 
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}
-
-      # This environment variable enables support for pseudo multi-target cargo builds.
-      # Current stable Rust does not support multi-targeting,
-      # see https://github.com/rust-lang/cargo/issues/8176
-      # The variable is treated as a comma-separated list of valid Rust targets.
-      # 'default' value emits no '--target' flag.
-      # E.g.: BUILD_TARGETS=i686-pc-windows-gnu,x86_64-pc-windows-gnu builds two times,
-      # each time providing '--target=*-pc-windows-gnu' flag to cargo.
       BUILD_TARGETS: default
-    
+
     # PowerShell core is available on all platforms and can be used to unify scripts
     defaults:
       run:
@@ -81,13 +222,13 @@ jobs:
         with:
           toolchain: ${{ matrix.config.rust-version }}
           default: true
-          components: rustfmt, clippy
-      
+
       - name: Set up R
         uses: r-lib/actions/setup-r@v1
         with:
           r-version: ${{ matrix.config.r }}
       
+
       # This step is only needed for Windows
       - name: Set up MSYS2 for Windows
         if: startsWith(runner.os, 'Windows')
@@ -97,11 +238,6 @@ jobs:
           release: false
           update: false
 
-      # All configurations for Windows go here
-      # If 'rust-version' has no architecture id, both if conditions are executed
-      # Otherwise, only one condition is met
-      # $targets variable is used to build targets list used later for cargo build/test
-      # The order of if blocks favors x86_64 over i686 paths, which is optimal for multi-targeting
       - name: Configure Windows
         if: startsWith(runner.os, 'Windows')
         # 1. Add rust target
@@ -126,140 +262,6 @@ jobs:
         env: 
           RUST_TOOLCHAIN: ${{ matrix.config.rust-version }}
 
-      # This is required for ubuntu r-devel
-      # 'Del alias:R' removes 'R' alias which prevents running R 
-      - name: Configure Linux
-        if: startsWith(runner.os, 'linux')
-        run: |
-          Del alias:R
-          echo "LD_LIBRARY_PATH=$(R -s -e 'cat(normalizePath(R.home()))')/lib" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
-      - name: Set up Pandoc
-        uses: r-lib/actions/setup-pandoc@v1
-      
-      # For each target in the BUILD_TARGETS comma-separated list, run cargo build with appropriate target
-      # Required by Windows builds, does not affect other platforms
-      - name: Build
-        run: |
-          foreach($target in ($env:BUILD_TARGETS).Split(',')) {cargo build -v $(if($target -ne 'default') {"--target=$target"} ) }
-
-      # For each target in the BUILD_TARGETS comma-separated list, run cargo test with appropriate target
-      # Required by Windows builds, does not affect other platforms
-      - name: Run tests
-        run: |
-          foreach($target in ($env:BUILD_TARGETS).Split(',')) {cargo test -v $(if($target -ne 'default') {"--target=$target"} ) -- --nocapture --test-threads=1}
-
-
-      - name: Query dependencies for integration testing
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(pkgdir = "tests/extendrtests", dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
-
-      - name: Cache installed R packages
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
-
-      - name: Install R dependencies for integration testing
-        run: |
-          remotes::install_deps(pkgdir = "tests/extendrtests", dependencies = TRUE)
-          remotes::install_cran("rcmdcheck")
-        shell: Rscript {0}
-        
-      # Windows: modified PATH will launch 32-bit Rscript if the build targets only i686/i386, so no conflict will arise
-      # Rust pseudo multi-targeting: R CMD CHECK receives an extra argument '--no-multiarch' if BUILD_TARGETS is not 'default' and does not contain any commas
-      - name: Run R integration tests
-        id: r_integration_tests
-        env:
-          _R_CHECK_CRAN_INCOMING_REMOTE_: false
-        run: rcmdcheck::rcmdcheck(path = "tests/extendrtests", args = c("--no-manual", "--as-cran", ifelse(grepl("^default$|^.*,.*$", Sys.getenv("BUILD_TARGETS")), "", "--no-multiarch")), error_on = "warning", check_dir = "check")
-        shell: Rscript {0}
-        
-      - name: Upload check results from R integration tests
-        if: failure()
-        uses: actions/upload-artifact@main
-        with:
-          name:  ${{ matrix.config.os }}-R-${{ matrix.config.r }}-rust-${{ matrix.config.rust-version }}
-          path: check
-
-
-# All tests under this job are run with R devel and freshly generated bindings.
-  tests_R_devel_bindgen:
-    runs-on: ${{ matrix.config.os }}
-
-    name: ${{ matrix.config.os }} w/ bindgen (R-${{ matrix.config.r }} rust-${{ matrix.config.rust-version }})
-            
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          - {os: macOS-latest,   r: 'devel', rust-version: 'stable'}
-          - {os: windows-latest, r: 'devel', rust-version: 'stable-x86_64-pc-windows-msvc'}
-          - {os: windows-latest, r: 'devel', rust-version: 'stable-i686-pc-windows-msvc'}
-
-    env:
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      RSPM: ${{ matrix.config.rspm }}
-    
-    # PowerShell core is available on all platforms and can be used to unify scripts
-    defaults:
-      run:
-        shell: pwsh
-
-    steps:
-      - uses: actions/checkout@v2
-      
-      - name: Set up Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.config.rust-version }}
-          default: true
-
-      - name: Set up R
-        uses: r-lib/actions/setup-r@v1
-        with:
-          r-version: ${{ matrix.config.r }}
-      
-
-      # This step is only needed for Windows
-      - name: Set up MSYS2 for Windows
-        if: startsWith(runner.os, 'Windows')
-        uses: msys2/setup-msys2@v2
-        with:
-          path-type: inherit
-          release: false
-          update: false
-
-      # All configurations for Windows go here
-      # Rust toolchain is used to determine target architecture
-      - name: Configure Windows
-        if: runner.os == 'Windows'
-        # 1. Add appropriate *-gnu target
-        # 2. Set CARGO_BUILD_FLAGS to the `rust` target
-        # 3. Add path to `mingw32`/`mingw64` -- otherwise library is linked to `rtools`
-        # 4. Add path to R's `i386`/`x64`  -- to solve `x86` build/test issue
-        run: |
-          if ($env:RUST_TOOLCHAIN -like "*x86_64*") {
-            rustup target add x86_64-pc-windows-gnu ;
-            echo "CARGO_BUILD_FLAGS=--target=x86_64-pc-windows-gnu" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append ;
-            echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
-            echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\x64"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
-          }
-          if ($env:RUST_TOOLCHAIN -like "*i686*") {
-            rustup target add i686-pc-windows-gnu ;
-            echo "CARGO_BUILD_FLAGS=--target=i686-pc-windows-gnu" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append ;
-            echo "C:\msys64\mingw32\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
-            echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\i386"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
-
-          }
-        env: 
-          RUST_TOOLCHAIN: ${{ matrix.config.rust-version }}
-
       - name: Configure Linux
         if: startsWith(runner.os, 'linux')
         run: |
@@ -268,13 +270,25 @@ jobs:
 
       - name: Build
         run: |
-          cargo build $env:CARGO_BUILD_FLAGS -v --manifest-path extendr-api/Cargo.toml --features tests-all
-          cargo build $env:CARGO_BUILD_FLAGS -v --manifest-path extendr-engine/Cargo.toml --features tests-all
+          foreach($target in ($env:BUILD_TARGETS).Split(',')) {
+            cargo build --manifest-path extendr-api/Cargo.toml --features tests-all $(if($target -ne 'default') {"--target=$target"} ) 
+          }
+          foreach($target in ($env:BUILD_TARGETS).Split(',')) {
+            cargo build --manifest-path extendr-engine/Cargo.toml --features tests-all $(if($target -ne 'default') {"--target=$target"} ) 
+          }
 
       - name: Run tests
         run: |
-          cargo test $env:CARGO_BUILD_FLAGS -v --manifest-path extendr-engine/Cargo.toml --features tests-all -- --nocapture --test-threads=1
-          cargo test $env:CARGO_BUILD_FLAGS -v --manifest-path extendr-api/Cargo.toml --features tests-all -- --nocapture --test-threads=1
-          cargo test $env:CARGO_BUILD_FLAGS -v --manifest-path extendr-api/Cargo.toml --features tests-minimal -- --nocapture --test-threads=1
-          cargo test $env:CARGO_BUILD_FLAGS -v --manifest-path extendr-macros/Cargo.toml -- --nocapture --test-threads=1
+          foreach($target in ($env:BUILD_TARGETS).Split(',')) {
+            cargo test --manifest-path extendr-engine/Cargo.toml --features tests-all $(if($target -ne 'default') {"--target=$target"} ) -- --nocapture --test-threads=1 
+          }
+          foreach($target in ($env:BUILD_TARGETS).Split(',')) {
+            cargo test --manifest-path extendr-api/Cargo.toml --features tests-all $(if($target -ne 'default') {"--target=$target"} ) -- --nocapture --test-threads=1 
+          }
+          foreach($target in ($env:BUILD_TARGETS).Split(',')) {
+            cargo test --manifest-path extendr-api/Cargo.toml --features tests-minimal $(if($target -ne 'default') {"--target=$target"} ) -- --nocapture --test-threads=1
+          }
+          foreach($target in ($env:BUILD_TARGETS).Split(',')) {
+            cargo test --manifest-path extendr-macros/Cargo.toml  $(if($target -ne 'default') {"--target=$target"} ) -- --nocapture --test-threads=1
+          }
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,12 +78,9 @@ jobs:
       - name: Build
         run: cargo build
 
-      # - name: Run tests (not Windows)
-      #   if: runner.os != 'Windows'
-      #   run: |
-      #     export R_HOME=`R -s -e 'cat(R.home())'`
-      #     export LD_LIBRARY_PATH=${R_HOME}/lib
-      #     cargo test -- --nocapture --test-threads=1
+      - name: Run tests
+        run: |
+          cargo test -- --nocapture --test-threads=1
 
 
       # - name: Build (Windows)


### PR DESCRIPTION
In line with `extendr/libR-sys` GitHub Actions update, I made an attempt to improve `extendr`'s CI.
The goal is to be able to control the setup using matrix configuration and share as many steps as possible between OSs.

The problem is Windows builds were testing only `x86_64` binaries, but R integration tests were executed for both `x86_64` and `i386`. Because Rust does not support multi-targeting  (yet,  https://github.com/rust-lang/cargo/issues/8176), I simulate multiple targets for `cargo`. It does not affect other builds, but Windows builds are controlled through `rust-version`:
- if `rust-version` does not include architecture id, `cargo build`/`cargo test` and R integration tests are executed for both architectures
- if `rust-version` includes architecture specifier (`x86_64`/`i686`), then `cargo build`/`cargo test` are executed for one target only, and R integration tests are launched from R process with correct bitness and an extra `--no-multiarch` flag.

Currently, architecture-specific Wndows builds are disabled and commented out, but can be re-enabled to e.g. test 64-bit only build. 