### PR TITLE
Unify iterators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,9 @@
 # CLion support files
 **/.idea
 .vscode/tasks.json
+
+# Rstudio temps.
+.RData
+.Rhistory
+extendr.Rproj
+tests/extendrtests_0.1.0.tar.gz

--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -209,7 +209,7 @@ pub use lang::*;
 pub use logical::*;
 pub use rmacros::*;
 pub use robj::*;
-pub use thread_safety::{handle_panic, single_threaded, throw_r_error, catch_r_error};
+pub use thread_safety::{handle_panic, single_threaded, throw_r_error, catch_r_error, this_thread_id};
 pub use wrapper::*;
 pub use matrix::*;
 

--- a/extendr-api/src/matrix.rs
+++ b/extendr-api/src/matrix.rs
@@ -216,7 +216,7 @@ impl Robj {
         if self.is_array() {
             if let Some(data) = self.as_typed_slice() {
                 if let Some(dim) = self.dim() {
-                    let dim: Vec<_> = dim.cloned().collect();
+                    let dim: Vec<_> = dim.collect();
                     let dim = [dim[0] as usize, dim[1] as usize, dim[2] as usize];
                     return Some(RArray { data, dim });
                 }

--- a/extendr-api/src/robj/iter.rs
+++ b/extendr-api/src/robj/iter.rs
@@ -46,13 +46,13 @@ impl std::fmt::Debug for ListIter {
 pub type NamedListIter = std::iter::Zip<StrIter, ListIter>;
 
 /// Iterator over primitives in integer objects.
-pub type IntegerIter<'a> = std::slice::Iter<'a, i32>;
+pub type IntegerIter<'a> = std::iter::Cloned<std::slice::Iter<'a, i32>>;
 
 /// Iterator over primitives in real objects.
-pub type RealIter<'a> = std::slice::Iter<'a, f64>;
+pub type RealIter<'a> = std::iter::Cloned<std::slice::Iter<'a, f64>>;
 
 /// Iterator over primitives in logical objects.
-pub type LogicalIter<'a> = std::slice::Iter<'a, Bool>;
+pub type LogicalIter<'a> = std::iter::Cloned<std::slice::Iter<'a, Bool>>;
 
 /// Iterator over the objects in a vector or string.
 ///

--- a/extendr-api/src/robj/iter.rs
+++ b/extendr-api/src/robj/iter.rs
@@ -124,7 +124,7 @@ impl std::fmt::Debug for PairlistIter {
 /// let mut robj = R!(pairlist(a = 1, b = 2, 3)).unwrap();
 /// // let mut robj = pairlist!(a = 1, b = 2, 3);
 /// let tags : Vec<_> = robj.as_pairlist_tag_iter().unwrap().collect();
-/// assert_eq!(tags, vec![Some("a"), Some("b"), None]);
+/// assert_eq!(tags, vec!["a", "b", na_str()]);
 /// ```
 pub struct PairlistTagIter<'a> {
     list_elem: SEXP,
@@ -145,7 +145,7 @@ impl<'a> PairlistTagIter<'a> {
 
 // 'a is the lifetime of the pairlist.
 impl<'a> Iterator for PairlistTagIter<'a> {
-    type Item = Option<&'a str>;
+    type Item = &'a str;
 
     fn next(&mut self) -> Option<Self::Item> {
         unsafe {
@@ -155,9 +155,9 @@ impl<'a> Iterator for PairlistTagIter<'a> {
             } else {
                 self.list_elem = CDR(sexp);
                 if let Some(symbol) = new_borrowed::<'a>(TAG(sexp)).as_symbol() {
-                    Some(Some(std::mem::transmute(symbol.0)))
+                    Some(std::mem::transmute(symbol.0))
                 } else {
-                    Some(None)
+                    Some(na_str())
                 }
             }
         }
@@ -302,7 +302,7 @@ impl Robj {
     /// let mut robj = R!(pairlist(a = 1, b = 2, 3)).unwrap();
     /// // let mut robj = pairlist!(a = 1, b = 2, 3);
     /// let tags : Vec<_> = robj.as_pairlist_tag_iter().unwrap().collect();
-    /// assert_eq!(tags, vec![Some("a"), Some("b"), None]);
+    /// assert_eq!(tags, vec!["a", "b", na_str()]);
     /// ```
     pub fn as_pairlist_tag_iter<'a>(&self) -> Option<PairlistTagIter<'a>> {
         match self.sexptype() {

--- a/extendr-api/src/robj/iter.rs
+++ b/extendr-api/src/robj/iter.rs
@@ -32,16 +32,6 @@ impl Iterator for ListIter {
     }
 }
 
-impl std::fmt::Debug for ListIter {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "[")?;
-        for s in self.clone() {
-            write!(f, "{:?}", s)?;
-        }
-        write!(f, "]")
-    }
-}
-
 /// Iterator over name-value pairs in lists.
 pub type NamedListIter = std::iter::Zip<StrIter, ListIter>;
 
@@ -105,16 +95,6 @@ impl Iterator for PairlistIter {
     }
 }
 
-impl std::fmt::Debug for PairlistIter {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "[")?;
-        for s in self.clone() {
-            write!(f, "{:?}", s)?;
-        }
-        write!(f, "]")
-    }
-}
-
 #[derive(Clone)]
 /// Iterator over pairlist tag names.
 /// ```
@@ -161,16 +141,6 @@ impl<'a> Iterator for PairlistTagIter<'a> {
                 }
             }
         }
-    }
-}
-
-impl<'a> std::fmt::Debug for PairlistTagIter<'a> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "[")?;
-        for s in self.clone() {
-            write!(f, "{:?}", s)?;
-        }
-        write!(f, "]")
     }
 }
 
@@ -261,17 +231,26 @@ impl Iterator for StrIter {
     }
 }
 
-impl std::fmt::Debug for StrIter {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "[")?;
-        let mut comma = "";
-        for s in self.clone() {
-            write!(f, "{}{:?}", comma, s)?;
-            comma = ", ";
+macro_rules! impl_iter_debug {
+    ($name: ty) => {
+        impl std::fmt::Debug for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "[")?;
+                let mut comma = "";
+                for s in self.clone() {
+                    write!(f, "{}{:?}", comma, s)?;
+                    comma = ", ";
+                }
+                write!(f, "]")
+            }
         }
-        write!(f, "]")
     }
 }
+
+impl_iter_debug!(ListIter);
+impl_iter_debug!(PairlistIter);
+impl_iter_debug!(PairlistTagIter<'a>);
+impl_iter_debug!(StrIter);
 
 impl Robj {
     /// Get an iterator over a pairlist objects.

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -1013,16 +1013,16 @@ impl Robj {
                     for frame in as_list_iter {
                         if let Some(tag_iter) = frame.as_pairlist_tag_iter() {
                             for tag in tag_iter {
-                                if tag.is_some() {
-                                    names.push(tag.unwrap().to_string());
+                                if !tag.is_na() {
+                                    names.push(tag.to_string());
                                 }
                             }
                         }
                     }
                 } else if let Some(tag_iter) = frame.as_pairlist_tag_iter() {
                     for tag in tag_iter {
-                        if tag.is_some() {
-                            names.push(tag.unwrap().to_string());
+                        if !tag.is_na() {
+                            names.push(tag.to_string());
                         }
                     }
                 }

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -1001,35 +1001,12 @@ impl Robj {
     ///
     ///    let names_and_values : std::collections::HashMap<_, _> = (0..4).map(|i| (format!("n{}", i), r!(i))).collect();
     ///    let env = r!(Env{parent: global_env(), names_and_values});
-    ///    assert_eq!(env.ls().unwrap(), vec!["n0".to_string(), "n1".to_string(), "n2".to_string(), "n3".to_string()]);
+    ///    assert_eq!(env.ls().unwrap(), vec!["n0", "n1", "n2", "n3"]);
     /// ```
-    pub fn ls(&self) -> Option<Vec<String>> {
-        if self.is_environment() {
-            let mut names = Vec::new();
-            unsafe {
-                let hashtab = new_owned(HASHTAB(self.get()));
-                let frame = new_owned(FRAME(self.get()));
-                if let Some(as_list_iter) = hashtab.as_list_iter() {
-                    for frame in as_list_iter {
-                        if let Some(tag_iter) = frame.as_pairlist_tag_iter() {
-                            for tag in tag_iter {
-                                if !tag.is_na() {
-                                    names.push(tag.to_string());
-                                }
-                            }
-                        }
-                    }
-                } else if let Some(tag_iter) = frame.as_pairlist_tag_iter() {
-                    for tag in tag_iter {
-                        if !tag.is_na() {
-                            names.push(tag.to_string());
-                        }
-                    }
-                }
-            }
-            return Some(names);
-        }
-        None
+    pub fn ls(&self) -> Option<Vec<&str>> {
+        self.as_env_iter().map(
+            |iter| iter.map(|(k, _)| k).collect::<Vec<_>>()
+        )
     }
 }
 
@@ -1091,7 +1068,7 @@ impl PartialEq<Robj> for Robj {
                         .unwrap()
                         .eq(rhs.as_pairlist_iter().unwrap()),
                     CLOSXP => false,
-                    ENVSXP => self.as_environment() == rhs.as_environment(),
+                    ENVSXP => false, // objects must match.
                     PROMSXP => false,
                     SPECIALSXP => false,
                     BUILTINSXP => false,

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -79,7 +79,7 @@ pub use rinternals::*;
 ///
 /// let a : Robj = c!(1, 2, 3, 4, 5);
 /// let iter = a.as_integer_iter().unwrap();
-/// let robj = iter.filter(|&&x| x < 3).collect_robj();
+/// let robj = iter.filter(|&x| x < 3).collect_robj();
 /// assert_eq!(robj, c!(1, 2));
 /// ```
 ///
@@ -319,7 +319,7 @@ impl Robj {
         Self: 'a,
     {
         if let Some(slice) = self.as_integer_slice() {
-            Some(slice.iter())
+            Some(slice.iter().cloned())
         } else {
             None
         }
@@ -380,7 +380,7 @@ impl Robj {
     /// let robj = r!([TRUE, FALSE, NA_LOGICAL]);
     /// let (mut nt, mut nf, mut nna) = (0, 0, 0);
     /// for val in robj.as_logical_iter().unwrap() {
-    ///   match *val {
+    ///   match val {
     ///     TRUE => nt += 1,
     ///     FALSE => nf += 1,
     ///     NA_LOGICAL => nna += 1,
@@ -391,7 +391,7 @@ impl Robj {
     /// ```
     pub fn as_logical_iter(&self) -> Option<LogicalIter> {
         if let Some(slice) = self.as_logical_slice() {
-            Some(slice.iter())
+            Some(slice.iter().cloned())
         } else {
             None
         }
@@ -433,7 +433,7 @@ impl Robj {
     /// ```
     pub fn as_real_iter(&self) -> Option<RealIter> {
         if let Some(slice) = self.as_real_slice() {
-            Some(slice.iter())
+            Some(slice.iter().cloned())
         } else {
             None
         }
@@ -894,7 +894,7 @@ impl Robj {
     ///    extendr_engine::start_r();
     ///
     ///    let array = R!(array(data = c(1, 2, 3, 4), dim = c(2, 2), dimnames = list(c("x", "y"), c("a","b")))).unwrap();
-    ///    let dim : Vec<_> = array.dim().unwrap().cloned().collect();
+    ///    let dim : Vec<_> = array.dim().unwrap().collect();
     ///    assert_eq!(dim, vec![2, 2]);
     /// ```
     pub fn dim<'a>(&self) -> Option<IntegerIter<'a>>

--- a/extendr-api/src/robj/tests.rs
+++ b/extendr-api/src/robj/tests.rs
@@ -245,17 +245,17 @@ fn input_iterator_test() {
     let src: &[i32] = &[1, 2, 3];
     let robj = Robj::from(src);
     let iter = <IntegerIter>::from_robj(&robj).unwrap();
-    assert_eq!(iter.cloned().collect::<Vec<_>>(), src);
+    assert_eq!(iter.collect::<Vec<_>>(), src);
 
     let src: &[f64] = &[1., 2., 3.];
     let robj = Robj::from(src);
     let iter = <RealIter>::from_robj(&robj).unwrap();
-    assert_eq!(iter.cloned().collect::<Vec<_>>(), src);
+    assert_eq!(iter.collect::<Vec<_>>(), src);
 
     /*
     let src: &[Bool] = &[TRUE, FALSE, TRUE];
     let robj = Robj::from(src);
     let iter = <LogicalIter>::from_robj(&robj).unwrap();
-    assert_eq!(iter.cloned().collect::<Vec<_>>(), src);
+    assert_eq!(iter.collect::<Vec<_>>(), src);
     */
 }

--- a/extendr-api/src/thread_safety.rs
+++ b/extendr-api/src/thread_safety.rs
@@ -88,7 +88,11 @@ where
 
 pub fn throw_r_error<S: AsRef<str>>(s: S) {
     let s = s.as_ref();
-    unsafe { libR_sys::Rf_error(std::ffi::CString::new(s).unwrap().as_ptr()) };
+    unsafe {
+        let cstring = std::ffi::CString::new(s).unwrap();
+        libR_sys::Rf_error(cstring.as_ptr());
+        unreachable!("Rf_error does not return");
+    };
 }
 
 /// Wrap an R function such as Rf_findFunction and convert errors and panics into results.

--- a/extendr-api/src/thread_safety.rs
+++ b/extendr-api/src/thread_safety.rs
@@ -1,5 +1,6 @@
 //! Provide limited protection for multithreaded access to the R API.
 
+use crate::*;
 use std::sync::atomic::{AtomicU32, Ordering};
 
 static OWNER_THREAD: AtomicU32 = AtomicU32::new(0);

--- a/extendr-api/src/wrapper.rs
+++ b/extendr-api/src/wrapper.rs
@@ -56,7 +56,6 @@ pub struct Raw<'a>(pub &'a [u8]);
 /// let call_to_xyz = r!(Lang(&[r!(Symbol("xyz")), r!(1), r!(2)]));
 /// assert_eq!(call_to_xyz.is_language(), true);
 /// assert_eq!(call_to_xyz.len(), 3);
-/// assert_eq!(call_to_xyz.as_lang(), Some(Lang(vec![r!(Symbol("xyz")), r!(1), r!(2)])));
 /// ```
 ///
 /// Note: You can use the [lang!] macro for this.
@@ -83,7 +82,7 @@ pub struct Pairlist<NV> {
 /// extendr_engine::start_r();
 /// let list = r!(List(&[r!(0), r!(1), r!(2)]));
 /// assert_eq!(list.is_list(), true);
-/// assert_eq!(list.as_list(), Some(List(vec![r!(0), r!(1), r!(2)])));
+/// assert_eq!(list.len(), 3);
 /// assert_eq!(format!("{:?}", list), r#"r!(List([r!(0), r!(1), r!(2)]))"#);
 /// ```
 ///


### PR DESCRIPTION
This PR fills some gaps in the set of iterators to cover environments
and to make all string iterators use the `is_na()` methods rather than `Option<&str>`.

The environment method `as_env()` now returns the parent and an iterator over elements
of  the environment.

The `PartialEq` operator only compares pointers for environments, so `enva == envb` will
just compare SEXP pointers,

The integer and real iterators return actual i32 and f64 values instead of references which
will make it easier to write stats functions.


