### PR TITLE
Dumb rextendr integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -205,6 +205,20 @@ jobs:
             cat("::warning:: R version is not compatible with 'rextendr'\n")
           } else {
             cat("::group::Checking 'rextendr'\n")
+            
+            patch.crates_io <-
+              paste(
+                paste0(
+                  "extendr-api = { path = \"",
+                  normalizePath(file.path(getwd(), "extendr-api"), winslash = "/"),
+                  "\" }"),
+                paste0(
+                  "extendr-macros = { path = \"",
+                  normalizePath(file.path(getwd(), "extendr-macros"), winslash = "/"),
+                  "\" }"),
+                sep = ";")
+
+            Sys.setenv(REXTENDR_PATCH_CRATES_IO = patch.crates_io)
             rcmdcheck::rcmdcheck(
               path = "tests/rextendr", 
               args = c("--no-manual", "--as-cran", "--force-multiarch"), 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,6 +155,7 @@ jobs:
         run : |
           git clone https://github.com/extendr/rextendr ./tests/rextendr
 
+      # Dependencies from both test packages are combined
       - name: Query dependencies for integration testing
         run: |
           install.packages('remotes')
@@ -176,6 +177,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
           restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
 
+      # Currently rextendr requires R > 4, so if R version is older (e.g. 3.6.3), rextendr tests are omitted
       - name: Install R dependencies for integration testing
         run: |
           remotes::install_deps(pkgdir = "tests/extendrtests", dependencies = TRUE)
@@ -185,6 +187,7 @@ jobs:
         
       # Windows: modified PATH will launch 32-bit Rscript if the build targets only i686/i386, so no conflict will arise
       # Rust pseudo multi-targeting: R CMD CHECK receives an extra argument '--no-multiarch' if BUILD_TARGETS is not 'default' and does not contain any commas
+      # If R is older than 4.0, rextendr is not tested and a warning is emitted. 
       - name: Run R integration tests
         id: r_integration_tests
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - master
-      - 'rextendr-tests'
   pull_request:
     branches:
       - main
@@ -196,6 +195,10 @@ jobs:
         shell: Rscript {0}
         
       # If R is older than 4.0, rextendr is not tested and a warning is emitted. 
+      # With https://github.com/extendr/rextendr/pull/31
+      # rextendr can be configured using environment variables.
+      # 'patch.crates_io' is used to point libraries to local copies of
+      # extendr-api and extendr-macros, so rextendr tests current version of extendr-*
       - name: Run R integration tests using {rextendr}
         id: rextendr_check
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - master
+      - 'rextendr-tests'
   pull_request:
     branches:
       - main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -172,39 +172,62 @@ jobs:
       - name: Install R dependencies for integration testing
         run: |
           remotes::install_deps(pkgdir = "tests/extendrtests", dependencies = TRUE)
-          if (as.integer(R.version$major) >= 4) { remotes::install_deps(pkgdir = "tests/rextendr", dependencies = TRUE) }
+          if (as.integer(R.version$major) >= 4) { 
+            remotes::install_deps(pkgdir = "tests/rextendr", dependencies = TRUE)
+          }
           remotes::install_cran("rcmdcheck")
         shell: Rscript {0}
         
       # Windows: modified PATH will launch 32-bit Rscript if the build targets only i686/i386, so no conflict will arise
       # Rust pseudo multi-targeting: R CMD CHECK receives an extra argument '--no-multiarch' if BUILD_TARGETS is not 'default' and does not contain any commas
-      # If R is older than 4.0, rextendr is not tested and a warning is emitted. 
-      - name: Run R integration tests
-        id: r_integration_tests
+      - name: Run R integration tests using {extendrtests}
+        id: extendrtests_check
         env:
           _R_CHECK_CRAN_INCOMING_REMOTE_: false
         run: |
           cat("::group::Checking 'extendrtests'\n")
-          setwd("tests/extendrtests")
-          rcmdcheck::rcmdcheck(path = ".", args = c("--no-manual", "--as-cran", "--force-multiarch"), error_on = "warning", check_dir = "../../../")
+          rcmdcheck::rcmdcheck(
+            path = "tests/extendrtests", 
+            args = c("--no-manual", "--as-cran", "--force-multiarch"),
+            error_on = "warning", 
+            check_dir = "extendrtests_check"
+          )
           cat("::endgroup::\n")
-
+        shell: Rscript {0}
+        
+      # If R is older than 4.0, rextendr is not tested and a warning is emitted. 
+      - name: Run R integration tests using {rextendr}
+        id: rextendr_check
+        env:
+          _R_CHECK_CRAN_INCOMING_REMOTE_: false
+        run: |
           if (as.integer(R.version$major) < 4) {
             cat("::warning:: R version is not compatible with 'rextendr'\n")
           } else {
             cat("::group::Checking 'rextendr'\n")
-            setwd("../rextendr")
-            rcmdcheck::rcmdcheck(path = ".", args = c("--no-manual", "--as-cran", "--force-multiarch"), error_on = "warning", check_dir = "../../../")
+            rcmdcheck::rcmdcheck(
+              path = "tests/rextendr", 
+              args = c("--no-manual", "--as-cran", "--force-multiarch"), 
+              error_on = "warning", 
+              check_dir = "rextendr_check")
             cat("::endgroup::\n")
           }
         shell: Rscript {0}
-        
-      - name: Upload check results from R integration tests
-        if: failure()
+
+
+      - name: Upload extendrtests check results from R integration tests
+        if: steps.extendrtests_check.outcome != 'success'
         uses: actions/upload-artifact@main
         with:
-          name:  ${{ matrix.config.os }}-R-${{ matrix.config.r }}-rust-${{ matrix.config.rust-version }}
-          path: check
+          name:  extendrtests-${{ matrix.config.os }}-R-${{ matrix.config.r }}-rust-${{ matrix.config.rust-version }}
+          path: extendrtests_check
+
+      - name: Upload rextendr check results from R integration tests
+        if: steps.rextendr_check.outcome != 'success'
+        uses: actions/upload-artifact@main
+        with:
+          name:  rextendr-${{ matrix.config.os }}-R-${{ matrix.config.r }}-rust-${{ matrix.config.rust-version }}
+          path: rextendr_check
 
 
   # All tests under this job are run with R devel and freshly generated bindings.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -172,6 +172,7 @@ jobs:
       - name: Install R dependencies for integration testing
         run: |
           remotes::install_deps(pkgdir = "tests/extendrtests", dependencies = TRUE)
+          remotes::install_deps(pkgdir = "tests/rextendr", dependencies = TRUE)
           remotes::install_cran("rcmdcheck")
         shell: Rscript {0}
         

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,17 +168,30 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
 
       # Currently rextendr requires R > 4, so if R version is older (e.g. 3.6.3), rextendr tests are omitted
-      - name: Install R dependencies for integration testing
+      # Regex is used to inject absolute path into Cargo.toml
+      - name: Install dependencies & configure R for integration testing
         run: |
           remotes::install_deps(pkgdir = "tests/extendrtests", dependencies = TRUE)
           if (as.integer(R.version$major) >= 4) { 
             remotes::install_deps(pkgdir = "tests/rextendr", dependencies = TRUE)
           }
           remotes::install_cran("rcmdcheck")
+
+          api_path <- normalizePath(file.path(getwd(), "extendr-api"), winslash = "/")
+          toml_path <- file.path(getwd(), "tests", "extendrtests", "src", "rust", "Cargo.toml")
+          lines <- readLines(toml_path)
+          lines <- gsub(
+            "(^\\s*extendr-api\\s*=\\s*\\{\\s*path\\s*=\\s*\")(.*?)(\"\\s*\\})",
+            paste0("\\1", api_path, "\\3"),
+            lines
+          )
+          writeLines(lines, toml_path)
         shell: Rscript {0}
         
       # Windows: modified PATH will launch 32-bit Rscript if the build targets only i686/i386, so no conflict will arise
       # Rust pseudo multi-targeting: R CMD CHECK receives an extra argument '--no-multiarch' if BUILD_TARGETS is not 'default' and does not contain any commas
+      # To enable RStudio support, extendrtests should be installable from 'extendr/tests/extendrtests',
+      # for this work directory should be modified and then reverted back
       - name: Run R integration tests using {extendrtests}
         id: extendrtests_check
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -151,10 +151,14 @@ jobs:
             echo "::endgroup::"
           }
 
+      - name: Obtain 'rextendr'
+        run : |
+          git clone https://github.com/extendr/rextendr ./tests/
+
       - name: Query dependencies for integration testing
         run: |
           install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(pkgdir = "tests/extendrtests", dependencies = TRUE), ".github/depends.Rds", version = 2)
+          saveRDS(unique(rbind(remotes::dev_package_deps(pkgdir = "tests/extendrtests", dependencies = TRUE), remotes::dev_package_deps(pkgdir = "tests/rextendr", dependencies = TRUE))), ".github/depends.Rds", version = 2)
           writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
         shell: Rscript {0}
 
@@ -179,7 +183,9 @@ jobs:
           _R_CHECK_CRAN_INCOMING_REMOTE_: false
         run: |
           setwd("tests/extendrtests")
-          rcmdcheck::rcmdcheck(path = ".", args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "../../../")
+          rcmdcheck::rcmdcheck(path = ".", args = c("--no-manual", "--as-cran", "--force-multiarch"), error_on = "warning", check_dir = "../../../")
+          setwd("../rextendr")
+          rcmdcheck::rcmdcheck(path = ".", args = c("--no-manual", "--force-multiarch"), error_on = "warning", check_dir = "../../../")
         shell: Rscript {0}
         
       - name: Upload check results from R integration tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,7 +153,7 @@ jobs:
 
       - name: Obtain 'rextendr'
         run : |
-          git clone https://github.com/extendr/rextendr ./tests/
+          git clone https://github.com/extendr/rextendr ./tests/rextendr
 
       - name: Query dependencies for integration testing
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,7 +158,14 @@ jobs:
       - name: Query dependencies for integration testing
         run: |
           install.packages('remotes')
-          saveRDS(unique(rbind(remotes::dev_package_deps(pkgdir = "tests/extendrtests", dependencies = TRUE), remotes::dev_package_deps(pkgdir = "tests/rextendr", dependencies = TRUE))), ".github/depends.Rds", version = 2)
+          saveRDS(
+            unique(
+              rbind(
+                remotes::dev_package_deps(pkgdir = "tests/extendrtests", dependencies = TRUE), 
+                remotes::dev_package_deps(pkgdir = "tests/rextendr", dependencies = TRUE))),
+            ".github/depends.Rds", 
+            version = 2
+          )
           writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
         shell: Rscript {0}
 
@@ -172,7 +179,7 @@ jobs:
       - name: Install R dependencies for integration testing
         run: |
           remotes::install_deps(pkgdir = "tests/extendrtests", dependencies = TRUE)
-          remotes::install_deps(pkgdir = "tests/rextendr", dependencies = TRUE)
+          if (as.integer(R.version$major) >= 4) { remotes::install_deps(pkgdir = "tests/rextendr", dependencies = TRUE) }
           remotes::install_cran("rcmdcheck")
         shell: Rscript {0}
         
@@ -183,10 +190,20 @@ jobs:
         env:
           _R_CHECK_CRAN_INCOMING_REMOTE_: false
         run: |
+          cat("::group::Checking 'extendrtests'\n")
           setwd("tests/extendrtests")
           rcmdcheck::rcmdcheck(path = ".", args = c("--no-manual", "--as-cran", "--force-multiarch"), error_on = "warning", check_dir = "../../../")
-          setwd("../rextendr")
-          rcmdcheck::rcmdcheck(path = ".", args = c("--no-manual", "--force-multiarch"), error_on = "warning", check_dir = "../../../")
+          cat("::endgroup::\n")
+
+          if (as.integer(R.version$major) < 4) {
+            cat("::warning:: R version is not compatible with 'rextendr'\n")
+          } 
+          else {
+            cat("::group::Checking 'rextendr'\n")
+            setwd("../rextendr")
+            rcmdcheck::rcmdcheck(path = ".", args = c("--no-manual", "--force-multiarch"), error_on = "warning", check_dir = "../../../")
+            cat("::endgroup::\n")
+          }
         shell: Rscript {0}
         
       - name: Upload check results from R integration tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -200,7 +200,7 @@ jobs:
           } else {
             cat("::group::Checking 'rextendr'\n")
             setwd("../rextendr")
-            rcmdcheck::rcmdcheck(path = ".", args = c("--no-manual", "--force-multiarch"), error_on = "warning", check_dir = "../../../")
+            rcmdcheck::rcmdcheck(path = ".", args = c("--no-manual", "--as-cran", "--force-multiarch"), error_on = "warning", check_dir = "../../../")
             cat("::endgroup::\n")
           }
         shell: Rscript {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -197,8 +197,7 @@ jobs:
 
           if (as.integer(R.version$major) < 4) {
             cat("::warning:: R version is not compatible with 'rextendr'\n")
-          } 
-          else {
+          } else {
             cat("::group::Checking 'rextendr'\n")
             setwd("../rextendr")
             rcmdcheck::rcmdcheck(path = ".", args = c("--no-manual", "--force-multiarch"), error_on = "warning", check_dir = "../../../")

--- a/tests/extendrtests/src/rust/Cargo.toml
+++ b/tests/extendrtests/src/rust/Cargo.toml
@@ -20,7 +20,7 @@ extendr-api = "*"
 ## running rcmdcheck::rcmdcheck(check_dir = "../../../") from
 ## the root of extendrtests.
 ## The code is compiled in 
-## 'extendr/rextendr_check/extendrtests.Rcheck/00_pkg_src/extendrtests/src/rust'
+## 'extendr/extendrtests_check/extendrtests.Rcheck/00_pkg_src/extendrtests/src/rust'
 ## Cargo should go (relatively) 7 directories up (../) and then into './extendr/extendr-api'.
 extendr-api = { path = "../../../../../../../extendr/extendr-api/"}
 

--- a/tests/extendrtests/src/rust/Cargo.toml
+++ b/tests/extendrtests/src/rust/Cargo.toml
@@ -19,7 +19,10 @@ extendr-api = "*"
 ## Build against local extendr sources. Check locally by 
 ## running rcmdcheck::rcmdcheck(check_dir = "../../../") from
 ## the root of extendrtests.
-extendr-api = { path = "../../../../../extendr/extendr-api/"}
+## The code is compiled in 
+## 'extendr/rextendr_check/extendrtests.Rcheck/00_pkg_src/extendrtests/src/rust'
+## Cargo should go (relatively) 7 directories up (../) and then into './extendr/extendr-api'.
+extendr-api = { path = "../../../../../../../extendr/extendr-api/"}
 
 ## Build against current extendr version on github. Not recommended
 ## for development work.

--- a/tests/extendrtests/src/rust/Cargo.toml
+++ b/tests/extendrtests/src/rust/Cargo.toml
@@ -22,7 +22,7 @@ extendr-api = "*"
 ## The code is compiled in 
 ## 'extendr/extendrtests_check/extendrtests.Rcheck/00_pkg_src/extendrtests/src/rust'
 ## Cargo should go (relatively) 7 directories up (../) and then into './extendr/extendr-api'.
-extendr-api = { path = "../../../../../../../extendr/extendr-api/"}
+extendr-api = { path = "../../../../../extendr/extendr-api"}
 
 ## Build against current extendr version on github. Not recommended
 ## for development work.

--- a/tests/extendrtests/src/rust/Cargo.toml
+++ b/tests/extendrtests/src/rust/Cargo.toml
@@ -16,12 +16,9 @@ crate-type = ["staticlib"]
 extendr-api = "*"
 
 [patch.crates-io]
-## Build against local extendr sources. Check locally by 
-## running rcmdcheck::rcmdcheck(check_dir = "../../../") from
-## the root of extendrtests.
-## The code is compiled in 
-## 'extendr/extendrtests_check/extendrtests.Rcheck/00_pkg_src/extendrtests/src/rust'
-## Cargo should go (relatively) 7 directories up (../) and then into './extendr/extendr-api'.
+## This is configured to work with RStudio features.
+## Replace by absolute path to simplify testing.
+## CI overrides this path.
 extendr-api = { path = "../../../../../extendr/extendr-api"}
 
 ## Build against current extendr version on github. Not recommended


### PR DESCRIPTION
`tests/extendrtests` test integration of Rust code into an R package. `{rextendr}` generates rust libraries on the fly and loads them dynamically, using a slightly different method. 
So in #127 it was suggested to test `{rextendr}` as well.

I can suggest two obvious solutions:
1. Write more tests in this repo, testing `{rextendr}` behavior. However, we will have to watch `{rextendr}` changes and update tests to keep up, effectively maintaining two test codebases: here and in `extendr/rextendr`.
2. Use `{rextendr}` itself.

In this PR I suggest using `{rextendr}` as a test framework. We can run `rcmdcheck` on `{rextendr}` and verify its tests pass.
However, there is (yet again) an issue similar to #89 -- `{rextendr}` auto-generated `Cargo.toml` should point to the last commit in the currently tested/merged branch.

I patched `{rextendr}` https://github.com/extendr/rextendr/pull/31, allowing usage of environemnt variables to configure how rust libraries are build, in particular, `REXTENDR_TOOLCHAIN` configures an overriding rust toolchain, and `REXTENDR_PATCH_CRATES_IO` overrides crate references.
So, using `patch.crates_io` it is possible to point `{rextendr}` to the root of the tested extendr repo, effectively fixing #127.

I also found an issue with `extendrtests` and artifact uploading, so this PR also fixes #171 (this is a minor tweak).

