### PR TITLE
Remove specific r macros

### DIFF
--- a/extendr-api/src/prelude.rs
+++ b/extendr-api/src/prelude.rs
@@ -24,7 +24,7 @@ pub use super::functions::{
 
 pub use crate::{append, append_lang, append_with_name, args, call, lang, make_lang};
 pub use crate::{
-    c, data_frame, factor, global, list, r, read_table, rep, reprint, reprintln, rprint, rprintln,
+    data_frame, factor, global, list, r, reprint, reprintln, rprint, rprintln,
     sym, test, var, R,
 };
 

--- a/extendr-api/src/prelude.rs
+++ b/extendr-api/src/prelude.rs
@@ -24,8 +24,7 @@ pub use super::functions::{
 
 pub use crate::{append, append_lang, append_with_name, args, call, lang, make_lang};
 pub use crate::{
-    data_frame, factor, global, list, r, reprint, reprintln, rprint, rprintln,
-    sym, test, var, R,
+    data_frame, factor, global, list, r, reprint, reprintln, rprint, rprintln, sym, test, var, R,
 };
 
 pub use super::logical::Bool;

--- a/extendr-api/src/rmacros.rs
+++ b/extendr-api/src/rmacros.rs
@@ -110,64 +110,6 @@ macro_rules! sym {
     };
 }
 
-/// Concatenation operator.
-///
-/// Example:
-/// ```
-/// use extendr_api::prelude::*;
-/// test! {
-/// let fred = c!(1, 2, 3);
-/// assert_eq!(fred, r!([1, 2, 3]));
-/// }
-/// ```
-/// Note: make sure to use rust syntax for numbers: 1 is integer, 1. is numeric.
-/// For vectors of primitives, prefer to use `r!([1, 2, 3])`.
-///
-/// Panics on error.
-#[macro_export]
-macro_rules! c {
-    () => {
-        call!("c").unwrap()
-    };
-    ($($rest: tt)*) => {
-        call!("c", $($rest)*).unwrap()
-    };
-}
-
-/// Create a vector with repeating elements.
-///
-/// Example:
-/// ```
-/// use extendr_api::prelude::*;
-/// test! {
-/// let fred = rep!(1., 3);
-/// assert_eq!(fred, r!([1., 1., 1.]));
-/// }
-/// ```
-/// Note: make sure to use rust syntax for numbers: 1 is integer, 1. is numeric.
-#[macro_export]
-macro_rules! rep {
-    ($($rest: tt)*) => {
-        call!("rep", $($rest)*).unwrap()
-    };
-}
-
-/// Read a CSV file.
-///
-/// Example:
-/// ```no_run
-/// use extendr_api::prelude::*;
-/// test! {
-/// let mydata = read_table!("mydata.csv").unwrap();
-/// }
-/// ```
-#[macro_export]
-macro_rules! read_table {
-    ($($rest: tt)*) => {
-        call!("read.table", $($rest)*)
-    };
-}
-
 /// Create a list.
 ///
 /// Example:

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -66,7 +66,7 @@ pub use rinternals::*;
 ///
 ///     // Use an iterator (like (1:10)[(1:10) %% 3 == 0])
 ///     let a = (1 ..= 10).filter(|v| v % 3 == 0).collect_robj();
-///     assert_eq!(a, c!(3, 6, 9));
+///     assert_eq!(a, r!([3, 6, 9]));
 /// }
 /// ```
 ///
@@ -75,10 +75,10 @@ pub use rinternals::*;
 /// ```
 /// use extendr_api::prelude::*;
 /// test! {
-///     let a : Robj = c!(1, 2, 3, 4, 5);
+///     let a : Robj = r!([1, 2, 3, 4, 5]);
 ///     let iter = a.as_integer_iter().unwrap();
 ///     let robj = iter.filter(|&x| x < 3).collect_robj();
-///     assert_eq!(robj, c!(1, 2));
+///     assert_eq!(robj, r!([1, 2]));
 /// }
 /// ```
 ///


### PR DESCRIPTION
This PR removes the c!, rep! and read_table! macros as these can all be done
with r!, R! or call!
