### PR TITLE
Better & more informative logging and error handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,8 +120,14 @@ jobs:
       - name: Build
         run: |
           foreach($target in ($env:BUILD_TARGETS).Split(',')) {
-            echo $target
+            echo "::group::Build for $target target"
             cargo build $(if($target -ne 'default') {"--target=$target"} ) 
+            echo "::endgroup::"
+
+            if (!$?) { 
+              echo "::error::Build for $target target" ;
+              throw "Last exit code $LASTEXITCODE"
+            }
           }
 
       # For each target in the BUILD_TARGETS comma-separated list, run cargo test with appropriate target
@@ -129,8 +135,14 @@ jobs:
       - name: Run tests
         run: |
           foreach($target in ($env:BUILD_TARGETS).Split(',')) {
-            echo $target
+            echo "::group::Test for $target target"
             cargo test $(if($target -ne 'default') {"--target=$target"} ) -- --nocapture
+            echo "::endgroup::"
+            
+            if (!$?) { 
+              echo "::error::Test for $target target" ;
+              throw "Last exit code $LASTEXITCODE"
+            }
           }
 
 
@@ -249,7 +261,7 @@ jobs:
             echo "::endgroup::"
 
             if (!$?) { 
-              echo "::error::$target" ;
+              echo "::error::Build extendr-api for $target target" ;
               throw "Last exit code $LASTEXITCODE"
             }
           }
@@ -257,9 +269,9 @@ jobs:
             echo "::group::Build extendr-engine for $target target"
             cargo build --manifest-path extendr-engine/Cargo.toml --features tests-all $(if($target -ne 'default') {"--target=$target"} ) 
             echo "::endgroup::"
-            
+
             if (!$?) { 
-              echo "::error::$target" ;
+              echo "::error::Build extendr-engine for $target target" ;
               throw "Last exit code $LASTEXITCODE"
             }
           }
@@ -272,7 +284,7 @@ jobs:
             echo "::endgroup::"
 
             if (!$?) { 
-              echo "::error::$target" ;
+              echo "::error::Test extendr-engine \w tests-all for $target target" ;
               throw "Last exit code $LASTEXITCODE"
             }
           }
@@ -282,7 +294,7 @@ jobs:
             echo "::endgroup::"
 
             if (!$?) { 
-              echo "::error::$target" ;
+              echo "::error::Test extendr-api \w tests-all for $target target" ;
               throw "Last exit code $LASTEXITCODE"
             }
           }
@@ -292,7 +304,7 @@ jobs:
             echo "::endgroup::"
 
             if (!$?) { 
-              echo "::error::$target" ;
+              echo "::error::Test extendr-api \w tests-minimal for $target target" ;
               throw "Last exit code $LASTEXITCODE"
             }
           }
@@ -302,7 +314,7 @@ jobs:
             echo "::endgroup::"
 
             if (!$?) { 
-              echo "::error::$target" ;
+              echo "::error::Test extendr-macros for $target target" ;
               throw "Last exit code $LASTEXITCODE"
             }
           }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -244,16 +244,20 @@ jobs:
       - name: Build
         run: |
           foreach($target in ($env:BUILD_TARGETS).Split(',')) {
-            echo $target
+            echo "::group::Build extendr-api for $target target"
             cargo build --manifest-path extendr-api/Cargo.toml --features tests-all $(if($target -ne 'default') {"--target=$target"} )
+            echo "::endgroup::"
+
             if (!$?) { 
               echo "::error::$target" ;
               throw "Last exit code $LASTEXITCODE"
             }
           }
           foreach($target in ($env:BUILD_TARGETS).Split(',')) {
-            echo $target
+            echo "::group::Build extendr-engine for $target target"
             cargo build --manifest-path extendr-engine/Cargo.toml --features tests-all $(if($target -ne 'default') {"--target=$target"} ) 
+            echo "::endgroup::"
+            
             if (!$?) { 
               echo "::error::$target" ;
               throw "Last exit code $LASTEXITCODE"
@@ -263,32 +267,40 @@ jobs:
       - name: Run tests
         run: |
           foreach($target in ($env:BUILD_TARGETS).Split(',')) {
-            echo $target
+            echo "::group::Test extendr-engine \w tests-all for $target target"
             cargo test --manifest-path extendr-engine/Cargo.toml --features tests-all $(if($target -ne 'default') {"--target=$target"} ) -- --nocapture 
+            echo "::endgroup::"
+
             if (!$?) { 
               echo "::error::$target" ;
               throw "Last exit code $LASTEXITCODE"
             }
           }
           foreach($target in ($env:BUILD_TARGETS).Split(',')) {
-            echo $target
+            echo "::group::Test extendr-api \w tests-all for $target target"
             cargo test --manifest-path extendr-api/Cargo.toml --features tests-all $(if($target -ne 'default') {"--target=$target"} ) -- --nocapture 
+            echo "::endgroup::"
+
             if (!$?) { 
               echo "::error::$target" ;
               throw "Last exit code $LASTEXITCODE"
             }
           }
-          foreach($target in ($env:BUILD_TARGETS).Split(',')) {
-            echo $target
+          foreach($target in ($env:BUILD_TARGETS).Split(',')) {            
+            echo "::group::Test extendr-api \w tests-minimal for $target target"
             cargo test --manifest-path extendr-api/Cargo.toml --features tests-minimal $(if($target -ne 'default') {"--target=$target"} ) -- --nocapture
+            echo "::endgroup::"
+
             if (!$?) { 
               echo "::error::$target" ;
               throw "Last exit code $LASTEXITCODE"
             }
           }
           foreach($target in ($env:BUILD_TARGETS).Split(',')) {
-            echo $target
+            echo "::group::Test extendr-macros for $target target"
             cargo test --manifest-path extendr-macros/Cargo.toml  $(if($target -ne 'default') {"--target=$target"} ) -- --nocapture
+            echo "::endgroup::"
+
             if (!$?) { 
               echo "::error::$target" ;
               throw "Last exit code $LASTEXITCODE"


### PR DESCRIPTION
After digging into #129 I noticed that the current output of GH Actions is not really friendly for debugging purposes, especially when multiple commands are executed for several architectures in one step.

Using GHA syntax `"::group::"` I slightly improved how logs are displayed (see Check results especially for Windows bindgen).
I also added missing error handling to Build & Test steps, which previously could swallow some build/test errors.