### PR TITLE
Numeric wrappers

### DIFF
--- a/extendr-api/src/functions.rs
+++ b/extendr-api/src/functions.rs
@@ -34,8 +34,7 @@ pub fn new_env_with_capacity(capacity: usize) -> Robj {
         // Unhashed envirnment
         call!("new.env", FALSE, global_env(), 0).unwrap()
     } else {
-        // Hashed environment, the pidgeon hole principle
-        // ensures there are empty slots in the hash table.
+        // Hashed environment for larger hashmaps.
         call!("new.env", TRUE, global_env(), capacity as i32 * 2 + 1).unwrap()
     }
 }

--- a/extendr-api/src/iter.rs
+++ b/extendr-api/src/iter.rs
@@ -101,24 +101,33 @@ impl<T: Copy> Iterator for SliceIter<T> {
 pub type NamedListIter = std::iter::Zip<StrIter, ListIter>;
 
 /// Iterator over primitives in integer objects.
-#[deprecated = "Use Int instead"]
-pub type IntegerIter = SliceIter<i32>;
-
-/// Iterator over primitives in real objects.
-#[deprecated = "Use Real instead"]
-pub type RealIter = SliceIter<f64>;
-
-/// Iterator over primitives in logical objects.
-#[deprecated = "Use Logical instead"]
-pub type LogicalIter = SliceIter<Bool>;
-
-/// Iterator over primitives in integer objects.
+/// ```
+/// use extendr_api::prelude::*;
+///
+/// fn add(a: Int, b: Int) -> Robj {
+///     a.zip(b).map(|(a, b)| a+b).collect_robj()
+/// }
+/// ```
 pub type Int = SliceIter<i32>;
 
 /// Iterator over primitives in real objects.
+/// ```
+/// use extendr_api::prelude::*;
+///
+/// fn add1(a: Real) -> Robj {
+///     a.map(|a| a + 1.0).collect_robj()
+/// }
+/// ```
 pub type Real = SliceIter<f64>;
 
 /// Iterator over primitives in logical objects.
+/// ```
+/// use extendr_api::prelude::*;
+///
+/// fn all_true(mut a: Logical) -> bool {
+///     a.all(|a| a.is_true())
+/// }
+/// ```
 pub type Logical = SliceIter<Bool>;
 
 /// Iterator over the objects in a vector or string.

--- a/extendr-api/src/iter.rs
+++ b/extendr-api/src/iter.rs
@@ -72,7 +72,7 @@ impl<T> SliceIter<T> {
     }
 }
 
-/// Basis of IntegerIter, RealIter and LogicalIter.
+/// Basis of Int, Real and Logical.
 impl<T: Copy> Iterator for SliceIter<T> {
     type Item = T;
 
@@ -101,13 +101,25 @@ impl<T: Copy> Iterator for SliceIter<T> {
 pub type NamedListIter = std::iter::Zip<StrIter, ListIter>;
 
 /// Iterator over primitives in integer objects.
+#[deprecated = "Use Int instead"]
 pub type IntegerIter = SliceIter<i32>;
 
 /// Iterator over primitives in real objects.
+#[deprecated = "Use Real instead"]
 pub type RealIter = SliceIter<f64>;
 
 /// Iterator over primitives in logical objects.
+#[deprecated = "Use Logical instead"]
 pub type LogicalIter = SliceIter<Bool>;
+
+/// Iterator over primitives in integer objects.
+pub type Int = SliceIter<i32>;
+
+/// Iterator over primitives in real objects.
+pub type Real = SliceIter<f64>;
+
+/// Iterator over primitives in logical objects.
+pub type Logical = SliceIter<Bool>;
 
 /// Iterator over the objects in a vector or string.
 ///

--- a/extendr-api/src/iter.rs
+++ b/extendr-api/src/iter.rs
@@ -48,7 +48,7 @@ pub struct SliceIter<T> {
     vector: Robj,
     i: usize,
     len: usize,
-    ptr: * const T,
+    ptr: *const T,
 }
 
 impl<T> SliceIter<T> {
@@ -58,7 +58,7 @@ impl<T> SliceIter<T> {
             vector: ().into(),
             i: 0,
             len: 0,
-            ptr: std::ptr::null()
+            ptr: std::ptr::null(),
         }
     }
 
@@ -73,7 +73,7 @@ impl<T> SliceIter<T> {
 }
 
 /// Basis of IntegerIter, RealIter and LogicalIter.
-impl<T : Copy> Iterator for SliceIter<T> {
+impl<T: Copy> Iterator for SliceIter<T> {
     type Item = T;
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/extendr-api/src/iter.rs
+++ b/extendr-api/src/iter.rs
@@ -1,6 +1,24 @@
 use crate::*;
 
-// Iterator over the objects in a VECSXP, EXPRSXP or WEAKREFSXP.
+/// Iterator over the objects in a VECSXP, EXPRSXP or WEAKREFSXP.
+///
+/// ```
+/// use extendr_api::prelude::*;
+/// test! {
+///     let my_list = list!(a = 1, b = 2);
+///     let mut total = 0;
+///     for robj in my_list.as_list_iter().unwrap() {
+///       if let Some(val) = robj.as_integer() {
+///         total += val;
+///       }
+///     }
+///     assert_eq!(total, 3);
+///    
+///     for name in my_list.names().unwrap() {
+///        assert!(name == "a" || name == "b")
+///     }
+/// }
+/// ```
 #[derive(Clone)]
 pub struct ListIter {
     vector: Robj,
@@ -42,8 +60,9 @@ impl Iterator for ListIter {
     }
 }
 
+/// Generalised iterator of numbers and logical. See Int, Real and Logical.
 pub struct SliceIter<T> {
-    // Contol lifetime of vector to make sure the memory is not freed.
+    // Control lifetime of vector to make sure the memory is not freed.
     #[allow(dead_code)]
     vector: Robj,
     i: usize,
@@ -130,25 +149,6 @@ pub type Real = SliceIter<f64>;
 /// ```
 pub type Logical = SliceIter<Bool>;
 
-/// Iterator over the objects in a vector or string.
-///
-/// ```
-/// use extendr_api::prelude::*;
-/// test! {
-///     let my_list = list!(a = 1, b = 2);
-///     let mut total = 0;
-///     for robj in my_list.as_list_iter().unwrap() {
-///       if let Some(val) = robj.as_integer() {
-///         total += val;
-///       }
-///     }
-///     assert_eq!(total, 3);
-///    
-///     for name in my_list.names().unwrap() {
-///        assert!(name == "a" || name == "b")
-///     }
-/// }
-/// ```
 #[derive(Clone)]
 pub struct PairlistIter {
     root_obj: Robj,

--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -41,6 +41,7 @@
 //! test! {
 //!     // An R object with a single string "hello"
 //!     let character = r!("hello");
+//!     let character = r!(["hello", "goodbye"]);
 //!    
 //!     // An R integer object with a single number 1L.
 //!     // Note that in Rust, 1 is an integer and 1.0 is a real.
@@ -52,6 +53,8 @@
 //!    
 //!     // An R real vector.
 //!     let real_vector = r!([1.0, 2.0]);
+//!     let real_vector = &[1.0, 2.0].iter().collect_robj();
+//!     let real_vector = r!(vec![1.0, 2.0]);
 //!    
 //!     // An R function object.
 //!     let function = R!(function(x, y) { x + y })?;
@@ -59,8 +62,16 @@
 //!     // A named list using the list! macro.
 //!     let list = list!(a = 1, b = 2);
 //!    
+//!     // An unnamed list (of R objects) using the List wrapper.
+//!     let list = r!(List(vec![1, 2, 3]));
+//!     let list = r!(List(vec!["a", "b", "c"]));
+//!     let list = r!(List(&[r!("a"), r!(1), r!(2.0)]));
+//!
 //!     // A symbol
 //!     let sym = sym!(wombat);
+//!
+//!     // A R vector using collect_robj()
+//!     let vector = (0..3).map(|x| x * 10).collect_robj();
 //! }
 //! ```
 //!
@@ -484,17 +495,17 @@ mod tests {
     }
 
     #[extendr]
-    pub fn f64_iter(x: RealIter) -> RealIter {
+    pub fn f64_iter(x: Real) -> Real {
         x
     }
 
     #[extendr]
-    pub fn i32_iter(x: IntegerIter) -> IntegerIter {
+    pub fn i32_iter(x: Int) -> Int {
         x
     }
 
     #[extendr]
-    pub fn bool_iter(x: LogicalIter) -> LogicalIter {
+    pub fn bool_iter(x: Logical) -> Logical {
         x
     }
 
@@ -641,19 +652,19 @@ mod tests {
                 assert_eq!(new_owned(wrap__bool_slice(robj.get())), robj);
 
                 // #[extendr]
-                // pub fn f64_iter(x: RealIter) -> RealIter { x }
+                // pub fn f64_iter(x: Real) -> Real { x }
 
                 let robj = r!([1., 2., 3.]);
                 assert_eq!(new_owned(wrap__f64_iter(robj.get())), robj);
 
                 // #[extendr]
-                // pub fn i32_iter(x: IntegerIter) -> IntegerIter { x }
+                // pub fn i32_iter(x: Int) -> Int { x }
 
                 let robj = r!([1, 2, 3]);
                 assert_eq!(new_owned(wrap__i32_iter(robj.get())), robj);
 
                 // #[extendr]
-                // pub fn bool_iter(x: LogicalIter) -> LogicalIter { x }
+                // pub fn bool_iter(x: Logical) -> Logical { x }
 
                 let robj = r!([TRUE, FALSE, TRUE]);
                 assert_eq!(new_owned(wrap__bool_iter(robj.get())), robj);

--- a/extendr-api/src/logical.rs
+++ b/extendr-api/src/logical.rs
@@ -16,7 +16,7 @@ impl Bool {
 
     /// Test if TRUE
     pub fn is_true(&self) -> bool {
-        self.0 != 0
+        self.0 == 1
     }
 
     /// Test if FALSE

--- a/extendr-api/src/prelude.rs
+++ b/extendr-api/src/prelude.rs
@@ -39,7 +39,8 @@ pub use super::thread_safety::{
 };
 
 pub use super::wrapper::{
-    Int, Real, Logical, IntIn, RealIn, LogicalIn, Character, Env, Expr, Func, Lang, List, Nullable, Pairlist, Primitive, Promise, Raw, Symbol,
+    Character, Env, Expr, Func, Int, IntIn, Lang, List, Logical, LogicalIn, Nullable, Pairlist,
+    Primitive, Promise, Raw, Real, RealIn, Symbol,
 };
 
 #[cfg(feature = "ndarray")]

--- a/extendr-api/src/prelude.rs
+++ b/extendr-api/src/prelude.rs
@@ -39,7 +39,7 @@ pub use super::thread_safety::{
 };
 
 pub use super::wrapper::{
-    Character, Env, Expr, Func, Lang, List, Nullable, Pairlist, Primitive, Promise, Raw, Symbol,
+    Int, Real, Logical, IntIn, RealIn, LogicalIn, Character, Env, Expr, Func, Lang, List, Nullable, Pairlist, Primitive, Promise, Raw, Symbol,
 };
 
 #[cfg(feature = "ndarray")]

--- a/extendr-api/src/prelude.rs
+++ b/extendr-api/src/prelude.rs
@@ -39,8 +39,7 @@ pub use super::thread_safety::{
 };
 
 pub use super::wrapper::{
-    Character, Env, Expr, Func, Int, IntIn, Lang, List, Logical, LogicalIn, Nullable, Pairlist,
-    Primitive, Promise, Raw, Real, RealIn, Symbol,
+    Character, Env, Expr, Func, Lang, List, Nullable, Pairlist, Primitive, Promise, Raw, Symbol,
 };
 
 #[cfg(feature = "ndarray")]
@@ -52,5 +51,5 @@ pub use ndarray::*;
 pub use extendr_macros::{extendr, extendr_module};
 
 pub use super::iter::{
-    EnvIter, IntegerIter, ListIter, LogicalIter, PairlistIter, PairlistTagIter, RealIter, StrIter,
+    EnvIter, Int, ListIter, Logical, PairlistIter, PairlistTagIter, Real, StrIter,
 };

--- a/extendr-api/src/robj/from_robj.rs
+++ b/extendr-api/src/robj/from_robj.rs
@@ -153,9 +153,9 @@ macro_rules! impl_iter_from_robj {
 
 impl_iter_from_robj!(StrIter, as_str_iter, "Not a character vector.");
 impl_iter_from_robj!(ListIter, as_list_iter, "Not a list.");
-impl_iter_from_robj!(IntegerIter<'a>, as_integer_iter, "Not an integer vector.");
-impl_iter_from_robj!(RealIter<'a>, as_real_iter, "Not a real vector.");
-impl_iter_from_robj!(LogicalIter<'a>, as_logical_iter, "Not a logical vector.");
+impl_iter_from_robj!(IntegerIter, as_integer_iter, "Not an integer vector.");
+impl_iter_from_robj!(RealIter, as_real_iter, "Not a real vector.");
+impl_iter_from_robj!(LogicalIter, as_logical_iter, "Not a logical vector.");
 
 /// Pass-through Robj conversion.
 impl<'a> FromRobj<'a> for Robj {

--- a/extendr-api/src/robj/from_robj.rs
+++ b/extendr-api/src/robj/from_robj.rs
@@ -153,9 +153,9 @@ macro_rules! impl_iter_from_robj {
 
 impl_iter_from_robj!(StrIter, as_str_iter, "Not a character vector.");
 impl_iter_from_robj!(ListIter, as_list_iter, "Not a list.");
-impl_iter_from_robj!(IntegerIter, as_integer_iter, "Not an integer vector.");
-impl_iter_from_robj!(RealIter, as_real_iter, "Not a real vector.");
-impl_iter_from_robj!(LogicalIter, as_logical_iter, "Not a logical vector.");
+impl_iter_from_robj!(Int, as_integer_iter, "Not an integer vector.");
+impl_iter_from_robj!(Real, as_real_iter, "Not a real vector.");
+impl_iter_from_robj!(Logical, as_logical_iter, "Not a logical vector.");
 
 /// Pass-through Robj conversion.
 impl<'a> FromRobj<'a> for Robj {

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -497,23 +497,23 @@ impl_from_into_iter! {&'a [T]}
 impl_from_as_iterator! {Range<T>}
 impl_from_as_iterator! {RangeInclusive<T>}
 
-impl From<RealIter> for Robj {
+impl From<Real> for Robj {
     /// Convert a real iterator into a vector.
-    fn from(val: RealIter) -> Self {
+    fn from(val: Real) -> Self {
         val.collect_robj()
     }
 }
 
-impl From<IntegerIter> for Robj {
+impl From<Int> for Robj {
     /// Convert an integer iterator into a vector.
-    fn from(val: IntegerIter) -> Self {
+    fn from(val: Int) -> Self {
         val.collect_robj()
     }
 }
 
-impl From<LogicalIter> for Robj {
+impl From<Logical> for Robj {
     /// Convert a logical iterator into a vector.
-    fn from(val: LogicalIter) -> Self {
+    fn from(val: Logical) -> Self {
         val.collect_robj()
     }
 }

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -497,21 +497,21 @@ impl_from_into_iter! {&'a [T]}
 impl_from_as_iterator! {Range<T>}
 impl_from_as_iterator! {RangeInclusive<T>}
 
-impl<'a> From<RealIter<'a>> for Robj {
+impl From<RealIter> for Robj {
     /// Convert a real iterator into a vector.
     fn from(val: RealIter) -> Self {
         val.collect_robj()
     }
 }
 
-impl<'a> From<IntegerIter<'a>> for Robj {
+impl From<IntegerIter> for Robj {
     /// Convert an integer iterator into a vector.
     fn from(val: IntegerIter) -> Self {
         val.collect_robj()
     }
 }
 
-impl<'a> From<LogicalIter<'a>> for Robj {
+impl From<LogicalIter> for Robj {
     /// Convert a logical iterator into a vector.
     fn from(val: LogicalIter) -> Self {
         val.collect_robj()

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -299,9 +299,9 @@ impl Robj {
     /// assert_eq!(tot, 6);
     /// }
     /// ```
-    pub fn as_integer_iter(&self) -> Option<IntegerIter> {
+    pub fn as_integer_iter(&self) -> Option<Int> {
         if let Some(slice) = self.as_integer_slice() {
-            Some(IntegerIter::from_slice(self.to_owned(), slice))
+            Some(Int::from_slice(self.to_owned(), slice))
         } else {
             None
         }
@@ -372,9 +372,9 @@ impl Robj {
     ///     assert_eq!((nt, nf, nna), (1, 1, 1));
     /// }
     /// ```
-    pub fn as_logical_iter(&self) -> Option<LogicalIter> {
+    pub fn as_logical_iter(&self) -> Option<Logical> {
         if let Some(slice) = self.as_logical_slice() {
-            Some(LogicalIter::from_slice(self.to_owned(), slice))
+            Some(Logical::from_slice(self.to_owned(), slice))
         } else {
             None
         }
@@ -414,9 +414,9 @@ impl Robj {
     ///     assert_eq!(tot, 6.);
     /// }
     /// ```
-    pub fn as_real_iter(&self) -> Option<RealIter> {
+    pub fn as_real_iter(&self) -> Option<Real> {
         if let Some(slice) = self.as_real_slice() {
-            Some(RealIter::from_slice(self.to_owned(), slice))
+            Some(Real::from_slice(self.to_owned(), slice))
         } else {
             None
         }
@@ -901,7 +901,7 @@ impl Robj {
     ///    assert_eq!(dim, vec![2, 2]);
     /// }
     /// ```
-    pub fn dim(&self) -> Option<IntegerIter> {
+    pub fn dim(&self) -> Option<Int> {
         if let Some(dim) = self.get_attrib(dim_symbol()) {
             dim.as_integer_iter()
         } else {

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -299,8 +299,7 @@ impl Robj {
     /// assert_eq!(tot, 6);
     /// }
     /// ```
-    pub fn as_integer_iter(&self) -> Option<IntegerIter>
-    {
+    pub fn as_integer_iter(&self) -> Option<IntegerIter> {
         if let Some(slice) = self.as_integer_slice() {
             Some(IntegerIter::from_slice(self.to_owned(), slice))
         } else {
@@ -902,8 +901,7 @@ impl Robj {
     ///    assert_eq!(dim, vec![2, 2]);
     /// }
     /// ```
-    pub fn dim(&self) -> Option<IntegerIter>
-    {
+    pub fn dim(&self) -> Option<IntegerIter> {
         if let Some(dim) = self.get_attrib(dim_symbol()) {
             dim.as_integer_iter()
         } else {

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -299,12 +299,10 @@ impl Robj {
     /// assert_eq!(tot, 6);
     /// }
     /// ```
-    pub fn as_integer_iter<'a>(&self) -> Option<IntegerIter<'a>>
-    where
-        Self: 'a,
+    pub fn as_integer_iter(&self) -> Option<IntegerIter>
     {
         if let Some(slice) = self.as_integer_slice() {
-            Some(slice.iter().cloned())
+            Some(IntegerIter::from_slice(self.to_owned(), slice))
         } else {
             None
         }
@@ -377,7 +375,7 @@ impl Robj {
     /// ```
     pub fn as_logical_iter(&self) -> Option<LogicalIter> {
         if let Some(slice) = self.as_logical_slice() {
-            Some(slice.iter().cloned())
+            Some(LogicalIter::from_slice(self.to_owned(), slice))
         } else {
             None
         }
@@ -419,7 +417,7 @@ impl Robj {
     /// ```
     pub fn as_real_iter(&self) -> Option<RealIter> {
         if let Some(slice) = self.as_real_slice() {
-            Some(slice.iter().cloned())
+            Some(RealIter::from_slice(self.to_owned(), slice))
         } else {
             None
         }
@@ -904,10 +902,7 @@ impl Robj {
     ///    assert_eq!(dim, vec![2, 2]);
     /// }
     /// ```
-    pub fn dim<'a>(&self) -> Option<IntegerIter<'a>>
-    where
-        Self: 'a,
-        Robj: 'a,
+    pub fn dim(&self) -> Option<IntegerIter>
     {
         if let Some(dim) = self.get_attrib(dim_symbol()) {
             dim.as_integer_iter()

--- a/extendr-api/src/robj/rinternals.rs
+++ b/extendr-api/src/robj/rinternals.rs
@@ -111,7 +111,9 @@ impl Robj {
     /// test! {
     ///    let my_fun = base_env().find_function(sym!(ls)).unwrap();
     ///    assert_eq!(my_fun.is_function(), true);
-    ///    assert!(base_env().find_function(sym!(qwertyuiop)).is_none());
+    ///
+    ///    // Note: this may crash on some versions of windows which don't support unwinding.
+    ///    // assert!(base_env().find_function(sym!(qwertyuiop)).is_none());
     /// }
     /// ```
     pub fn find_function<K: Into<Robj>>(&self, key: K) -> Option<Robj> {

--- a/extendr-api/src/robj/rinternals.rs
+++ b/extendr-api/src/robj/rinternals.rs
@@ -159,7 +159,9 @@ impl Robj {
     ///        .find_var(sym!(iris)).unwrap().eval_promise().unwrap();
     ///    assert_eq!(iris_dataframe.is_frame(), true);
     ///    assert_eq!(iris_dataframe.len(), 5);
-    ///    assert_eq!(global_env().find_var(sym!(imnotasymbol)), None);
+    ///
+    ///    // Note: this may crash on some versions of windows which don't support unwinding.
+    ///    //assert_eq!(global_env().find_var(sym!(imnotasymbol)), None);
     /// }
     /// ```
     pub fn find_var<K: Into<Robj>>(&self, key: K) -> Option<Robj> {

--- a/extendr-api/src/robj/tests.rs
+++ b/extendr-api/src/robj/tests.rs
@@ -227,7 +227,7 @@ fn output_iterator_test() {
 // Test that we can use Iterators as the input to functions.
 // eg.
 // #[extendr]
-// fn fred(a: RealIter, b: RealIter) -> RealIter {
+// fn fred(a: Real, b: Real) -> Robj {
 // }
 #[test]
 fn input_iterator_test() {
@@ -244,18 +244,18 @@ fn input_iterator_test() {
 
         let src: &[i32] = &[1, 2, 3];
         let robj = Robj::from(src);
-        let iter = <IntegerIter>::from_robj(&robj).unwrap();
+        let iter = <Int>::from_robj(&robj).unwrap();
         assert_eq!(iter.collect::<Vec<_>>(), src);
 
         let src: &[f64] = &[1., 2., 3.];
         let robj = Robj::from(src);
-        let iter = <RealIter>::from_robj(&robj).unwrap();
+        let iter = <Real>::from_robj(&robj).unwrap();
         assert_eq!(iter.collect::<Vec<_>>(), src);
 
         /*
         let src: &[Bool] = &[TRUE, FALSE, TRUE];
         let robj = Robj::from(src);
-        let iter = <LogicalIter>::from_robj(&robj).unwrap();
+        let iter = <Logical>::from_robj(&robj).unwrap();
         assert_eq!(iter.collect::<Vec<_>>(), src);
         */
     }

--- a/extendr-api/src/thread_safety.rs
+++ b/extendr-api/src/thread_safety.rs
@@ -96,7 +96,7 @@ pub fn throw_r_error<S: AsRef<str>>(s: S) {
 }
 
 /// Wrap an R function such as Rf_findFunction and convert errors and panics into results.
-/// ```
+/// ```ignore
 /// use extendr_api::prelude::*;
 /// test! {
 ///    let res = catch_r_error(|| unsafe {
@@ -138,6 +138,8 @@ where
         let cleandata = std::mem::transmute(&x);
         let cont = R_MakeUnwindCont();
         Rf_protect(cont);
+
+        // Note that catch_unwind does not work for 32 bit windows targets.
         let res = match std::panic::catch_unwind(|| {
             R_UnwindProtect(fun, data, cleanfun, cleandata, cont)
         }) {

--- a/extendr-api/src/wrapper.rs
+++ b/extendr-api/src/wrapper.rs
@@ -2,40 +2,9 @@
 //! They do not contain an Robj (see array.rs for an example of this).
 
 #[doc(hidden)]
-use crate::iter::IntegerIter;
 use crate::*;
 #[doc(hidden)]
 use libR_sys::*;
-
-/// Wrapper for creating integer vectors.
-///
-/// ```
-/// use extendr_api::prelude::*;
-///
-/// test! {
-///     // Convert Rust integer iterator to R vector.
-///     let rint = r!(Int(0..3));
-///     assert_eq!(rint, r!([0, 1, 2]));
-///
-///     // Convert R vector to integer iterator.
-///     let rustint = <IntIn>::from_robj(&rint)?;
-///     assert_eq!(rustint.0.collect::<Vec<_>>(), vec![0, 1, 2]);
-/// }
-/// ```
-#[derive(Debug, PartialEq, Clone)]
-pub struct Int<T>(pub T);
-
-pub type IntIn = Int<IntegerIter>;
-
-#[derive(Debug, PartialEq, Clone)]
-pub struct Real<T>(pub T);
-
-pub type RealIn = Real<RealIter>;
-
-#[derive(Debug, PartialEq, Clone)]
-pub struct Logical<T>(pub T);
-
-pub type LogicalIn = Logical<LogicalIter>;
 
 /// Wrapper for creating symbols.
 ///
@@ -218,123 +187,6 @@ pub struct Primitive<'a>(pub &'a str);
 pub enum Nullable<T> {
     NotNull(T),
     Null,
-}
-
-impl<T> From<Int<T>> for Robj
-where
-    T: IntoIterator,
-    T::Item: ToVectorValue,
-{
-    /// Make a vector object from an integer iterator.
-    /// ```
-    /// use extendr_api::prelude::*;
-    /// test! {
-    ///     let vector = r!(Int(&[1, 2]));
-    ///     assert_eq!(vector.len(), 2);
-    /// }
-    /// ``````
-    fn from(val: Int<T>) -> Self {
-        val.0.into_iter().collect_robj()
-    }
-}
-
-impl<'a> FromRobj<'a> for IntIn {
-    /// Convert a Robj to an integer iterator.
-    /// Prefer to use [Robj::as_integer_iter].
-    /// ```
-    /// use extendr_api::prelude::*;
-    /// test! {
-    ///     let robj = r!([1, 2, 3]);
-    ///     let rust = <IntIn>::from_robj(&robj)?;
-    ///     assert_eq!(rust.0.sum::<i32>(), 6);
-    ///     assert_eq!(robj.as_integer_iter().unwrap().sum::<i32>(), 6);
-    /// }
-    /// ```
-    fn from_robj(robj: &'a Robj) -> std::result::Result<Self, &'static str> {
-        if let Some(iter) = robj.as_integer_iter() {
-            Ok(Int(iter))
-        } else {
-            Err("Expected integer vector.")
-        }
-    }
-}
-
-impl<T> From<Real<T>> for Robj
-where
-    T: IntoIterator,
-    T::Item: ToVectorValue,
-{
-    /// Make a vector object from an integer iterator.
-    /// ```
-    /// use extendr_api::prelude::*;
-    /// test! {
-    ///     let vector = r!(Real(&[1.0, 2.0]));
-    ///     assert_eq!(vector.len(), 2);
-    /// }
-    /// ``````
-    fn from(val: Real<T>) -> Self {
-        val.0.into_iter().collect_robj()
-    }
-}
-
-impl<'a> FromRobj<'a> for RealIn {
-    /// Convert a Robj to an integer iterator.
-    /// Synonymous with [Robj::as_real_iter].
-    /// ```
-    /// use extendr_api::prelude::*;
-    /// test! {
-    ///     let robj = r!([1.0, 2.0, 3.0]);
-    ///     let rust = <RealIn>::from_robj(&robj)?;
-    ///     assert_eq!(rust.0.sum::<f64>(), 6.0);
-    ///     assert_eq!(robj.as_real_iter().unwrap().sum::<f64>(), 6.0);
-    /// }
-    /// ```
-    fn from_robj(robj: &'a Robj) -> std::result::Result<Self, &'static str> {
-        if let Some(iter) = robj.as_real_iter() {
-            Ok(Real(iter))
-        } else {
-            Err("Expected real vector.")
-        }
-    }
-}
-
-impl<T> From<Logical<T>> for Robj
-where
-    T: IntoIterator,
-    T::Item: ToVectorValue,
-{
-    /// Make a vector object from a logical iterator.
-    /// ```
-    /// use extendr_api::prelude::*;
-    /// test! {
-    ///     let vector = r!(Logical(&[TRUE, FALSE]));
-    ///     assert_eq!(vector.len(), 2);
-    /// }
-    /// ``````
-    fn from(val: Logical<T>) -> Self {
-        val.0.into_iter().collect_robj()
-    }
-}
-
-impl<'a> FromRobj<'a> for LogicalIn {
-    /// Convert a Robj to an logical iterator.
-    /// Synonymous with [Robj::as_logical_iter].
-    /// ```
-    /// use extendr_api::prelude::*;
-    /// test! {
-    ///     let robj = r!([TRUE, TRUE, TRUE]);
-    ///     let mut rust = <LogicalIn>::from_robj(&robj)?;
-    ///     assert_eq!(rust.0.all(|b| b.is_true()), true);
-    ///     assert_eq!(robj.as_logical_iter().unwrap().all(|b| b.is_true()), true);
-    /// }
-    /// ```
-    fn from_robj(robj: &'a Robj) -> std::result::Result<Self, &'static str> {
-        if let Some(iter) = robj.as_logical_iter() {
-            Ok(Logical(iter))
-        } else {
-            Err("Expected logical vector.")
-        }
-    }
 }
 
 impl<T> From<List<T>> for Robj

--- a/extendr-api/src/wrapper.rs
+++ b/extendr-api/src/wrapper.rs
@@ -1,12 +1,11 @@
 //! Wrappers are lightweight proxies for references to R datatypes.
 //! They do not contain an Robj (see array.rs for an example of this).
 
+#[doc(hidden)]
+use crate::iter::IntegerIter;
 use crate::*;
 #[doc(hidden)]
 use libR_sys::*;
-#[doc(hidden)]
-
-use crate::iter::IntegerIter;
 
 /// Wrapper for creating integer vectors.
 ///

--- a/extendr-api/src/wrapper.rs
+++ b/extendr-api/src/wrapper.rs
@@ -6,6 +6,38 @@ use crate::*;
 use libR_sys::*;
 #[doc(hidden)]
 
+use crate::iter::IntegerIter;
+
+/// Wrapper for creating integer vectors.
+///
+/// ```
+/// use extendr_api::prelude::*;
+///
+/// test! {
+///     // Convert Rust integer iterator to R vector.
+///     let rint = r!(Int(0..3));
+///     assert_eq!(rint, r!([0, 1, 2]));
+///
+///     // Convert R vector to integer iterator.
+///     let rustint = <IntIn>::from_robj(&rint)?;
+///     assert_eq!(rustint.0.collect::<Vec<_>>(), vec![0, 1, 2]);
+/// }
+/// ```
+#[derive(Debug, PartialEq, Clone)]
+pub struct Int<T>(pub T);
+
+pub type IntIn = Int<IntegerIter>;
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct Real<T>(pub T);
+
+pub type RealIn = Real<RealIter>;
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct Logical<T>(pub T);
+
+pub type LogicalIn = Logical<LogicalIter>;
+
 /// Wrapper for creating symbols.
 ///
 /// ```
@@ -189,13 +221,130 @@ pub enum Nullable<T> {
     Null,
 }
 
+impl<T> From<Int<T>> for Robj
+where
+    T: IntoIterator,
+    T::Item: ToVectorValue,
+{
+    /// Make a vector object from an integer iterator.
+    /// ```
+    /// use extendr_api::prelude::*;
+    /// test! {
+    ///     let vector = r!(Int(&[1, 2]));
+    ///     assert_eq!(vector.len(), 2);
+    /// }
+    /// ``````
+    fn from(val: Int<T>) -> Self {
+        val.0.into_iter().collect_robj()
+    }
+}
+
+impl<'a> FromRobj<'a> for IntIn {
+    /// Convert a Robj to an integer iterator.
+    /// Prefer to use [Robj::as_integer_iter].
+    /// ```
+    /// use extendr_api::prelude::*;
+    /// test! {
+    ///     let robj = r!([1, 2, 3]);
+    ///     let rust = <IntIn>::from_robj(&robj)?;
+    ///     assert_eq!(rust.0.sum::<i32>(), 6);
+    ///     assert_eq!(robj.as_integer_iter().unwrap().sum::<i32>(), 6);
+    /// }
+    /// ```
+    fn from_robj(robj: &'a Robj) -> std::result::Result<Self, &'static str> {
+        if let Some(iter) = robj.as_integer_iter() {
+            Ok(Int(iter))
+        } else {
+            Err("Expected integer vector.")
+        }
+    }
+}
+
+impl<T> From<Real<T>> for Robj
+where
+    T: IntoIterator,
+    T::Item: ToVectorValue,
+{
+    /// Make a vector object from an integer iterator.
+    /// ```
+    /// use extendr_api::prelude::*;
+    /// test! {
+    ///     let vector = r!(Real(&[1.0, 2.0]));
+    ///     assert_eq!(vector.len(), 2);
+    /// }
+    /// ``````
+    fn from(val: Real<T>) -> Self {
+        val.0.into_iter().collect_robj()
+    }
+}
+
+impl<'a> FromRobj<'a> for RealIn {
+    /// Convert a Robj to an integer iterator.
+    /// Synonymous with [Robj::as_real_iter].
+    /// ```
+    /// use extendr_api::prelude::*;
+    /// test! {
+    ///     let robj = r!([1.0, 2.0, 3.0]);
+    ///     let rust = <RealIn>::from_robj(&robj)?;
+    ///     assert_eq!(rust.0.sum::<f64>(), 6.0);
+    ///     assert_eq!(robj.as_real_iter().unwrap().sum::<f64>(), 6.0);
+    /// }
+    /// ```
+    fn from_robj(robj: &'a Robj) -> std::result::Result<Self, &'static str> {
+        if let Some(iter) = robj.as_real_iter() {
+            Ok(Real(iter))
+        } else {
+            Err("Expected real vector.")
+        }
+    }
+}
+
+impl<T> From<Logical<T>> for Robj
+where
+    T: IntoIterator,
+    T::Item: ToVectorValue,
+{
+    /// Make a vector object from a logical iterator.
+    /// ```
+    /// use extendr_api::prelude::*;
+    /// test! {
+    ///     let vector = r!(Logical(&[TRUE, FALSE]));
+    ///     assert_eq!(vector.len(), 2);
+    /// }
+    /// ``````
+    fn from(val: Logical<T>) -> Self {
+        val.0.into_iter().collect_robj()
+    }
+}
+
+impl<'a> FromRobj<'a> for LogicalIn {
+    /// Convert a Robj to an logical iterator.
+    /// Synonymous with [Robj::as_logical_iter].
+    /// ```
+    /// use extendr_api::prelude::*;
+    /// test! {
+    ///     let robj = r!([TRUE, TRUE, TRUE]);
+    ///     let mut rust = <LogicalIn>::from_robj(&robj)?;
+    ///     assert_eq!(rust.0.all(|b| b.is_true()), true);
+    ///     assert_eq!(robj.as_logical_iter().unwrap().all(|b| b.is_true()), true);
+    /// }
+    /// ```
+    fn from_robj(robj: &'a Robj) -> std::result::Result<Self, &'static str> {
+        if let Some(iter) = robj.as_logical_iter() {
+            Ok(Logical(iter))
+        } else {
+            Err("Expected logical vector.")
+        }
+    }
+}
+
 impl<T> From<List<T>> for Robj
 where
     T: IntoIterator,
     T::IntoIter: ExactSizeIterator,
     T::Item: Into<Robj>,
 {
-    /// Make a list object from an array of Robjs.
+    /// Make a list object from an iterator of Robjs.
     /// ```
     /// use extendr_api::prelude::*;
     /// test! {
@@ -214,7 +363,7 @@ where
     T::IntoIter: ExactSizeIterator,
     T::Item: Into<Robj>,
 {
-    /// Make an expression object from an array of Robjs.
+    /// Make an expression object from an iterator of Robjs.
     /// ```
     /// use extendr_api::prelude::*;
     /// test! {


### PR DESCRIPTION
This PR adds the wrappers Int, Real and Logical as well as the types IntIn, RealIn and LogicalIn for parameters.

For example, when returning an integer vector, we should be able to do:

```
fn add(a: IntIn, b:IntIn) -> Robj {
   Int(a.zip(b).map(|(a, b)| a + b)).into()
}
```
(Need to confirm this).

We may need to implement IntoIterator for them all.

Also, this may be too complex. I'm happy if we just keep the iterators.
