### PR TITLE
Make extendr-engine dev-dependency

### DIFF
--- a/extendr-api/Cargo.toml
+++ b/extendr-api/Cargo.toml
@@ -20,7 +20,7 @@ extendr-engine = { path = "../extendr-engine", version = "0.1.11", optional = tr
 ndarray = { version = "0.13.1", optional = true }
 
 [features]
-default = []
+default = ["extendr-engine"]
 
 # All features to test
 tests-all = ["ndarray", "extendr-engine", "libR-sys/use-bindgen"]

--- a/extendr-api/Cargo.toml
+++ b/extendr-api/Cargo.toml
@@ -16,14 +16,16 @@ repository = "https://github.com/extendr/extendr"
 [dependencies]
 libR-sys = "0.2.0"
 extendr-macros = { path = "../extendr-macros", version = "0.1.11" }
-extendr-engine = { path = "../extendr-engine", version = "0.1.11", optional = true }
 ndarray = { version = "0.13.1", optional = true }
 
+[dev-dependencies]
+extendr-engine = { path = "../extendr-engine", version = "0.1.11" }
+
 [features]
-default = ["extendr-engine"]
+default = []
 
 # All features to test
-tests-all = ["ndarray", "extendr-engine", "libR-sys/use-bindgen"]
+tests-all = ["ndarray", "libR-sys/use-bindgen"]
 
 # The minimal set of features without all optional ones
 tests-minimal = ["libR-sys/use-bindgen"]

--- a/extendr-api/Cargo.toml
+++ b/extendr-api/Cargo.toml
@@ -15,15 +15,15 @@ repository = "https://github.com/extendr/extendr"
 
 [dependencies]
 libR-sys = "0.2.0"
-extendr-macros = { path = "../extendr-macros", version="0.1.11" }
-extendr-engine = { path = "../extendr-engine", version="0.1.11" }
+extendr-macros = { path = "../extendr-macros", version = "0.1.11" }
+extendr-engine = { path = "../extendr-engine", version = "0.1.11", optional = true }
 ndarray = { version = "0.13.1", optional = true }
 
 [features]
 default = []
 
 # All features to test
-tests-all = ["ndarray", "libR-sys/use-bindgen"]
+tests-all = ["ndarray", "extendr-engine", "libR-sys/use-bindgen"]
 
 # The minimal set of features without all optional ones
 tests-minimal = ["libR-sys/use-bindgen"]

--- a/extendr-api/src/functions.rs
+++ b/extendr-api/src/functions.rs
@@ -376,18 +376,3 @@ pub fn blank_scalar_string() -> Robj {
 pub fn na_str() -> &'static str {
     unsafe { std::str::from_utf8_unchecked(&[b'N', b'A']) }
 }
-
-/// Extendr test harness.
-///
-/// See also [test!]
-/// ```
-/// extendr_api::test(|| {
-///   Ok(())
-/// })
-/// ```
-#[cfg(test)]
-pub fn test<F: FnOnce() -> Result<()>>(f: F) {
-    extendr_engine::start_r();
-
-    f().unwrap();
-}

--- a/extendr-api/src/functions.rs
+++ b/extendr-api/src/functions.rs
@@ -385,14 +385,9 @@ pub fn na_str() -> &'static str {
 ///   Ok(())
 /// })
 /// ```
-#[cfg(feature = "extendr_engine")]
+#[cfg(test)]
 pub fn test<F: FnOnce() -> Result<()>>(f: F) {
     extendr_engine::start_r();
 
     f().unwrap();
-}
-
-#[cfg(not(feature = "extendr_engine"))]
-pub fn test<F: FnOnce() -> Result<()>>(_: F) {
-    ()
 }

--- a/extendr-api/src/functions.rs
+++ b/extendr-api/src/functions.rs
@@ -385,8 +385,14 @@ pub fn na_str() -> &'static str {
 ///   Ok(())
 /// })
 /// ```
+#[cfg(feature = "extendr_engine")]
 pub fn test<F: FnOnce() -> Result<()>>(f: F) {
     extendr_engine::start_r();
 
     f().unwrap();
+}
+
+#[cfg(not(feature = "extendr_engine"))]
+pub fn test<F: FnOnce() -> Result<()>>(_: F) {
+    ()
 }

--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -521,7 +521,6 @@ mod tests {
         impl Person;
     }
 
-    #[cfg(feature = "extendr_engine")]
     #[test]
     fn export_test() {
         extendr_engine::start_r();
@@ -648,7 +647,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "extendr_engine")]
     #[test]
     fn r_output_test() {
         // R equivalent

--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -521,6 +521,7 @@ mod tests {
         impl Person;
     }
 
+    #[cfg(feature = "extendr_engine")]
     #[test]
     fn export_test() {
         extendr_engine::start_r();
@@ -647,6 +648,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "extendr_engine")]
     #[test]
     fn r_output_test() {
         // R equivalent

--- a/extendr-api/src/rmacros.rs
+++ b/extendr-api/src/rmacros.rs
@@ -280,10 +280,10 @@ macro_rules! reprintln {
 #[macro_export]
 macro_rules! test {
     () => {
-        test(|| Ok(()))
+        extendr_engine::test(|| Ok(()))
     };
     ($($rest: tt)*) => {
-        test(|| {
+        extendr_engine::test(|| {
             $($rest)*
             Ok(())
         })

--- a/extendr-api/src/robj/tests.rs
+++ b/extendr-api/src/robj/tests.rs
@@ -1,5 +1,6 @@
 use crate::*;
 
+#[cfg(feature = "extendr_engine")]
 #[test]
 fn test_debug() {
     extendr_engine::start_r();
@@ -35,6 +36,7 @@ fn test_debug() {
     );
 }
 
+#[cfg(feature = "extendr_engine")]
 #[test]
 fn test_from_robj() {
     extendr_engine::start_r();
@@ -125,6 +127,8 @@ fn test_from_robj() {
     );
     assert!(<Option<String>>::from_robj(&Robj::from(["1", "2"])).is_err());
 }
+
+#[cfg(feature = "extendr_engine")]
 #[test]
 fn test_to_robj() {
     extendr_engine::start_r();
@@ -163,6 +167,7 @@ fn test_to_robj() {
     assert!(Robj::from(<Option<&str>>::None).is_na());
 }
 
+#[cfg(feature = "extendr_engine")]
 #[test]
 fn parse_test() -> Result<()> {
     extendr_engine::start_r();
@@ -178,6 +183,7 @@ fn parse_test() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "extendr_engine")]
 #[test]
 fn output_iterator_test() -> Result<()> {
     extendr_engine::start_r();
@@ -228,6 +234,7 @@ fn output_iterator_test() -> Result<()> {
 // #[extendr]
 // fn fred(a: RealIter, b: RealIter) -> RealIter {
 // }
+#[cfg(feature = "extendr_engine")]
 #[test]
 fn input_iterator_test() {
     extendr_engine::start_r();

--- a/extendr-api/src/robj/tests.rs
+++ b/extendr-api/src/robj/tests.rs
@@ -1,6 +1,5 @@
 use crate::*;
 
-#[cfg(feature = "extendr_engine")]
 #[test]
 fn test_debug() {
     extendr_engine::start_r();
@@ -36,7 +35,6 @@ fn test_debug() {
     );
 }
 
-#[cfg(feature = "extendr_engine")]
 #[test]
 fn test_from_robj() {
     extendr_engine::start_r();
@@ -128,7 +126,6 @@ fn test_from_robj() {
     assert!(<Option<String>>::from_robj(&Robj::from(["1", "2"])).is_err());
 }
 
-#[cfg(feature = "extendr_engine")]
 #[test]
 fn test_to_robj() {
     extendr_engine::start_r();
@@ -167,7 +164,6 @@ fn test_to_robj() {
     assert!(Robj::from(<Option<&str>>::None).is_na());
 }
 
-#[cfg(feature = "extendr_engine")]
 #[test]
 fn parse_test() -> Result<()> {
     extendr_engine::start_r();
@@ -183,7 +179,6 @@ fn parse_test() -> Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "extendr_engine")]
 #[test]
 fn output_iterator_test() -> Result<()> {
     extendr_engine::start_r();
@@ -234,7 +229,6 @@ fn output_iterator_test() -> Result<()> {
 // #[extendr]
 // fn fred(a: RealIter, b: RealIter) -> RealIter {
 // }
-#[cfg(feature = "extendr_engine")]
 #[test]
 fn input_iterator_test() {
     extendr_engine::start_r();

--- a/extendr-engine/src/lib.rs
+++ b/extendr-engine/src/lib.rs
@@ -61,6 +61,20 @@ pub fn end_r() {
     }
 }
 
+/// Extendr test harness.
+///
+/// See also [test!]
+/// ```
+/// extendr_api::test(|| {
+///   Ok(())
+/// })
+/// ```
+pub fn test<F: FnOnce() -> Result<(), String>>(f: F) {
+    start_r();
+
+    f().unwrap();
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/extendrtests/src/rust/Cargo.toml
+++ b/tests/extendrtests/src/rust/Cargo.toml
@@ -25,5 +25,5 @@ extendr-api = "*"
 ## Build against local extendr sources. Check locally by 
 ## running rcmdcheck::rcmdcheck(check_dir = "../../../") from
 ## the root of extendrtests.
-extendr-api = { path = "../../../../../extendr/extendr-api/", features = [] }
+extendr-api = { path = "../../../../../extendr/extendr-api/" }
 extendr-macros = { path = "../../../../../extendr/extendr-macros/" }

--- a/tests/extendrtests/src/rust/Cargo.toml
+++ b/tests/extendrtests/src/rust/Cargo.toml
@@ -19,11 +19,11 @@ extendr-api = "*"
 
 ## Build against current extendr version on github. Not recommended
 ## for development work.
-#extendr-api = { git = "https://github.com/extendr/extendr"}
+#extendr-api = { git = "https://github.com/extendr/extendr" }
 #extendr-macros = { git = "https://github.com/extendr/extendr" }
 
 ## Build against local extendr sources. Check locally by 
 ## running rcmdcheck::rcmdcheck(check_dir = "../../../") from
 ## the root of extendrtests.
-extendr-api = { path = "../../../../../extendr/extendr-api/"}
-extendr-macros = { path = "../../../../../extendr/extendr-macros/"}
+extendr-api = { path = "../../../../../extendr/extendr-api/", features = [] }
+extendr-macros = { path = "../../../../../extendr/extendr-macros/" }

--- a/tests/extendrtests/src/rust/Cargo.toml
+++ b/tests/extendrtests/src/rust/Cargo.toml
@@ -20,12 +20,10 @@ extendr-api = "*"
 ## Build against current extendr version on github. Not recommended
 ## for development work.
 #extendr-api = { git = "https://github.com/extendr/extendr"}
-#extendr-engine = { git = "https://github.com/extendr/extendr" }
 #extendr-macros = { git = "https://github.com/extendr/extendr" }
 
 ## Build against local extendr sources. Check locally by 
 ## running rcmdcheck::rcmdcheck(check_dir = "../../../") from
 ## the root of extendrtests.
 extendr-api = { path = "../../../../../extendr/extendr-api/"}
-extendr-engine = { path = "../../../../../extendr/extendr-engine/"}
 extendr-macros = { path = "../../../../../extendr/extendr-macros/"}


### PR DESCRIPTION
Fix #144

The main purpose of extendr-engine was not to call non-API symbols in R (#46). But, in actual, extendr-api unconditionally depends on it to execute tests. So, we need to opt-out the tests and accordingly the dependency on extendr-engine.

I'm yet to figure out how to do this elegantly. Currently, I made `extendr-engine` as the default feature because otherwise I probably need to add `no_run` to all the example code... Any ideas?