### PR TITLE
use make_name instead of quote to get the impl nm

### DIFF
--- a/extendr-macros/src/lib.rs
+++ b/extendr-macros/src/lib.rs
@@ -283,6 +283,8 @@ fn generate_wrappers(_opts: &ExtendrOptions, wrappers: &mut Vec<ItemFn>, prefix:
     ));
 }
 
+// Extracts the `impl` name from a `syn::Type`. It's used to make names for 
+// the C init wrappers.
 fn make_name (ty: &syn::Type) -> String {
 
     // c.f. https://docs.rs/syn/1.0.58/syn/enum.Type.html#variants
@@ -290,19 +292,19 @@ fn make_name (ty: &syn::Type) -> String {
         syn::Type::Path(p) => {
             // <Type as Trait>::function(...), which should not appear in impl
             if p.qself.is_some() {
-                panic!("Something is wrong");
+                panic!("This doesn't look to be an `impl`.");
             }
 
             &p.path
         }
         _ => {
-            panic!("Unknown type")
+            panic!("Unknown type.")
         }
     };
 
     // ::Foo
     if path.leading_colon.is_some() {
-        panic!("There shouldn't be leading colons?")
+        panic!("There shouldn't be leading colons.")
     }
 
     if path.segments.len() > 1 {

--- a/extendr-macros/src/lib.rs
+++ b/extendr-macros/src/lib.rs
@@ -306,7 +306,7 @@ fn make_name (ty: &syn::Type) -> String {
     }
 
     if path.segments.len() > 1 {
-        panic!("Namespaced impl are not supported and connot be exported.")
+        panic!("Namespaced impl are not supported and cannot be exported.")
     }
 
     path.segments[0].ident.to_string()


### PR DESCRIPTION
This PR allows to export `impl`s that have lifetime annotations (to fix #131) like the one below:

```
struct Person<'a> {
    pub name: &'a String,
}

#[extendr]
impl<'a> Person<'a> {
    fn new() -> Self {
        Self { name: &"".to_string() }
    }
}
```

See discussion in #131

I am happy to add tests but I couldn't find out where I should add them, if in the R package or somewhere in the `extendr-macros` directory. 

