### PR TITLE
Increase R_CStackLimit also on Windows

### DIFF
--- a/extendr-engine/src/lib.rs
+++ b/extendr-engine/src/lib.rs
@@ -43,10 +43,7 @@ pub fn start_r() {
             // In case you are curious.
             // Maybe 8MB is a bit small.
             // eprintln!("R_CStackLimit={:016x}", R_CStackLimit);
-
-            if cfg!(not(target_os = "windows")) {
-                R_CStackLimit = usize::max_value();
-            }
+            R_CStackLimit = usize::max_value();
 
             setup_Rmainloop();
         }


### PR DESCRIPTION
Fix #129

Increasing `R_CStackLimit` is currently skipped on Windows, but it seems we need larger stack limit to avoid errors about stack usages.

Note that, while this works, I'm not 100% sure if this is the reliable solution in the long term. As @clauswilke commented (https://github.com/extendr/extendr/issues/129#issuecomment-761256481) `R_CStackLimit` is defined in `Rinterface.h`, which is not included on Windows. But, it probably doesn't prevent us from including `Rinterface.h` by ourselves, as suggested in this SO answer:

https://stackoverflow.com/a/47117089

I guess this is similar to how setting `R_CStackLimit` works even on Windows. If I grep `R_CStackLimit`, I only can find this one line:

```
PS C:\Program Files\R\R-4.0.2\include> grep R_CStackLimit -R .
./Rinternals.h: if(R_CStackLimit != (uintptr_t)(-1) && usage > ((intptr_t) R_CStackLimit)) \
```

~~But, only from this piece of code, bindgen is smart enough to generate the following code:~~ (edit: I was wrong...)

``` rust
extern "C" {
    pub static mut R_CStackLimit: usize;
}
```
(https://github.com/extendr/libR-sys/blob/5ca8d402ff0f56c67544d87ec58fed2d1adbe50c/bindings/bindings-windows-x86-R4.0.rs#L6419-L6421)