### PR TITLE
Remove documentation field from Cargo.toml

### DIFF
--- a/extendr-api/Cargo.toml
+++ b/extendr-api/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["andy-thomason <andy@andythomason.com>"]
 edition = "2018"
 description = "Safe and user friendly bindings to the R programming language."
 license = "MIT"
-documentation = "https://extendr.github.io/extendr/extendr_api/index.html"
 repository = "https://github.com/extendr/extendr"
 
 [dependencies]

--- a/extendr-engine/Cargo.toml
+++ b/extendr-engine/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["andy-thomason <andy@andythomason.com>"]
 edition = "2018"
 description = "Safe and user friendly bindings to the R programming language."
 license = "MIT"
-documentation = "https://extendr.github.io/extendr/extendr_engine/index.html"
 repository = "https://github.com/extendr/extendr"
 
 [dependencies]

--- a/extendr-macros/Cargo.toml
+++ b/extendr-macros/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["andy-thomason <andy@andythomason.com>"]
 edition = "2018"
 description = "Generate bindings from R to Rust."
 license = "MIT"
-documentation = "https://extendr.github.io/extendr/extendr_macros/index.html"
 repository = "https://github.com/extendr/extendr"
 
 [lib]


### PR DESCRIPTION
While I tweaked `documentation` field (#83), I now think it should be linked to the published version of the docs, instead of the dev version because it will be used on crates.io. It seems we can just remove the field unless we'll have nicer documentation site than docs.rs.

> If no URL is specified in the manifest file, crates.io will automatically link your crate to the corresponding docs.rs page.
(https://doc.rust-lang.org/cargo/reference/manifest.html#the-documentation-field)