### PR TITLE
Make calls to R thread safe.

### DIFF
--- a/extendr-api/0001-Add-single_threaded-and-wrap-R-api-writes.patch
+++ b/extendr-api/0001-Add-single_threaded-and-wrap-R-api-writes.patch
@@ -1,0 +1,710 @@
+From 2e8907f4eb47af5634f4973478159915a076cc2a Mon Sep 17 00:00:00 2001
+From: andy-thomason <andy@andythomason.com>
+Date: Tue, 29 Dec 2020 19:27:34 +0000
+Subject: [PATCH] Add "single_threaded" and wrap R api writes.
+
+---
+ extendr-api/src/lang.rs            |  23 +++--
+ extendr-api/src/lib.rs             |  25 +----
+ extendr-api/src/robj/into_robj.rs  | 141 ++++++++++++++++-------------
+ extendr-api/src/robj/mod.rs        |  34 +++----
+ extendr-api/src/robj/rinternals.rs |  36 ++++----
+ extendr-api/src/thread_safety.rs   |  98 ++++++++++++++++++++
+ extendr-api/src/wrapper.rs         |  13 +--
+ 7 files changed, 233 insertions(+), 137 deletions(-)
+ create mode 100644 extendr-api/src/thread_safety.rs
+
+diff --git a/extendr-api/src/lang.rs b/extendr-api/src/lang.rs
+index 1a430adb..ae551230 100644
+--- a/extendr-api/src/lang.rs
++++ b/extendr-api/src/lang.rs
+@@ -4,6 +4,7 @@
+ use libR_sys::*;
+ //use crate::robj::*;
+ use crate::robj::Robj;
++use crate::single_threaded;
+ 
+ /// Convert a list of tokens to an array of tuples.
+ #[doc(hidden)]
+@@ -42,15 +43,17 @@ macro_rules! args {
+ 
+ #[doc(hidden)]
+ pub unsafe fn append_with_name(tail: SEXP, obj: Robj, name: &str) -> SEXP {
+-    let mut name = Vec::from(name.as_bytes());
+-    name.push(0);
+-    let cons = Rf_cons(obj.get(), R_NilValue);
+-    SET_TAG(
+-        cons,
+-        Rf_install(name.as_ptr() as *const std::os::raw::c_char),
+-    );
+-    SETCDR(tail, cons);
+-    cons
++    single_threaded(||{
++        let mut name = Vec::from(name.as_bytes());
++        name.push(0);
++        let cons = Rf_cons(obj.get(), R_NilValue);
++        SET_TAG(
++            cons,
++            Rf_install(name.as_ptr() as *const std::os::raw::c_char),
++        );
++        SETCDR(tail, cons);
++        cons
++    })
+ }
+ 
+ #[doc(hidden)]
+@@ -64,7 +67,7 @@ pub unsafe fn append(tail: SEXP, obj: Robj) -> SEXP {
+ pub unsafe fn make_lang(sym: &str) -> Robj {
+     let mut name = Vec::from(sym.as_bytes());
+     name.push(0);
+-    let sexp = Rf_lang1(Rf_install(name.as_ptr() as *const std::os::raw::c_char));
++    let sexp = single_threaded(|| Rf_lang1(Rf_install(name.as_ptr() as *const std::os::raw::c_char)));
+     Robj::from(sexp)
+ }
+ 
+diff --git a/extendr-api/src/lib.rs b/extendr-api/src/lib.rs
+index 17027d4a..397df2bb 100644
+--- a/extendr-api/src/lib.rs
++++ b/extendr-api/src/lib.rs
+@@ -147,6 +147,7 @@ mod logical;
+ mod rmacros;
+ mod robj;
+ mod wrapper;
++mod thread_safety;
+ 
+ #[cfg(feature = "ndarray")]
+ mod robj_ndarray;
+@@ -157,6 +158,7 @@ pub use rmacros::*;
+ pub use robj::*;
+ pub use wrapper::*;
+ pub use logical::*;
++pub use thread_safety::{single_threaded, handle_panic};
+ 
+ #[cfg(feature = "ndarray")]
+ pub use robj_ndarray::*;
+@@ -215,23 +217,6 @@ pub unsafe fn register_call_methods(info: *mut libR_sys::DllInfo, methods: &[Cal
+     libR_sys::R_forceSymbols(info, 1);
+ }
+ 
+-/// This function is use by the wrapper logic to catch
+-/// panics on return.
+-#[doc(hidden)]
+-pub fn handle_panic<F>(err_str: &str, f: F) -> SEXP
+-where
+-    F : FnOnce() -> SEXP,
+-    F : std::panic::UnwindSafe
+-{
+-    match std::panic::catch_unwind(f) {
+-        Ok(res) => res,
+-        Err(_) => {
+-            unsafe { libR_sys::Rf_error(err_str.as_ptr() as * const std::os::raw::c_char); }
+-            unreachable!("handle_panic unreachable")
+-        }
+-    }
+-}
+-
+ /// Return true if this primitive is NA.
+ pub trait IsNA {
+     fn is_na(&self) -> bool;
+@@ -255,12 +240,6 @@ impl IsNA for Bool {
+     }
+ }
+ 
+-// pub fn add_function_to_namespace(namespace: &str, fn_name: &str, wrap_name: &str) {
+-//     let rcode = format!("{}::{} <- function(...) .Call(\"{}\", ...)", namespace, fn_name, wrap_name);
+-//     eprintln!("[{}]", rcode);
+-//     Robj::eval_string(rcode.as_str()).unwrap();
+-// }
+-
+ #[doc(hidden)]
+ pub fn print_r_output<T: Into<Vec<u8>>>(s: T) {
+     let cs = CString::new(s).expect("NulError");
+diff --git a/extendr-api/src/robj/into_robj.rs b/extendr-api/src/robj/into_robj.rs
+index efb104e3..414e7ed1 100644
+--- a/extendr-api/src/robj/into_robj.rs
++++ b/extendr-api/src/robj/into_robj.rs
+@@ -1,4 +1,14 @@
+ use super::*;
++use crate::single_threaded;
++
++fn str_to_character(s: &str) -> SEXP {
+q+    unsafe {
++        Rf_mkCharLen(
++            s.as_ptr() as *const raw::c_char,
++            s.len() as i32,
++        )
++    }
++}
+ 
+ /// Borrow an already protected SEXP
+ /// Note that the SEXP must outlive the generated object.
+@@ -19,12 +29,9 @@ impl From<()> for Robj {
+ /// Convert a wrapped string ref to an Robj char object.
+ impl<'a> From<Character<'a>> for Robj {
+     fn from(val: Character) -> Self {
+-        unsafe {
+-            new_owned(Rf_mkCharLen(
+-                val.0.as_ptr() as *const raw::c_char,
+-                val.0.len() as i32,
+-            ))
+-        }
++        single_threaded(|| unsafe {
++            new_owned(str_to_character(val.0))
++        })
+     }
+ }
+ 
+@@ -180,8 +187,7 @@ macro_rules! impl_str_tvv {
+             where
+                 Self: Sized,
+             {
+-                let s: &str = self.as_ref();
+-                unsafe { Rf_mkCharLen(s.as_ptr() as *const raw::c_char, s.len() as i32) }
++                str_to_character(self.as_ref())
+             }
+         }
+ 
+@@ -194,8 +200,7 @@ macro_rules! impl_str_tvv {
+             where
+                 Self: Sized,
+             {
+-                let s: &str = self.as_ref();
+-                unsafe { Rf_mkCharLen(s.as_ptr() as *const raw::c_char, s.len() as i32) }
++                str_to_character(self.as_ref())
+             }
+         }
+ 
+@@ -209,8 +214,7 @@ macro_rules! impl_str_tvv {
+                 Self: Sized,
+             {
+                 if let Some(s) = self {
+-                    let s: &str = s.as_ref();
+-                    unsafe { Rf_mkCharLen(s.as_ptr() as *const raw::c_char, s.len() as i32) }
++                    str_to_character(s.as_ref())
+                 } else {
+                     unsafe { R_NaString }
+                 }
+@@ -314,6 +318,58 @@ impl ToVectorValue for &u8 {
+     }
+ }
+ 
++// Not thread safe.
++unsafe fn fixed_size_collect<I>(iter: I, len: usize) -> Robj
++where
++    I: Iterator,
++    I: Sized,
++    I::Item: ToVectorValue,
++{
++    // Length of the vector is known in advance.
++    let sexptype = I::Item::sexptype();
++    if sexptype != 0 {
++        let sexp = Rf_allocVector(sexptype, len as R_xlen_t);
++        R_PreserveObject(sexp);
++        match sexptype {
++            REALSXP => {
++                let ptr = REAL(sexp);
++                for (i, v) in iter.enumerate() {
++                    *ptr.offset(i as isize) = v.to_real();
++                }
++            }
++            INTSXP => {
++                let ptr = INTEGER(sexp);
++                for (i, v) in iter.enumerate() {
++                    *ptr.offset(i as isize) = v.to_integer();
++                }
++            }
++            LGLSXP => {
++                let ptr = LOGICAL(sexp);
++                for (i, v) in iter.enumerate() {
++                    *ptr.offset(i as isize) = v.to_logical();
++                }
++            }
++            RAWSXP => {
++                let ptr = RAW(sexp);
++                for (i, v) in iter.enumerate() {
++                    *ptr.offset(i as isize) = v.to_raw();
++                }
++            }
++            STRSXP => {
++                for (i, v) in iter.enumerate() {
++                    SET_STRING_ELT(sexp, i as isize, v.to_sexp());
++                }
++            }
++            _ => {
++                panic!("unexpected SEXPTYPE in collect_robj");
++            }
++        }
++        return Robj::Owned(sexp);
++    } else {
++        return Robj::from(());
++    }
++}
++
+ /// Extensions to iterators for R objects including [RobjItertools::collect_robj()].
+ pub trait RobjItertools: Iterator {
+     /// Convert a wide range of iterators to Robj.
+@@ -344,60 +400,17 @@ pub trait RobjItertools: Iterator {
+         Self: Sized,
+         Self::Item: ToVectorValue,
+     {
+-        unsafe {
+-            if let (len, Some(max)) = self.size_hint().clone() {
+-                if len == max {
+-                    // Length of the vector is known in advance.
+-                    let sexptype = Self::Item::sexptype();
+-                    if sexptype != 0 {
+-                        let sexp = Rf_allocVector(sexptype, len as R_xlen_t);
+-                        R_PreserveObject(sexp);
+-                        match sexptype {
+-                            REALSXP => {
+-                                let ptr = REAL(sexp);
+-                                for (i, v) in self.enumerate() {
+-                                    *ptr.offset(i as isize) = v.to_real();
+-                                }
+-                            }
+-                            INTSXP => {
+-                                let ptr = INTEGER(sexp);
+-                                for (i, v) in self.enumerate() {
+-                                    *ptr.offset(i as isize) = v.to_integer();
+-                                }
+-                            }
+-                            LGLSXP => {
+-                                let ptr = LOGICAL(sexp);
+-                                for (i, v) in self.enumerate() {
+-                                    *ptr.offset(i as isize) = v.to_logical();
+-                                }
+-                            }
+-                            RAWSXP => {
+-                                let ptr = RAW(sexp);
+-                                for (i, v) in self.enumerate() {
+-                                    *ptr.offset(i as isize) = v.to_raw();
+-                                }
+-                            }
+-                            STRSXP => {
+-                                for (i, v) in self.enumerate() {
+-                                    SET_STRING_ELT(sexp, i as isize, v.to_sexp());
+-                                }
+-                            }
+-                            _ => {
+-                                panic!("unexpected SEXPTYPE in collect_robj");
+-                            }
+-                        }
+-                        return Robj::Owned(sexp);
+-                    } else {
+-                        return Robj::from(());
+-                    }
+-                }
++        if let (len, Some(max)) = self.size_hint().clone() {
++            if len == max {
++                return single_threaded(|| unsafe {
++                    fixed_size_collect(self, len)
++                });
+             }
+-
+-            // If the size is indeterminate, create a vector and call recursively.
+-            let vec: Vec<_> = self.collect();
+-            assert!(vec.iter().size_hint() == (vec.len(), Some(vec.len())));
+-            vec.into_iter().collect_robj()
+         }
++        // If the size is indeterminate, create a vector and call recursively.
++        let vec: Vec<_> = self.collect();
++        assert!(vec.iter().size_hint() == (vec.len(), Some(vec.len())));
++        vec.into_iter().collect_robj()
+     }
+ }
+ 
+diff --git a/extendr-api/src/robj/mod.rs b/extendr-api/src/robj/mod.rs
+index d69ea536..d0070c52 100644
+--- a/extendr-api/src/robj/mod.rs
++++ b/extendr-api/src/robj/mod.rs
+@@ -14,7 +14,7 @@ use std::os::raw;
+ 
+ use crate::logical::*;
+ use crate::wrapper::*;
+-use crate::{AnyError, IsNA};
++use crate::{single_threaded, AnyError, IsNA};
+ 
+ use std::collections::HashMap;
+ use std::iter::IntoIterator;
+@@ -596,7 +596,7 @@ impl Robj {
+     ///    assert_eq!(add.eval().unwrap(), r!(3));
+     /// ```
+     pub fn eval(&self) -> Result<Robj, AnyError> {
+-        unsafe {
++        single_threaded(|| unsafe {
+             let mut error: raw::c_int = 0;
+             let res = R_tryEval(self.get(), R_GlobalEnv, &mut error as *mut raw::c_int);
+             if error != 0 {
+@@ -604,7 +604,7 @@ impl Robj {
+             } else {
+                 Ok(Robj::from(res))
+             }
+-        }
++        })
+     }
+ 
+     /// Evaluate the expression and return NULL or an R object.
+@@ -631,7 +631,7 @@ impl Robj {
+     ///    assert!(expr.is_expression());
+     /// ```
+     pub fn parse(code: &str) -> Result<Robj, AnyError> {
+-        unsafe {
++        single_threaded(|| unsafe {
+             use libR_sys::*;
+             let mut status = 0_u32;
+             let status_ptr = &mut status as *mut u32;
+@@ -641,7 +641,7 @@ impl Robj {
+                 1 => Ok(parsed),
+                 _ => Err(AnyError::from("parse_error")),
+             }
+-        }
++        })
+     }
+ 
+     /// Parse a string into an R executable object and run it.
+@@ -652,14 +652,16 @@ impl Robj {
+     ///    assert_eq!(res, r!(3.));
+     /// ```
+     pub fn eval_string(code: &str) -> Result<Robj, AnyError> {
+-        let expr = Robj::parse(code)?;
+-        let mut res = Robj::from(());
+-        if let Some(iter) = expr.list_iter() {
+-            for lang in iter {
+-                res = lang.eval()?;
++        single_threaded(|| {
++            let expr = Robj::parse(code)?;
++            let mut res = Robj::from(());
++            if let Some(iter) = expr.list_iter() {
++                for lang in iter {
++                    res = lang.eval()?;
++                }
+             }
+-        }
+-        Ok(res)
++            Ok(res)
++        })
+     }
+ 
+     /// Unprotect an object - assumes a transfer of ownership.
+@@ -668,7 +670,7 @@ impl Robj {
+     pub unsafe fn unprotected(self) -> Robj {
+         match self {
+             Robj::Owned(sexp) => {
+-                R_ReleaseObject(sexp);
++                single_threaded(|| R_ReleaseObject(sexp));
+                 Robj::Borrowed(sexp)
+             }
+             _ => self,
+@@ -806,7 +808,7 @@ impl Robj {
+     {
+         let name = Robj::from(name);
+         let value = Robj::from(value);
+-        unsafe { new_borrowed(Rf_setAttrib(self.get(), name.get(), value.get())) }
++        single_threaded(||unsafe { new_borrowed(Rf_setAttrib(self.get(), name.get(), value.get())) })
+     }
+ 
+     /// Get the names attribute as a string iterator if one exists.
+@@ -935,7 +937,7 @@ impl Robj {
+ 
+ #[doc(hidden)]
+ pub unsafe fn new_owned(sexp: SEXP) -> Robj {
+-    R_PreserveObject(sexp);
++    single_threaded(|| R_PreserveObject(sexp));
+     Robj::Owned(sexp)
+ }
+ 
+@@ -1118,7 +1120,7 @@ impl Drop for Robj {
+     fn drop(&mut self) {
+         unsafe {
+             match self {
+-                Robj::Owned(sexp) => R_ReleaseObject(*sexp),
++                Robj::Owned(sexp) => single_threaded(|| R_ReleaseObject(*sexp)),
+                 Robj::Borrowed(_) => (),
+                 Robj::Sys(_) => (),
+             }
+diff --git a/extendr-api/src/robj/rinternals.rs b/extendr-api/src/robj/rinternals.rs
+index dcf1d7e8..7d0ea7cf 100644
+--- a/extendr-api/src/robj/rinternals.rs
++++ b/extendr-api/src/robj/rinternals.rs
+@@ -68,27 +68,27 @@ impl Robj {
+ 
+     /// Convert to vectors of many kinds.
+     pub fn coerce_vector(&self, sexptype: u32) -> Robj {
+-        unsafe { new_owned(Rf_coerceVector(self.get(), sexptype as SEXPTYPE)) }
++        single_threaded(|| unsafe { new_owned(Rf_coerceVector(self.get(), sexptype as SEXPTYPE)) })
+     }
+ 
+     /// Convert a pairlist (LISTSXP) to a vector list (VECSXP).
+     pub fn pair_to_vector_list(&self) -> Robj {
+-        unsafe { new_owned(Rf_PairToVectorList(self.get())) }
++        single_threaded(|| unsafe { new_owned(Rf_PairToVectorList(self.get())) })
+     }
+ 
+     /// Convert a vector list (VECSXP) to a pair list (LISTSXP)
+     pub fn vector_to_pair_list(&self) -> Robj {
+-        unsafe { new_owned(Rf_VectorToPairList(self.get())) }
++        single_threaded(|| unsafe { new_owned(Rf_VectorToPairList(self.get())) })
+     }
+ 
+     /// Convert a factor to a string vector.
+     pub fn as_character_factor(&self) -> Robj {
+-        unsafe { new_owned(Rf_asCharacterFactor(self.get())) }
++        single_threaded(|| unsafe { new_owned(Rf_asCharacterFactor(self.get())) })
+     }
+ 
+     /// Allocate a matrix object.
+     pub fn alloc_matrix(sexptype: SEXPTYPE, rows: i32, cols: i32) -> Robj {
+-        unsafe { new_owned(Rf_allocMatrix(sexptype, rows, cols)) }
++        single_threaded(|| unsafe { new_owned(Rf_allocMatrix(sexptype, rows, cols)) })
+     }
+ 
+     /* TODO:
+@@ -128,7 +128,7 @@ impl Robj {
+     /// Compatible way to duplicate an object. Use obj.clone() instead
+     /// for Rust compatibility.
+     pub fn duplicate(&self) -> Self {
+-        unsafe { new_owned(Rf_duplicate(self.get())) }
++        single_threaded(|| unsafe { new_owned(Rf_duplicate(self.get())) })
+     }
+ 
+     /*
+@@ -168,7 +168,7 @@ impl Robj {
+         if !self.is_environment() {
+             return Err("find_fun needs an environment.".into());
+         }
+-        Ok(unsafe { new_borrowed(Rf_findFun(symbol.get(), self.get())) })
++        Ok(single_threaded(|| unsafe { new_borrowed(Rf_findFun(symbol.get(), self.get())) }))
+     }
+ 
+     /*
+@@ -257,11 +257,11 @@ impl Robj {
+     /// Internal function used to implement `#[extendr]` impl
+     #[doc(hidden)]
+     pub unsafe fn make_external_ptr<T>(p: *mut T, tag: Robj, prot: Robj) -> Self {
+-        new_owned(R_MakeExternalPtr(
++        new_owned(single_threaded(|| R_MakeExternalPtr(
+             p as *mut ::std::os::raw::c_void,
+             tag.get(),
+             prot.get(),
+-        ))
++        )))
+     }
+ 
+     #[doc(hidden)]
+@@ -294,12 +294,12 @@ impl Robj {
+ 
+     #[doc(hidden)]
+     pub unsafe fn registerCFinalizer(&self, func: R_CFinalizer_t) {
+-        self.register_c_finalizer(func)
++        single_threaded(|| self.register_c_finalizer(func))
+     }
+ 
+     #[doc(hidden)]
+     pub unsafe fn register_c_finalizer(&self, func: R_CFinalizer_t) {
+-        R_RegisterCFinalizer(self.get(), func);
++        single_threaded(|| R_RegisterCFinalizer(self.get(), func));
+     }
+ 
+     // SEXP R_ExternalPtrTag(SEXP s);
+@@ -350,7 +350,7 @@ impl Robj {
+     pub fn xlengthgets(&self, new_len: usize) -> Result<Robj, AnyError> {
+         unsafe {
+             if self.is_vector() {
+-                Ok(new_owned(Rf_xlengthgets(self.get(), new_len as R_xlen_t)))
++                Ok(single_threaded(|| new_owned(Rf_xlengthgets(self.get(), new_len as R_xlen_t))))
+             } else {
+                 Err(AnyError::from("xlengthgets: Not a vector type"))
+             }
+@@ -359,18 +359,18 @@ impl Robj {
+ 
+     /// Allocated an owned object of a certain type.
+     pub fn alloc_vector(sexptype: u32, len: usize) -> Robj {
+-        unsafe { new_owned(Rf_allocVector(sexptype, len as R_xlen_t)) }
++        single_threaded(|| unsafe { new_owned(Rf_allocVector(sexptype, len as R_xlen_t)) })
+     }
+ 
+     /// Return true if two arrays have identical dims.
+     pub fn conformable(a: &Robj, b: &Robj) -> bool {
+-        unsafe { Rf_conformable(a.get(), b.get()) != 0 }
++        single_threaded(|| unsafe { Rf_conformable(a.get(), b.get()) != 0 })
+     }
+ 
+     /// Borrow an element from a list.
+-    pub fn elt(&self, index: usize) -> Robj {
+-        unsafe { Robj::from(Rf_elt(self.get(), index as raw::c_int)) }
+-    }
++    // pub fn elt(&self, index: usize) -> Robj {
++    //     single_threaded(|| unsafe { Robj::from(Rf_elt(self.get(), index as raw::c_int)) })
++    // }
+ 
+     //Rboolean Rf_inherits(SEXP, const char *);
+ 
+@@ -490,5 +490,5 @@ impl Robj {
+ 
+ pub fn find_namespace(name: &str) -> Robj {
+     let name = r!(Symbol(name));
+-    unsafe { new_borrowed(R_FindNamespace(name.get())) }
++    single_threaded(|| unsafe { new_borrowed(R_FindNamespace(name.get())) })
+ }
+diff --git a/extendr-api/src/thread_safety.rs b/extendr-api/src/thread_safety.rs
+new file mode 100644
+index 00000000..64780f2f
+--- /dev/null
++++ b/extendr-api/src/thread_safety.rs
+@@ -0,0 +1,98 @@
++//! Provide limited protection for multithreaded access to the R API.
++
++use std::cell::RefCell;
++use std::sync::atomic::{AtomicUsize, Ordering};
++
++static OWNER_THREAD: AtomicUsize = AtomicUsize::new(0);
++static NEXT_THREAD_ID: AtomicUsize = AtomicUsize::new(1);
++
++thread_local! {
++    static THREAD_ID: RefCell<usize> = RefCell::new(0);
++}
++
++// Get an integer 1.. for each thread that calls this.
++fn this_thread_id() -> usize {
++    THREAD_ID.with(|f| {
++        if *f.borrow() == 0 {
++            // Initialise with next value.
++            *f.borrow_mut() = NEXT_THREAD_ID.fetch_add(1, Ordering::SeqCst);
++        }
++        *f.borrow()
++    })
++}
++
++/// Run a function single threaded.
++/// Note: This will fail badly if the called function panics or calls RF_error.
++///
++/// ```
++/// use extendr_api::*;
++/// use std::sync::atomic::{AtomicUsize, Ordering};
++/// static GLOBAL_THREAD_COUNT: AtomicUsize = AtomicUsize::new(0);
++///
++/// let threads : Vec<_> = (0..100).map(|_| {
++///    std::thread::spawn(move|| {
++///       single_threaded(|| {
++///         // check that we are single threaded.
++///         let old_thread_count = GLOBAL_THREAD_COUNT.fetch_add(1, Ordering::AcqRel);
++///         assert_eq!(old_thread_count, 0);
++///         std::thread::sleep(std::time::Duration::from_millis(1));
++///         GLOBAL_THREAD_COUNT.fetch_sub(1, Ordering::AcqRel);
++///         // recursive calls are ok.
++///         assert_eq!(single_threaded(|| {
++///           1
++///         }), 1);    
++///       })
++///    })
++/// }).collect();
++/// ```
++pub fn single_threaded<F, R>(f: F) -> R
++where
++    F: FnOnce() -> R,
++{
++    let id = this_thread_id();
++    let old_id = OWNER_THREAD.load(Ordering::Acquire);
++
++    if old_id == id {
++        // println!("{:?} id={} RECURSIVE", std::thread::current().name(), id);
++        // recursive call, don't re-lock.
++        f()
++    } else {
++        // println!("{:?} id={}", std::thread::current().name(), id);
++
++        // wait for OWNER_THREAD to become 0 and put us as the owner.
++        while OWNER_THREAD
++            .compare_exchange(0, id, Ordering::Acquire, Ordering::Relaxed)
++            .is_err()
++        {
++            std::thread::sleep(std::time::Duration::from_millis(1));
++        }
++
++        // println!("{:?} id={} lock", std::thread::current().name(), id);
++
++        let res = f();
++
++        // println!("{:?} id={} unlock", std::thread::current().name(), id);
++
++        // release the lock.
++        OWNER_THREAD.store(0, Ordering::Release);
++        res
++    }
++}
++
++/// This function is used by the wrapper logic to catch
++/// panics on return.
++pub fn handle_panic<F, R>(err_str: &str, f: F) -> R
++where
++    F: FnOnce() -> R,
++    F: std::panic::UnwindSafe,
++{
++    match std::panic::catch_unwind(f) {
++        Ok(res) => res,
++        Err(_) => {
++            unsafe {
++                libR_sys::Rf_error(err_str.as_ptr() as *const std::os::raw::c_char);
++            }
++            unreachable!("handle_panic unreachable")
++        }
++    }
++}
+diff --git a/extendr-api/src/wrapper.rs b/extendr-api/src/wrapper.rs
+index 9c378f03..4d339c76 100644
+--- a/extendr-api/src/wrapper.rs
++++ b/extendr-api/src/wrapper.rs
+@@ -6,6 +6,7 @@ use crate::robj::*;
+ use libR_sys::*;
+ #[doc(hidden)]
+ use std::ffi::CString;
++use crate::single_threaded;
+ 
+ /// Wrapper for creating symbols.
+ ///
+@@ -82,36 +83,36 @@ impl<'a> PartialEq<List<'a>> for Robj {
+ impl<'a> From<List<'a>> for Robj {
+     /// Make a list object from an array of Robjs.
+     fn from(val: List<'a>) -> Self {
+-        unsafe {
++        single_threaded(|| unsafe {
+             let sexp = Rf_allocVector(VECSXP, val.0.len() as R_xlen_t);
+             R_PreserveObject(sexp);
+             for i in 0..val.0.len() {
+                 SET_VECTOR_ELT(sexp, i as R_xlen_t, val.0[i].get());
+             }
+             Robj::Owned(sexp)
+-        }
++        })
+     }
+ }
+ 
+ impl<'a> From<Symbol<'a>> for Robj {
+     /// Convert a string to a symbol.
+     fn from(name: Symbol) -> Self {
+-        unsafe {
++        single_threaded(|| unsafe {
+             if let Ok(name) = CString::new(name.0) {
+                 new_owned(Rf_install(name.as_ptr()))
+             } else {
+                 Robj::from(())
+             }
+-        }
++        })
+     }
+ }
+ 
+ impl<'a> From<Lang<'a>> for Robj {
+     /// Convert a wrapped string ref to an Robj language object.
+     fn from(val: Lang<'a>) -> Self {
+-        unsafe {
++        single_threaded(|| unsafe {
+             let name = Robj::from(Symbol(val.0));
+             new_owned(Rf_lang1(name.get()))
+-        }
++        })
+     }
+ }
+-- 
+2.25.1
+

--- a/extendr-api/src/thread_safety.rs
+++ b/extendr-api/src/thread_safety.rs
@@ -1,0 +1,98 @@
+//! Provide limited protection for multithreaded access to the R API.
+
+use std::cell::RefCell;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static OWNER_THREAD: AtomicUsize = AtomicUsize::new(0);
+static NEXT_THREAD_ID: AtomicUsize = AtomicUsize::new(1);
+
+thread_local! {
+    static THREAD_ID: RefCell<usize> = RefCell::new(0);
+}
+
+// Get an integer 1.. for each thread that calls this.
+fn this_thread_id() -> usize {
+    THREAD_ID.with(|f| {
+        if *f.borrow() == 0 {
+            // Initialise with next value.
+            *f.borrow_mut() = NEXT_THREAD_ID.fetch_add(1, Ordering::SeqCst);
+        }
+        *f.borrow()
+    })
+}
+
+/// Run a function single threaded.
+/// Note: This will fail badly if the called function panics or calls RF_error.
+///
+/// ```
+/// use extendr_api::*;
+/// use std::sync::atomic::{AtomicUsize, Ordering};
+/// static GLOBAL_THREAD_COUNT: AtomicUsize = AtomicUsize::new(0);
+///
+/// let threads : Vec<_> = (0..100).map(|_| {
+///    std::thread::spawn(move|| {
+///       single_threaded(|| {
+///         // check that we are single threaded.
+///         let old_thread_count = GLOBAL_THREAD_COUNT.fetch_add(1, Ordering::AcqRel);
+///         assert_eq!(old_thread_count, 0);
+///         std::thread::sleep(std::time::Duration::from_millis(1));
+///         GLOBAL_THREAD_COUNT.fetch_sub(1, Ordering::AcqRel);
+///         // recursive calls are ok.
+///         assert_eq!(single_threaded(|| {
+///           1
+///         }), 1);    
+///       })
+///    })
+/// }).collect();
+/// ```
+pub fn single_threaded<F, R>(f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    let id = this_thread_id();
+    let old_id = OWNER_THREAD.load(Ordering::Acquire);
+
+    if old_id == id {
+        // println!("{:?} id={} RECURSIVE", std::thread::current().name(), id);
+        // recursive call, don't re-lock.
+        f()
+    } else {
+        // println!("{:?} id={}", std::thread::current().name(), id);
+
+        // wait for OWNER_THREAD to become 0 and put us as the owner.
+        while OWNER_THREAD
+            .compare_exchange(0, id, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+
+        // println!("{:?} id={} lock", std::thread::current().name(), id);
+
+        let res = f();
+
+        // println!("{:?} id={} unlock", std::thread::current().name(), id);
+
+        // release the lock.
+        OWNER_THREAD.store(0, Ordering::Release);
+        res
+    }
+}
+
+/// This function is used by the wrapper logic to catch
+/// panics on return.
+pub fn handle_panic<F, R>(err_str: &str, f: F) -> R
+where
+    F: FnOnce() -> R,
+    F: std::panic::UnwindSafe,
+{
+    match std::panic::catch_unwind(f) {
+        Ok(res) => res,
+        Err(_) => {
+            unsafe {
+                libR_sys::Rf_error(err_str.as_ptr() as *const std::os::raw::c_char);
+            }
+            unreachable!("handle_panic unreachable")
+        }
+    }
+}


### PR DESCRIPTION
Until now, running in multi-threaded environments has been not possible for **extendr**.

With this PR, we introduce a function `single_threaded` which wraps calls to R which
would allocate or write data.

We assume that functions in R that only read are thread safe, but this may not be true and
if in doubt consult the R source-code.

I can't guarantee that my amateur attempts at making a recursive mutex using thread local variables
and atomics are perfect, but they do seem to pass the tests.

I am now getting test runs to pass without the `--test-threads=1`, but a few more checks and runs would
be necessary to make this routine without random failures.