### PR TITLE
Implement unwind protection by converting R errors to panics.

### DIFF
--- a/extendr-api/src/error.rs
+++ b/extendr-api/src/error.rs
@@ -24,6 +24,7 @@ pub fn unwrap_or_throw<T>(r: std::result::Result<T, &'static str>) -> T {
 
 #[derive(Debug, PartialEq)]
 pub enum Error {
+    Panic{},
     NotFound,
     NotAVectorType,
     ParseError,

--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -209,7 +209,7 @@ pub use lang::*;
 pub use logical::*;
 pub use rmacros::*;
 pub use robj::*;
-pub use thread_safety::{handle_panic, single_threaded};
+pub use thread_safety::{handle_panic, single_threaded, throw_r_error, catch_r_error};
 pub use wrapper::*;
 pub use matrix::*;
 

--- a/extendr-api/src/robj/rinternals.rs
+++ b/extendr-api/src/robj/rinternals.rs
@@ -112,13 +112,14 @@ impl Robj {
     ///
     ///    let my_fun = base_env().find_function(sym!(ls)).unwrap();
     ///    assert_eq!(my_fun.is_function(), true);
-    ///    assert_eq!(base_env().find_var(sym!(ls)).unwrap().is_promise(), true);
+    ///    assert!(base_env().find_function(sym!(qwertyuiop)).is_none());
     /// ```
     pub fn find_function<K: Into<Robj>>(&self, key: K) -> Option<Robj> {
         let key = key.into();
         if !self.is_environment() || !key.is_symbol() {
             return None;
         }
+        // This may be better:
         // let mut env: Robj = self.into();
         // loop {
         //     if let Some(var) = env.local(&key) {
@@ -135,8 +136,7 @@ impl Robj {
         //     }
         // }
         unsafe {
-            let var = Rf_findFun(key.get(), self.get());
-            if var != R_UnboundValue {
+            if let Ok(var) = catch_r_error(|| Rf_findFun(key.get(), self.get())) {
                 Some(new_borrowed(var))
             } else {
                 None

--- a/extendr-api/src/thread_safety.rs
+++ b/extendr-api/src/thread_safety.rs
@@ -101,7 +101,7 @@ where
     }
 }
 
-pub fn throw_r_error<S : AsRef<str>>(s: S) {
+pub fn throw_r_error<S: AsRef<str>>(s: S) {
     let s = s.as_ref();
     unsafe { libR_sys::Rf_error(std::ffi::CString::new(s).unwrap().as_ptr()) };
 }
@@ -111,10 +111,10 @@ pub fn throw_r_error<S : AsRef<str>>(s: S) {
 /// use extendr_api::*;
 /// test! {
 ///    let res = catch_r_error(|| unsafe {
-///        throw_r_error("bad things!")
+///        throw_r_error("bad things!");
 ///        std::ptr::null_mut()
 ///    });
-///    assert_eq!(res.is_ok(), true);
+///    assert_eq!(res.is_ok(), false);
 /// }
 /// ```
 pub fn catch_r_error<F>(f: F) -> Result<SEXP>
@@ -128,11 +128,11 @@ where
     where
         F: FnOnce() -> SEXP + Copy,
     {
-        let data = data as * const ();
-        let f : &F = std::mem::transmute(data);
+        let data = data as *const ();
+        let f: &F = std::mem::transmute(data);
         f()
     }
-    
+
     unsafe extern "C" fn do_cleanup(_: *mut raw::c_void, jump: Rboolean) {
         if jump != 0 {
             panic!("R has thrown an error.");
@@ -140,8 +140,8 @@ where
     }
 
     unsafe {
-        let fun_ptr = do_call::<F> as * const ();
-        let clean_ptr = do_cleanup as * const ();
+        let fun_ptr = do_call::<F> as *const ();
+        let clean_ptr = do_cleanup as *const ();
         let x = false;
         let fun = std::mem::transmute(fun_ptr);
         let cleanfun = std::mem::transmute(clean_ptr);
@@ -153,9 +153,7 @@ where
             R_UnwindProtect(fun, data, cleanfun, cleandata, cont)
         }) {
             Ok(res) => Ok(res),
-            Err(_) => {
-                Err("Error in protected R code".into())
-            }
+            Err(_) => Err("Error in protected R code".into()),
         };
         Rf_unprotect(1);
         res


### PR DESCRIPTION
Wrap an R function such as Rf_findFunction and convert errors and panics into results.
```
use extendr_api::*;
test! {
   let res = catch_r_error(|| unsafe {
       throw_r_error("bad things!")
       std::ptr::null_mut()
   });
   assert_eq!(res.is_ok(), true);
}
```
