### PR TITLE
Field accessors

### DIFF
--- a/extendr-api/src/metadata.rs
+++ b/extendr-api/src/metadata.rs
@@ -286,7 +286,7 @@ fn write_impl_wrapper(
     method
   }} else {{
     getter <- get0(paste0(\"get_\", name), {impl_name})
-    if (is.null(getter)) {{
+    if (!is.null(getter)) {{
       environment(getter) <- environment()
       getter()
     }} else {{
@@ -300,6 +300,30 @@ fn write_impl_wrapper(
         call. = FALSE
       )
     }}
+  }}
+}}",
+        class_name = imp.name,
+        impl_name = imp_name_fixed
+    )?;
+
+    writeln!(
+        w,
+        "
+`$<-.{class_name}` <- function (self, name, value) {{
+  setter <- get0(paste0(\"set_\", name), {impl_name})
+  if (!is.null(setter)) {{
+      environment(setter) <- environment()
+      setter(value)
+      self
+  }} else {{
+      stop(
+      paste(
+          \"Class member not found.\",
+          paste0(\"x No setter `set_\", name, \"` found in `{impl_name}`.\"),
+          sep = \"\\n\"
+      ),
+      call. = FALSE
+      )
   }}
 }}",
         class_name = imp.name,

--- a/extendr-api/src/metadata.rs
+++ b/extendr-api/src/metadata.rs
@@ -277,31 +277,32 @@ fn write_impl_wrapper(
     // but in the body `imp_name_fixed` is called as valid R function,
     // so we pass preprocessed value
     writeln!(
-        w, "
-        `$.{class_name}` <- function (self, name) {{
-            method <- get0(name, {impl_name})
-            if (!is.null(method)) {{
-                environment(method) <- environment
-                method
-            }} else {{
-                getter <- get0(paste0(\"get_\", name), {impl_name})
-                if (is.null(getter)) {{
-                    environment(getter) <- environment()
-                    getter()
-                }} else {{
-                    stop(
-                        paste(
-                            \"Class member not found.\",
-                            paste0(\"x No method `\", name, \"` found in `{impl_name}`.\"),
-                            paste0(\"x No getter `get_\", name, \"` found in `{impl_name}`.\"),
-                            sep = \"\\n\"
-                        )
-                        call. = FALSE
-                    )
-                }}
-            }}
-        }}", 
-        class_name = imp.name, 
+        w,
+        "
+`$.{class_name}` <- function (self, name) {{
+  method <- get0(name, {impl_name})
+  if (!is.null(method)) {{
+    environment(method) <- environment()
+    method
+  }} else {{
+    getter <- get0(paste0(\"get_\", name), {impl_name})
+    if (is.null(getter)) {{
+      environment(getter) <- environment()
+      getter()
+    }} else {{
+      stop(
+        paste(
+          \"Class member not found.\",
+          paste0(\"x No method `\", name, \"` found in `{impl_name}`.\"),
+          paste0(\"x No getter `get_\", name, \"` found in `{impl_name}`.\"),
+          sep = \"\\n\"
+        ),
+        call. = FALSE
+      )
+    }}
+  }}
+}}",
+        class_name = imp.name,
         impl_name = imp_name_fixed
     )?;
 

--- a/tests/extendrtests/R/extendr-wrappers.R
+++ b/tests/extendrtests/R/extendr-wrappers.R
@@ -60,9 +60,9 @@ hello_submodule <- function() .Call(wrap__hello_submodule)
 #' Class for testing (exported)
 #' @examples
 #' x <- MyClass$new()
-#' x$a
-#' x$a <- 10
-#' x$a
+#' x$get_a()
+#' x$set_a(10)
+#' x$get_a()
 #' @export
 MyClass <- new.env(parent = emptyenv())
 

--- a/tests/extendrtests/R/extendr-wrappers.R
+++ b/tests/extendrtests/R/extendr-wrappers.R
@@ -70,15 +70,55 @@ MyClass$new <- function() .Call(wrap__MyClass__new)
 
 MyClass$set_a <- function(x) invisible(.Call(wrap__MyClass__set_a, self, x))
 
-MyClass$a <- function() .Call(wrap__MyClass__a, self)
+MyClass$get_a <- function() .Call(wrap__MyClass__get_a, self)
 
 MyClass$me <- function() .Call(wrap__MyClass__me, self)
 
 #' @rdname MyClass
 #' @usage NULL
 #' @export
-`$.MyClass` <- function (self, name) { func <- MyClass[[name]]; environment(func) <- environment(); func }
 
+`$.MyClass` <- function (self, name) {
+  method <- get0(name, MyClass)
+  if (!is.null(method)) {
+    environment(method) <- environment()
+    method
+  } else {
+    getter <- get0(paste0("get_", name), MyClass)
+    if (!is.null(getter)) {
+      environment(getter) <- environment()
+      getter()
+    } else {
+      stop(
+        paste(
+          "Class member not found.",
+          paste0("x No method `", name, "` found in `MyClass`."),
+          paste0("x No getter `get_", name, "` found in `MyClass`."),
+          sep = "\n"
+        ),
+        call. = FALSE
+      )
+    }
+  }
+}
+
+`$<-.MyClass` <- function (self, name, value) {
+  setter <- get0(paste0("set_", name), MyClass)
+  if (!is.null(setter)) {
+      environment(setter) <- environment()
+      setter(value)
+      self
+  } else {
+      stop(
+      paste(
+          "Class member not found.",
+          paste0("x No setter `set_", name, "` found in `MyClass`."),
+          sep = "\n"
+      ),
+      call. = FALSE
+      )
+  }
+}
 `__MyClass` <- new.env(parent = emptyenv())
 
 `__MyClass`$new <- function() .Call(wrap____MyClass__new)
@@ -86,18 +126,98 @@ MyClass$me <- function() .Call(wrap__MyClass__me, self)
 `__MyClass`$`__name_test` <- function() invisible(.Call(wrap____MyClass____name_test, self))
 
 #' @export
-`$.__MyClass` <- function (self, name) { func <- `__MyClass`[[name]]; environment(func) <- environment(); func }
 
+`$.__MyClass` <- function (self, name) {
+  method <- get0(name, `__MyClass`)
+  if (!is.null(method)) {
+    environment(method) <- environment()
+    method
+  } else {
+    getter <- get0(paste0("get_", name), `__MyClass`)
+    if (!is.null(getter)) {
+      environment(getter) <- environment()
+      getter()
+    } else {
+      stop(
+        paste(
+          "Class member not found.",
+          paste0("x No method `", name, "` found in ``__MyClass``."),
+          paste0("x No getter `get_", name, "` found in ``__MyClass``."),
+          sep = "\n"
+        ),
+        call. = FALSE
+      )
+    }
+  }
+}
+
+`$<-.__MyClass` <- function (self, name, value) {
+  setter <- get0(paste0("set_", name), `__MyClass`)
+  if (!is.null(setter)) {
+      environment(setter) <- environment()
+      setter(value)
+      self
+  } else {
+      stop(
+      paste(
+          "Class member not found.",
+          paste0("x No setter `set_", name, "` found in ``__MyClass``."),
+          sep = "\n"
+      ),
+      call. = FALSE
+      )
+  }
+}
 #' Class for testing (unexported)
 MyClassUnexported <- new.env(parent = emptyenv())
 
 MyClassUnexported$new <- function() .Call(wrap__MyClassUnexported__new)
 
-MyClassUnexported$a <- function() .Call(wrap__MyClassUnexported__a, self)
+MyClassUnexported$get_a <- function() .Call(wrap__MyClassUnexported__get_a, self)
 
 #' @export
-`$.MyClassUnexported` <- function (self, name) { func <- MyClassUnexported[[name]]; environment(func) <- environment(); func }
 
+`$.MyClassUnexported` <- function (self, name) {
+  method <- get0(name, MyClassUnexported)
+  if (!is.null(method)) {
+    environment(method) <- environment()
+    method
+  } else {
+    getter <- get0(paste0("get_", name), MyClassUnexported)
+    if (!is.null(getter)) {
+      environment(getter) <- environment()
+      getter()
+    } else {
+      stop(
+        paste(
+          "Class member not found.",
+          paste0("x No method `", name, "` found in `MyClassUnexported`."),
+          paste0("x No getter `get_", name, "` found in `MyClassUnexported`."),
+          sep = "\n"
+        ),
+        call. = FALSE
+      )
+    }
+  }
+}
+
+`$<-.MyClassUnexported` <- function (self, name, value) {
+  setter <- get0(paste0("set_", name), MyClassUnexported)
+  if (!is.null(setter)) {
+      environment(setter) <- environment()
+      setter(value)
+      self
+  } else {
+      stop(
+      paste(
+          "Class member not found.",
+          paste0("x No setter `set_", name, "` found in `MyClassUnexported`."),
+          sep = "\n"
+      ),
+      call. = FALSE
+      )
+  }
+}
 #' Class for testing (exported)
 #' @examples
 #' x <- MySubmoduleClass$new()
@@ -118,5 +238,45 @@ MySubmoduleClass$me <- function() .Call(wrap__MySubmoduleClass__me, self)
 #' @rdname MySubmoduleClass
 #' @usage NULL
 #' @export
-`$.MySubmoduleClass` <- function (self, name) { func <- MySubmoduleClass[[name]]; environment(func) <- environment(); func }
 
+`$.MySubmoduleClass` <- function (self, name) {
+  method <- get0(name, MySubmoduleClass)
+  if (!is.null(method)) {
+    environment(method) <- environment()
+    method
+  } else {
+    getter <- get0(paste0("get_", name), MySubmoduleClass)
+    if (!is.null(getter)) {
+      environment(getter) <- environment()
+      getter()
+    } else {
+      stop(
+        paste(
+          "Class member not found.",
+          paste0("x No method `", name, "` found in `MySubmoduleClass`."),
+          paste0("x No getter `get_", name, "` found in `MySubmoduleClass`."),
+          sep = "\n"
+        ),
+        call. = FALSE
+      )
+    }
+  }
+}
+
+`$<-.MySubmoduleClass` <- function (self, name, value) {
+  setter <- get0(paste0("set_", name), MySubmoduleClass)
+  if (!is.null(setter)) {
+      environment(setter) <- environment()
+      setter(value)
+      self
+  } else {
+      stop(
+      paste(
+          "Class member not found.",
+          paste0("x No setter `set_", name, "` found in `MySubmoduleClass`."),
+          sep = "\n"
+      ),
+      call. = FALSE
+      )
+  }
+}

--- a/tests/extendrtests/R/extendr-wrappers.R
+++ b/tests/extendrtests/R/extendr-wrappers.R
@@ -60,9 +60,9 @@ hello_submodule <- function() .Call(wrap__hello_submodule)
 #' Class for testing (exported)
 #' @examples
 #' x <- MyClass$new()
-#' x$a()
-#' x$set_a(10)
-#' x$a()
+#' x$a
+#' x$a <- 10
+#' x$a
 #' @export
 MyClass <- new.env(parent = emptyenv())
 

--- a/tests/extendrtests/man/MyClass.Rd
+++ b/tests/extendrtests/man/MyClass.Rd
@@ -16,8 +16,8 @@ Class for testing (exported)
 }
 \examples{
 x <- MyClass$new()
-x$a
-x$a <- 10
-x$a
+x$get_a()
+x$set_a(10)
+x$get_a()
 }
 \keyword{datasets}

--- a/tests/extendrtests/man/MyClass.Rd
+++ b/tests/extendrtests/man/MyClass.Rd
@@ -16,8 +16,8 @@ Class for testing (exported)
 }
 \examples{
 x <- MyClass$new()
-x$a()
-x$set_a(10)
-x$a()
+x$a
+x$a <- 10
+x$a
 }
 \keyword{datasets}

--- a/tests/extendrtests/src/rust/src/lib.rs
+++ b/tests/extendrtests/src/rust/src/lib.rs
@@ -74,9 +74,9 @@ struct MyClass {
 /// Class for testing (exported)
 /// @examples
 /// x <- MyClass$new()
-/// x$a()
-/// x$set_a(10)
-/// x$a()
+/// x$a
+/// x$a <- 10
+/// x$a
 /// @export
 #[extendr]
 impl MyClass {

--- a/tests/extendrtests/src/rust/src/lib.rs
+++ b/tests/extendrtests/src/rust/src/lib.rs
@@ -74,9 +74,9 @@ struct MyClass {
 /// Class for testing (exported)
 /// @examples
 /// x <- MyClass$new()
-/// x$a
-/// x$a <- 10
-/// x$a
+/// x$get_a()
+/// x$set_a(10)
+/// x$get_a()
 /// @export
 #[extendr]
 impl MyClass {

--- a/tests/extendrtests/src/rust/src/lib.rs
+++ b/tests/extendrtests/src/rust/src/lib.rs
@@ -92,7 +92,7 @@ impl MyClass {
     }
     
     /// Method for getting stuff.
-    fn a(&self) -> i32 {
+    fn get_a(&self) -> i32 {
         self.a
     }
     
@@ -135,7 +135,7 @@ impl MyClassUnexported {
     }
     
     /// Method for getting stuff.
-    fn a(&self) -> i32 {
+    fn get_a(&self) -> i32 {
         self.a
     }
 }

--- a/tests/extendrtests/tests/testthat/test-classes.R
+++ b/tests/extendrtests/tests/testthat/test-classes.R
@@ -1,16 +1,23 @@
 test_that("Exported class works", {
   x <- MyClass$new()
-  expect_equal(x$a(), 0L)
-  x$set_a(10L)
-  expect_equal(x$a(), 10L)
+  # Using getter
+  expect_equal(x$a, 0L)
+  # Using setter
+  x$a <- 10L
+  expect_equal(x$a, 10L)
   expect_equal(x$me(), x)
-  
-  expect_visible(x$a())
+
+  # Directly invoking methods
+  expect_visible(x$get_a())
   expect_invisible(x$set_a(5L))
+
+  # Verifying methods and accessors do the same
+  expect_equal(x$a, 5L)
+
 })
 
 test_that("Unexported class works", {
   # unexported code works in testthat tests
   x <- MyClassUnexported$new()
-  expect_equal(x$a(), 22L)
+  expect_equal(x$a, 22L)
 })


### PR DESCRIPTION
At some point, we were discussing that field accessors should use R syntax, not `field()` and `set_field(val)` methods.
Drawing inspiration from my favorite language, C#, I suggest the following, convention-based, solution.
<details>
<summary>C# property behavior</summary>
In C#, a field can be accessed by declaring a special set of methods, which are combined into a property.
E.g., if a class `MyClass` has a field `int x`, then a property can be declared:

```C#

int X 
{
   get {return this.x;}
   set {this.x = value;}
}   
```
Under the hood, compiler generates special `get_X` and `set_X` methods, which are then invoked, allowing `X` to be both rvalue and lvalue (which is syntactic sugar):
`var y = myClassInstance.X;`
`myClassInstance.X = z;`
</details>

`$.ClassName <- function(self, name)` now has the following behavior:
1. If `name` is exported from `ClassName`, return it as a function (which is currently implemented)
2. Otherwise, look for `get_{name}`. 
a. If it exists, treat is a getter and return the result of its invocation (a value).
b. Otherwise, fail with a detailed error.

A new method is exported, `$<-.ClassName <- function(self, name, value)`, which only supports setters:
1. If `set_{name}` is exported, treat is a setter.
a. Invoke `setter(value)`
b. Return `self` by convention
2. Otherwise, fail with a detailed error.

A prototype R implementation (no Rust backend required is attached).

<details>
<summary> R-only prototype </summary>

```R

Class <- new.env(parent = emptyenv())
Class$new <- function() {
    e <- new.env()
    e$m_a <- 42L
    structure(e, class = "Class")
}
Class$get_a <- function() self[["m_a"]]
Class$set_a <- function(value) {
    self[["m_a"]] <- value
    # self
}
Class$some_method <- function(b, c) self$a + b + c


`$.Class` <- function(self, name) {
    method <- get0(name, Class, ifnotfound = NULL)
    if (rlang::is_null(method)) {
        # Getter branch
        getter <- get0(glue::glue("get_{name}"), Class, ifnotfound = NULL)
        if (rlang::is_null(getter)) {
            rlang::abort(
                glue::glue(
                    "Class member not found.",
                    "x No method `{name}` found in `Class`.",
                    "x No field accessor `get_{name}` found in `Class`.",
                    .sep = "\n"
                )
            )
        }
        environment(getter) <- environment()
        # !!! Returns value
        getter()
    } else {
        # Method branch
        environment(method) <- environment()
        # !!! Returns method
        method
    }
}

# Allow only field accessors, i.e. setters.
`$<-.Class` <- function(self, name, value) {
    setter <- get0(glue::glue("set_{name}"), Class, ifnotfound = NULL)
    if (rlang::is_null(setter)) {
        rlang::abort(
            glue::glue(
                "Class member not found.",
                "x No field accessor `set_{name}` found in `Class`.",
                .sep = "\n"
            )
        )
    }
    environment(setter) <- environment()
    setter(value)
    # Return `self` by convention
    self
}


x <- Class$new()
x$a <- 100500
print(x$a)
#> [1] 100500
print(x$some_method(10, 100))
#> [1] 100610

<sup>Created on 2021-02-22 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>

```
</details>

The code generated by `extendr-api` invokes only baseR methods (no package dependencies).
{extendrtests} has been updated to use accessors in key places.

**UPD01**: It is also backward-compatible, it is possible to directly invoke `x$get_a()` and `x$set_a(new_val)`.