### PR TITLE
Removed MSYS2 installation from GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,15 +77,6 @@ jobs:
       - name: Set up Pandoc
         uses: r-lib/actions/setup-pandoc@v1
       
-      # This step is only needed for Windows
-      - name: Set up MSYS2 for Windows
-        if: startsWith(runner.os, 'Windows')
-        uses: msys2/setup-msys2@v2
-        with:
-          path-type: inherit
-          release: false
-          update: false
-
       # All configurations for Windows go here
       # If 'rust-version' has no architecture id, both if conditions are executed
       # Otherwise, only one condition is met
@@ -219,15 +210,6 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
       
-
-      # This step is only needed for Windows
-      - name: Set up MSYS2 for Windows
-        if: startsWith(runner.os, 'Windows')
-        uses: msys2/setup-msys2@v2
-        with:
-          path-type: inherit
-          release: false
-          update: false
 
       - name: Configure Windows
         if: startsWith(runner.os, 'Windows')


### PR DESCRIPTION
This (https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md) listing mentions that `MSYS2` is pre-installed on Windows, but is not added to the `PATH` variable. We have a dedicated step to install `MSYS2`, but does not utilize any of its configuration and setup environment ourselves. Therefore, the `MSYS2` installation step is unnecessary.

I have already removed a similar step from `extendr/libR-sys`:
https://github.com/extendr/libR-sys/issues/41
https://github.com/extendr/libR-sys/pull/42