### PR TITLE
Fix module registration.

### DIFF
--- a/extendr-api/examples/R/data/src/entrypoint.c
+++ b/extendr-api/examples/R/data/src/entrypoint.c
@@ -1,11 +1,9 @@
+// We need to forward routine registration from C to Rust 
+// to avoid the linker removing the static library.
 
+void R_init_data_extendr(void *dll);
 
-// Take the address of the wrap__hello stub function to avoid
-// the linker removing the static library.
-//
-// This will be removed in future versions with the module macro.
-void R_init_libdata();
-
-void *__dummy = (void*)&R_init_libdata;
-
+void R_init_data(void *dll) {
+  R_init_data_extendr(dll);
+}
 

--- a/extendr-api/examples/R/hello/README.md
+++ b/extendr-api/examples/R/hello/README.md
@@ -8,6 +8,5 @@ Then in R:
 
     > library(hello)
     > hello()
-    hello
-    NULL
+    [1] "hello"
     > 

--- a/extendr-api/examples/R/hello/src/entrypoint.c
+++ b/extendr-api/examples/R/hello/src/entrypoint.c
@@ -1,11 +1,9 @@
+// We need to forward routine registration from C to Rust 
+// to avoid the linker removing the static library.
 
+void R_init_hello_extendr(void *dll);
 
-// Take the address of the wrap__hello stub function to avoid
-// the linker removing the static library.
-//
-// This will be removed in future versions with the module macro.
-void R_init_libhello();
-
-void *__dummy = (void*)&R_init_libhello;
-
+void R_init_hello(void *dll) {
+  R_init_hello_extendr(dll);
+}
 

--- a/tests/extendrtests/src/entrypoint.c
+++ b/tests/extendrtests/src/entrypoint.c
@@ -1,10 +1,8 @@
 // We need to forward routine registration from C to Rust 
 // to avoid the linker removing the static library.
 
-#include <Rinternals.h>
+void R_init_extendrtests_extendr(void *dll);
 
-void R_init_extendrtests_extendr(DllInfo *dll);
-
-void R_init_extendrtests(DllInfo *dll) {
+void R_init_extendrtests(void *dll) {
   R_init_extendrtests_extendr(dll);
 }

--- a/tests/extendrtests/src/entrypoint.c
+++ b/tests/extendrtests/src/entrypoint.c
@@ -1,29 +1,10 @@
-/*
-// Take the address of the wrap__hello stub function to avoid
-// the linker removing the static library.
-//
-// This will be removed in future versions with the module macro.
-void wrap__hello();
+// We need to forward routine registration from C to Rust 
+// to avoid the linker removing the static library.
 
-void *x = (void*)&wrap__hello;
-*/
-
-
-#define R_NO_REMAP
-#define STRICT_R_HEADERS
 #include <Rinternals.h>
 
-SEXP wrap__hello();
-SEXP wrap__add_ints();
-
-// Standard R package stuff
-static const R_CallMethodDef CallEntries[] = {
-  {"wrap__hello", (DL_FUNC) &wrap__hello, 0},
-  {"wrap__add_ints", (DL_FUNC) &wrap__add_ints, 2},
-  {NULL, NULL, 0}
-};
+void R_init_extendrtests_extendr(DllInfo *dll);
 
 void R_init_extendrtests(DllInfo *dll) {
-  R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
-  R_useDynamicSymbols(dll, FALSE);
+  R_init_extendrtests_extendr(dll);
 }

--- a/tests/extendrtests/src/rust/Cargo.toml
+++ b/tests/extendrtests/src/rust/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["staticlib"]
 extendr-api = "*"
 
 [patch.crates-io]
-extendr-api = { git = "https://github.com/extendr/extendr" }
-extendr-engine = { git = "https://github.com/extendr/extendr" }
-extendr-macros = { git = "https://github.com/extendr/extendr" }
+extendr-api = { git = "https://github.com/clauswilke/extendr", branch = "reg-forwarding" }
+extendr-engine = { git = "https://github.com/clauswilke/extendr", branch = "reg-forwarding" }
+extendr-macros = { git = "https://github.com/clauswilke/extendr", branch = "reg-forwarding" }
 #libR-sys = { git = "https://github.com/extendr/libR-sys" }

--- a/tests/extendrtests/src/rust/src/lib.rs
+++ b/tests/extendrtests/src/rust/src/lib.rs
@@ -11,10 +11,9 @@ fn add_ints(x:i32, y:i32) -> i32 {
 }
 
 
-/* Doesn't currently work yet.
 // Macro to generate exports
 extendr_module! {
     mod extendrtests;
     fn hello;
+    fn add_ints;
 }
-*/


### PR DESCRIPTION
Fix module registration by forwarding the registration call from C to Rust. Apparently this is needed on Windows i686. See discussion here: #91 

This closes #75.