### PR TITLE
Add a special "NA" string that tests as a NA.

### DIFF
--- a/extendr-api/src/functions.rs
+++ b/extendr-api/src/functions.rs
@@ -364,6 +364,20 @@ pub fn blank_scalar_string() -> Robj {
     unsafe { new_sys(R_BlankScalarString) }
 }
 
+/// Special "NA" string that represents null strings.
+/// ```
+/// use extendr_api::*;
+/// test! {
+///     assert!(na_str().as_ptr() != "NA".as_ptr());
+///     assert_eq!(na_str(), "NA");
+///     assert_eq!("NA".is_na(), false);
+///     assert_eq!(na_str().is_na(), true);
+/// }
+/// ```
+pub fn na_str() -> &'static str {
+    unsafe { std::str::from_utf8_unchecked(&[b'N', b'A']) }
+}
+
 /// Extendr test harness.
 ///
 /// See also [test!]

--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -288,6 +288,13 @@ impl IsNA for Bool {
     }
 }
 
+impl IsNA for &str {
+    /// Check for NA in a string by address.
+    fn is_na(&self) -> bool {
+        self.as_ptr() == na_str().as_ptr()
+    }
+}
+
 #[doc(hidden)]
 pub fn print_r_output<T: Into<Vec<u8>>>(s: T) {
     let cs = CString::new(s).expect("NulError");
@@ -498,5 +505,13 @@ mod tests {
         call!("close", &txt_con).unwrap();
         let result = R!(test_con).unwrap();
         assert_eq!(result, r!("Hello world"));
+    }
+
+    #[test]
+    fn test_na_str() {
+        assert!(na_str().as_ptr() != "NA".as_ptr());
+        assert_eq!(na_str(), "NA");
+        assert_eq!("NA".is_na(), false);
+        assert_eq!(na_str().is_na(), true);
     }
 }

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -2,7 +2,13 @@ use super::*;
 use crate::single_threaded;
 
 fn str_to_character(s: &str) -> SEXP {
-    unsafe { Rf_mkCharLen(s.as_ptr() as *const raw::c_char, s.len() as i32) }
+    unsafe {
+        if s.is_na() {
+            R_NaString
+        } else {
+            Rf_mkCharLen(s.as_ptr() as *const raw::c_char, s.len() as i32)
+        }
+    }
 }
 
 /// Convert a null to an Robj.


### PR DESCRIPTION
To make constructing string vectors with nulls more intuitive, I've added
a special null string with value "NA" but guaranteed to have a different address from
the regular "NA" string.

This means we can keep `StrIter` returning strings and still test for null strings.

The converse works, to, with `na_str()` mixable with regular string references.

```
    let character_with_nulls = r!(["a", na_str(), "b"]);
```

You can use `is_na()` to test for NAs.