### PR TITLE
Fix clippy warnings

### DIFF
--- a/extendr-api/src/error.rs
+++ b/extendr-api/src/error.rs
@@ -76,7 +76,7 @@ impl std::fmt::Display for Error {
         match self {
             Error::Panic(robj) => write!(f, "Panic detected {:?}.", robj),
             Error::NotFound(robj) => write!(f, "Not found. {:?}", robj),
-            Error::EvalError(robj) => write!(f, "Evalualtion error in {:?}.", robj),
+            Error::EvalError(robj) => write!(f, "Evaluation error in {:?}.", robj),
             Error::ParseError(code) => write!(f, "Parse error in {:?}.", code),
             Error::NamesLengthMismatch(robj) => {
                 write!(f, "Length of names does not match vector. {:?}", robj)

--- a/extendr-api/src/functions.rs
+++ b/extendr-api/src/functions.rs
@@ -13,7 +13,7 @@ use crate::*;
 /// ```
 pub fn global_var<K: Into<Robj>>(key: K) -> Result<Robj> {
     let key = key.into();
-    Ok(global_env().find_var(key)?.eval_promise()?)
+    global_env().find_var(key)?.eval_promise()
 }
 
 /// Get a local variable from current_env() and ancestors.
@@ -33,7 +33,7 @@ pub fn global_var<K: Into<Robj>>(key: K) -> Result<Robj> {
 /// ```
 pub fn local_var<K: Into<Robj>>(key: K) -> Result<Robj> {
     let key = key.into();
-    Ok(current_env().find_var(key)?.eval_promise()?)
+    current_env().find_var(key)?.eval_promise()
 }
 
 /// Get a global function from global_env() and ancestors.

--- a/extendr-api/src/iter.rs
+++ b/extendr-api/src/iter.rs
@@ -178,7 +178,7 @@ impl Iterator for StrIter {
             self.i += 1;
             let vector = self.vector.get();
             if i >= self.len {
-                return None;
+                None
             } else if TYPEOF(vector) as u32 == STRSXP {
                 Some(str_from_strsxp(vector, i as isize))
             } else if TYPEOF(vector) as u32 == INTSXP && TYPEOF(self.levels) as u32 == STRSXP {
@@ -187,7 +187,7 @@ impl Iterator for StrIter {
             } else if TYPEOF(vector) as u32 == NILSXP {
                 Some(na_str())
             } else {
-                return None;
+                None
             }
         }
     }

--- a/extendr-api/src/iter.rs
+++ b/extendr-api/src/iter.rs
@@ -138,7 +138,7 @@ impl StrIter {
             Self {
                 vector: ().into(),
                 i: 0,
-                len: len,
+                len,
                 levels: R_NilValue,
             }
         }

--- a/extendr-api/src/iter.rs
+++ b/extendr-api/src/iter.rs
@@ -12,6 +12,12 @@ pub struct SliceIter<T> {
     ptr: *const T,
 }
 
+impl<T> Default for SliceIter<T> {
+    fn default() -> Self {
+        SliceIter::new()
+    }
+}
+
 impl<T> SliceIter<T> {
     // A new, empty list iterator.
     pub fn new() -> Self {
@@ -26,9 +32,9 @@ impl<T> SliceIter<T> {
     pub fn from_slice(vector: Robj, slice: &[T]) -> Self {
         SliceIter {
             vector,
-            i: 0,
             len: slice.len(),
             ptr: slice.as_ptr(),
+            ..Default::default()
         }
     }
 }
@@ -120,6 +126,12 @@ pub struct StrIter {
     levels: SEXP,
 }
 
+impl Default for StrIter {
+    fn default() -> Self {
+        StrIter::new()
+    }
+}
+
 impl StrIter {
     /// Make an empty str iterator.
     pub fn new() -> Self {
@@ -134,13 +146,9 @@ impl StrIter {
     }
 
     pub fn na_iter(len: usize) -> StrIter {
-        unsafe {
-            Self {
-                vector: ().into(),
-                i: 0,
-                len,
-                levels: R_NilValue,
-            }
+        Self {
+            len,
+            ..Default::default()
         }
     }
 }

--- a/extendr-api/src/iter.rs
+++ b/extendr-api/src/iter.rs
@@ -54,7 +54,7 @@ impl<T: Copy> Iterator for SliceIter<T> {
             self.i = self.len;
             None
         } else {
-            unsafe { Some(*self.ptr.offset(i as isize)) }
+            unsafe { Some(*self.ptr.add(i)) }
         }
     }
 
@@ -190,7 +190,7 @@ impl Iterator for StrIter {
             } else if TYPEOF(vector) as u32 == STRSXP {
                 Some(str_from_strsxp(vector, i as isize))
             } else if TYPEOF(vector) as u32 == INTSXP && TYPEOF(self.levels) as u32 == STRSXP {
-                let j = *(INTEGER(vector).offset(i as isize));
+                let j = *(INTEGER(vector).add(i));
                 Some(str_from_strsxp(self.levels, j as isize - 1))
             } else if TYPEOF(vector) as u32 == NILSXP {
                 Some(na_str())

--- a/extendr-api/src/metadata.rs
+++ b/extendr-api/src/metadata.rs
@@ -100,7 +100,7 @@ fn write_doc(w: &mut Vec<u8>, doc: &str) -> std::io::Result<()> {
                 write!(w, "{}", c)?;
             }
         }
-        writeln!(w, "")?;
+        writeln!(w)?;
     }
     Ok(())
 }
@@ -314,7 +314,7 @@ impl Metadata {
             writeln!(w, "#' @usage NULL")?;
             writeln!(w, "#' @useDynLib {}, .registration = TRUE", package_name)?;
             writeln!(w, "NULL")?;
-            writeln!(w, "")?;
+            writeln!(w)?;
         }
 
         for func in &self.functions {

--- a/extendr-api/src/ownership.rs
+++ b/extendr-api/src/ownership.rs
@@ -3,7 +3,7 @@
 //! This provides the functions protect() and unprotect()
 //! A single preserved vector holds ownership of all protected objects.
 //!
-//! Objects are refernce counted, so multiple calls are possible,
+//! Objects are reference counted, so multiple calls are possible,
 //! unlike R_PreserveObject.
 //!
 //! This module exports two functions, protect(sexp) and unprotect(sexp).

--- a/extendr-api/src/ownership.rs
+++ b/extendr-api/src/ownership.rs
@@ -74,94 +74,80 @@ impl Ownership {
         }
 
         let sexp_usize = sexp as usize;
-        match *self {
-            Ownership {
-                ref mut preservation,
-                ref mut cur_index,
-                ref mut max_index,
-                ref mut objects,
-            } => {
-                let mut entry = objects.entry(sexp_usize);
-                let preservation_sexp = *preservation as SEXP;
-                match entry {
-                    Entry::Occupied(ref mut occupied) => {
-                        if occupied.get().refcount == 0 {
-                            // Address re-used - re-set the sexp.
-                            SET_VECTOR_ELT(
-                                preservation_sexp,
-                                occupied.get().index as R_xlen_t,
-                                sexp,
-                            );
-                        }
-                        occupied.get_mut().refcount += 1;
-                    }
-                    Entry::Vacant(vacant) => {
-                        let index = *cur_index;
-                        SET_VECTOR_ELT(preservation_sexp, index as R_xlen_t, sexp);
-                        *cur_index += 1;
-                        assert!(index != *max_index);
-                        let refcount = 1;
-                        vacant.insert(Object { refcount, index });
-                    }
+        let Ownership {
+            ref mut preservation,
+            ref mut cur_index,
+            ref mut max_index,
+            ref mut objects,
+        } = *self;
+
+        let mut entry = objects.entry(sexp_usize);
+        let preservation_sexp = *preservation as SEXP;
+        match entry {
+            Entry::Occupied(ref mut occupied) => {
+                if occupied.get().refcount == 0 {
+                    // Address re-used - re-set the sexp.
+                    SET_VECTOR_ELT(preservation_sexp, occupied.get().index as R_xlen_t, sexp);
                 }
+                occupied.get_mut().refcount += 1;
+            }
+            Entry::Vacant(vacant) => {
+                let index = *cur_index;
+                SET_VECTOR_ELT(preservation_sexp, index as R_xlen_t, sexp);
+                *cur_index += 1;
+                assert!(index != *max_index);
+                let refcount = 1;
+                vacant.insert(Object { refcount, index });
             }
         }
     }
 
     pub unsafe fn unprotect(&mut self, sexp: SEXP) {
         let sexp_usize = sexp as usize;
-        match *self {
-            Ownership {
-                preservation,
-                cur_index: _,
-                max_index: _,
-                ref mut objects,
-            } => {
-                let mut entry = objects.entry(sexp_usize);
-                match entry {
-                    Entry::Occupied(ref mut occupied) => {
-                        let object = occupied.get_mut();
-                        if object.refcount == 0 {
-                            panic!("Attempt to unprotect an already unprotected object.")
-                        } else {
-                            object.refcount -= 1;
-                            if object.refcount == 0 {
-                                // Clear the preservation vector, but keep the hash table entry.
-                                // It is hard to clear the hash table entry here because we don't
-                                // have a ref to objects anymore and it is faster to clear them up en-masse.
-                                let preservation_sexp = preservation as SEXP;
-                                SET_VECTOR_ELT(
-                                    preservation_sexp,
-                                    object.index as R_xlen_t,
-                                    R_NilValue,
-                                );
-                            }
-                        }
-                    }
-                    Entry::Vacant(_) => {
-                        panic!("Attempt to unprotect a never protected object.")
+        let Ownership {
+            preservation,
+            cur_index: _,
+            max_index: _,
+            ref mut objects,
+        } = *self;
+
+        let mut entry = objects.entry(sexp_usize);
+        match entry {
+            Entry::Occupied(ref mut occupied) => {
+                let object = occupied.get_mut();
+                if object.refcount == 0 {
+                    panic!("Attempt to unprotect an already unprotected object.")
+                } else {
+                    object.refcount -= 1;
+                    if object.refcount == 0 {
+                        // Clear the preservation vector, but keep the hash table entry.
+                        // It is hard to clear the hash table entry here because we don't
+                        // have a ref to objects anymore and it is faster to clear them up en-masse.
+                        let preservation_sexp = preservation as SEXP;
+                        SET_VECTOR_ELT(preservation_sexp, object.index as R_xlen_t, R_NilValue);
                     }
                 }
+            }
+            Entry::Vacant(_) => {
+                panic!("Attempt to unprotect a never protected object.")
             }
         }
     }
 
     #[allow(dead_code)]
     unsafe fn ref_count(&mut self, sexp: SEXP) -> usize {
-        match *self {
-            Ownership {
-                preservation: _,
-                cur_index: _,
-                max_index: _,
-                ref mut objects,
-            } => {
-                let sexp_usize = sexp as usize;
-                let mut entry = objects.entry(sexp_usize);
-                match entry {
-                    Entry::Occupied(ref mut occupied) => occupied.get().refcount,
-                    Entry::Vacant(_) => 0,
-                }
-            }
+        let Ownership {
+            preservation: _,
+            cur_index: _,
+            max_index: _,
+            ref mut objects,
+        } = *self;
+
+        let sexp_usize = sexp as usize;
+        let mut entry = objects.entry(sexp_usize);
+        match entry {
+            Entry::Occupied(ref mut occupied) => occupied.get().refcount,
+            Entry::Vacant(_) => 0,
         }
     }
 

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -393,7 +393,7 @@ pub trait RobjItertools: Iterator {
         Self: Sized,
         Self::Item: ToVectorValue,
     {
-        if let (len, Some(max)) = self.size_hint().clone() {
+        if let (len, Some(max)) = self.size_hint() {
             if len == max {
                 return fixed_size_collect(self, len);
             }

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -356,9 +356,9 @@ where
                     panic!("unexpected SEXPTYPE in collect_robj");
                 }
             }
-            return Robj::Owned(sexp);
+            Robj::Owned(sexp)
         } else {
-            return Robj::from(());
+            Robj::from(())
         }
     })
 }

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -332,19 +332,19 @@ where
                 REALSXP => {
                     let ptr = REAL(sexp);
                     for (i, v) in iter.enumerate() {
-                        *ptr.offset(i as isize) = v.to_real();
+                        *ptr.add(i) = v.to_real();
                     }
                 }
                 INTSXP => {
                     let ptr = INTEGER(sexp);
                     for (i, v) in iter.enumerate() {
-                        *ptr.offset(i as isize) = v.to_integer();
+                        *ptr.add(i) = v.to_integer();
                     }
                 }
                 LGLSXP => {
                     let ptr = LOGICAL(sexp);
                     for (i, v) in iter.enumerate() {
-                        *ptr.offset(i as isize) = v.to_logical();
+                        *ptr.add(i) = v.to_logical();
                     }
                 }
                 STRSXP => {

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -936,7 +936,7 @@ impl Robj {
     /// ```
     pub fn inherits(&self, classname: &str) -> bool {
         if let Some(mut iter) = self.class() {
-            iter.find(|&n| n == classname).is_some()
+            iter.any(|n| n == classname)
         } else {
             false
         }

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -291,11 +291,8 @@ impl Robj {
     /// }
     /// ```
     pub fn as_integer_iter(&self) -> Option<Int> {
-        if let Some(slice) = self.as_integer_slice() {
-            Some(Int::from_slice(self.to_owned(), slice))
-        } else {
-            None
-        }
+        self.as_integer_slice()
+            .map(|slice| Int::from_slice(self.to_owned(), slice))
     }
 
     /// Get a Vec<i32> copied from the object.
@@ -308,11 +305,7 @@ impl Robj {
     /// }
     /// ```
     pub fn as_integer_vector(&self) -> Option<Vec<i32>> {
-        if let Some(value) = self.as_integer_slice() {
-            Some(value.to_vec())
-        } else {
-            None
-        }
+        self.as_integer_slice().map(|value| value.to_vec())
     }
 
     /// Get a read-only reference to the content of a logical vector
@@ -339,11 +332,7 @@ impl Robj {
     /// }
     /// ```
     pub fn as_logical_vector(&self) -> Option<Vec<Bool>> {
-        if let Some(value) = self.as_logical_slice() {
-            Some(value.to_vec())
-        } else {
-            None
-        }
+        self.as_logical_slice().map(|value| value.to_vec())
     }
 
     /// Get an iterator over logical elements of this slice.
@@ -364,11 +353,8 @@ impl Robj {
     /// }
     /// ```
     pub fn as_logical_iter(&self) -> Option<Logical> {
-        if let Some(slice) = self.as_logical_slice() {
-            Some(Logical::from_slice(self.to_owned(), slice))
-        } else {
-            None
-        }
+        self.as_logical_slice()
+            .map(|slice| Logical::from_slice(self.to_owned(), slice))
     }
 
     /// Get a read-only reference to the content of a double vector.
@@ -406,11 +392,8 @@ impl Robj {
     /// }
     /// ```
     pub fn as_real_iter(&self) -> Option<Real> {
-        if let Some(slice) = self.as_real_slice() {
-            Some(Real::from_slice(self.to_owned(), slice))
-        } else {
-            None
-        }
+        self.as_real_slice()
+            .map(|slice| Real::from_slice(self.to_owned(), slice))
     }
 
     /// Get a Vec<f64> copied from the object.
@@ -422,11 +405,7 @@ impl Robj {
     /// }
     /// ```
     pub fn as_real_vector(&self) -> Option<Vec<f64>> {
-        if let Some(value) = self.as_real_slice() {
-            Some(value.to_vec())
-        } else {
-            None
-        }
+        self.as_real_slice().map(|value| value.to_vec())
     }
 
     /// Get a read-only reference to the content of an integer or logical vector.
@@ -497,11 +476,8 @@ impl Robj {
     /// }
     /// ```
     pub fn as_string_vector(&self) -> Option<Vec<String>> {
-        if let Some(iter) = self.as_str_iter() {
-            Some(iter.map(str::to_string).collect())
-        } else {
-            None
-        }
+        self.as_str_iter()
+            .map(|iter| iter.map(str::to_string).collect())
     }
 
     /// Get a vector of string references.
@@ -516,11 +492,7 @@ impl Robj {
     /// }
     /// ```
     pub fn as_str_vector(&self) -> Option<Vec<&str>> {
-        if let Some(iter) = self.as_str_iter() {
-            Some(iter.collect())
-        } else {
-            None
-        }
+        self.as_str_iter().map(|iter| iter.collect())
     }
 
     /// Get a read-only reference to a scalar string type.

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -676,10 +676,7 @@ impl Robj {
     /// }
     /// ```
     pub fn is_owned(&self) -> bool {
-        match self {
-            Robj::Owned(_) => true,
-            _ => false,
-        }
+        matches!(self, Robj::Owned(_))
     }
 
     // Convert the Robj to an owned one.

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -236,6 +236,19 @@ impl Robj {
         unsafe { Rf_xlength(self.get()) as usize }
     }
 
+    /// Returns `true` if the `Robj` contains no elements.
+    /// ```
+    /// use extendr_api::prelude::*;
+    /// test! {
+    ///
+    /// let a : Robj = r!(vec![0.; 0]); // length zero of numeric vector
+    /// assert_eq!(a.is_empty(), true);
+    /// }
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Is this object is an NA scalar?
     /// Works for character, integer and numeric types.
     /// ```

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -657,10 +657,10 @@ impl Robj {
     /// ```
     pub fn eval_blind(&self) -> Robj {
         let res = self.eval();
-        if res.is_err() {
-            Robj::from(())
+        if let Ok(robj) = res {
+            Robj::from(robj)
         } else {
-            Robj::from(res.unwrap())
+            Robj::from(())
         }
     }
 

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -309,7 +309,7 @@ impl Robj {
     /// ```
     pub fn as_integer_vector(&self) -> Option<Vec<i32>> {
         if let Some(value) = self.as_integer_slice() {
-            Some(value.iter().cloned().collect::<Vec<_>>())
+            Some(value.to_vec())
         } else {
             None
         }
@@ -340,7 +340,7 @@ impl Robj {
     /// ```
     pub fn as_logical_vector(&self) -> Option<Vec<Bool>> {
         if let Some(value) = self.as_logical_slice() {
-            Some(value.iter().cloned().collect::<Vec<_>>())
+            Some(value.to_vec())
         } else {
             None
         }
@@ -423,7 +423,7 @@ impl Robj {
     /// ```
     pub fn as_real_vector(&self) -> Option<Vec<f64>> {
         if let Some(value) = self.as_real_slice() {
-            Some(value.iter().cloned().collect::<Vec<_>>())
+            Some(value.to_vec())
         } else {
             None
         }

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -658,7 +658,7 @@ impl Robj {
     pub fn eval_blind(&self) -> Robj {
         let res = self.eval();
         if let Ok(robj) = res {
-            Robj::from(robj)
+            robj
         } else {
             Robj::from(())
         }

--- a/extendr-api/src/robj/operators.rs
+++ b/extendr-api/src/robj/operators.rs
@@ -15,7 +15,7 @@ impl Robj {
     /// assert_eq!(env.dollar("b").unwrap(), r!(2));
     /// }
     /// ```
-    pub fn dollar<'a, T>(&self, symbol: T) -> Result<Robj>
+    pub fn dollar<T>(&self, symbol: T) -> Result<Robj>
     where
         T: AsRef<str>,
     {

--- a/extendr-api/src/robj/operators.rs
+++ b/extendr-api/src/robj/operators.rs
@@ -104,7 +104,7 @@ impl Robj {
         }
 
         if args.rtype() != RType::Pairlist {
-            return Err(Error::ExpectedPairlist(args.clone()));
+            return Err(Error::ExpectedPairlist(args));
         }
 
         unsafe {

--- a/extendr-api/src/robj/try_from_robj.rs
+++ b/extendr-api/src/robj/try_from_robj.rs
@@ -131,7 +131,7 @@ impl TryFrom<Robj> for Vec<String> {
     fn try_from(robj: Robj) -> Result<Self> {
         if let Some(iter) = robj.as_str_iter() {
             // check for NA's in the string vector
-            if iter.clone().find(|&s| s.is_na()).is_some() {
+            if iter.clone().any(|s| s.is_na()) {
                 Err(Error::MustNotBeNA(robj))
             } else {
                 Ok(iter.map(|s| s.to_string()).collect::<Vec<String>>())

--- a/extendr-api/src/thread_safety.rs
+++ b/extendr-api/src/thread_safety.rs
@@ -118,7 +118,7 @@ where
         F: FnOnce() -> SEXP + Copy,
     {
         let data = data as *const ();
-        let f: &F = std::mem::transmute(data);
+        let f: &F = &*(data as *const F);
         f()
     }
 

--- a/extendr-api/src/wrapper/environment.rs
+++ b/extendr-api/src/wrapper/environment.rs
@@ -101,7 +101,7 @@ impl Environment {
     pub fn set_envflags(&mut self, flags: i32) -> &mut Self {
         unsafe {
             let sexp = self.robj.get();
-            SET_ENVFLAGS(sexp, flags.into())
+            SET_ENVFLAGS(sexp, flags)
         }
         self
     }

--- a/extendr-api/src/wrapper/environment.rs
+++ b/extendr-api/src/wrapper/environment.rs
@@ -213,18 +213,11 @@ impl Iterator for EnvIter {
         loop {
             // Environments are a hash table (list) or pair lists (pairlist)
             // Get the first available value from the pair list.
-            loop {
-                match self.pairlist.next() {
-                    Some((key, value)) => {
-                        // if the key and value are valid, return a pair.
-                        if !key.is_na() && !value.is_unbound_value() {
-                            return Some((key, value));
-                        }
-                    }
-                    // if the key and value are invalid, move on to the hash table.
-                    _ => break,
+            while let Some((key, value)) = self.pairlist.next() {
+                // if the key and value are valid, return a pair.
+                if !key.is_na() && !value.is_unbound_value() {
+                    return Some((key, value));
                 }
-                // continue pair list loop.
             }
 
             // Get the first pairlist from the hash table.

--- a/extendr-api/src/wrapper/list.rs
+++ b/extendr-api/src/wrapper/list.rs
@@ -109,7 +109,7 @@ impl IntoIterator for List {
     /// }
     /// ```
     fn into_iter(self) -> Self::IntoIter {
-        self.iter().clone()
+        self.iter()
     }
 }
 
@@ -250,7 +250,7 @@ impl From<ListIter> for Robj {
     /// }
     /// ```
     fn from(iter: ListIter) -> Self {
-        iter.robj.clone()
+        iter.robj
     }
 }
 

--- a/extendr-api/src/wrapper/list.rs
+++ b/extendr-api/src/wrapper/list.rs
@@ -5,6 +5,12 @@ pub struct List {
     pub(crate) robj: Robj,
 }
 
+impl Default for List {
+    fn default() -> Self {
+        List::new()
+    }
+}
+
 impl List {
     /// Create a new, empty list.
     /// ```
@@ -131,6 +137,12 @@ pub struct ListIter {
     robj: Robj,
     i: usize,
     len: usize,
+}
+
+impl Default for ListIter {
+    fn default() -> Self {
+        ListIter::new()
+    }
 }
 
 impl ListIter {

--- a/extendr-api/src/wrapper/list.rs
+++ b/extendr-api/src/wrapper/list.rs
@@ -218,7 +218,7 @@ where
         let res: Result<Vec<_>> = listiter
             .map(|robj| T::try_from(robj).map_err(|e| e.into()))
             .collect();
-        res.map(|v| FromList(v))
+        res.map(FromList)
     }
 }
 

--- a/extendr-api/src/wrapper/list.rs
+++ b/extendr-api/src/wrapper/list.rs
@@ -167,7 +167,7 @@ impl Iterator for ListIter {
         let i = self.i;
         self.i += 1;
         if i >= self.len {
-            return None;
+            None
         } else {
             Some(unsafe { new_owned(VECTOR_ELT(self.robj.get(), i as isize)) })
         }

--- a/extendr-api/src/wrapper/matrix.rs
+++ b/extendr-api/src/wrapper/matrix.rs
@@ -320,12 +320,7 @@ impl<T> Index<[usize; 2]> for RArray<T, [usize; 2]> {
     /// }
     /// ```
     fn index(&self, index: [usize; 2]) -> &Self::Output {
-        unsafe {
-            self.data
-                .offset(self.offset(index) as isize)
-                .as_ref()
-                .unwrap()
-        }
+        unsafe { self.data.add(self.offset(index)).as_ref().unwrap() }
     }
 }
 
@@ -345,12 +340,7 @@ impl<T> IndexMut<[usize; 2]> for RArray<T, [usize; 2]> {
     /// }
     /// ```
     fn index_mut(&mut self, index: [usize; 2]) -> &mut Self::Output {
-        unsafe {
-            self.data
-                .offset(self.offset(index) as isize)
-                .as_mut()
-                .unwrap()
-        }
+        unsafe { self.data.add(self.offset(index)).as_mut().unwrap() }
     }
 }
 

--- a/extendr-api/src/wrapper/matrix.rs
+++ b/extendr-api/src/wrapper/matrix.rs
@@ -275,7 +275,7 @@ where
 impl<T, D> From<RArray<T, D>> for Robj {
     /// Convert a column, matrix or matrix3d to an Robj.
     fn from(array: RArray<T, D>) -> Self {
-        array.robj.clone()
+        array.robj
     }
 }
 

--- a/extendr-api/src/wrapper/pairlist.rs
+++ b/extendr-api/src/wrapper/pairlist.rs
@@ -164,6 +164,6 @@ impl TryFrom<Robj> for PairlistIter {
 impl From<PairlistIter> for Robj {
     /// You can return a PairlistIter from a function.
     fn from(iter: PairlistIter) -> Self {
-        iter.robj.clone()
+        iter.robj
     }
 }

--- a/extendr-api/src/wrapper/pairlist.rs
+++ b/extendr-api/src/wrapper/pairlist.rs
@@ -87,6 +87,12 @@ pub struct PairlistIter {
     pub(crate) list_elem: SEXP,
 }
 
+impl Default for PairlistIter {
+    fn default() -> Self {
+        PairlistIter::new()
+    }
+}
+
 impl PairlistIter {
     /// Make an empty pairlist iterator.
     pub fn new() -> Self {

--- a/extendr-api/src/wrapper/raw.rs
+++ b/extendr-api/src/wrapper/raw.rs
@@ -30,7 +30,7 @@ impl Raw {
             let sexp = Rf_allocVector(RAWSXP, bytes.len() as R_xlen_t);
             let robj = new_owned(sexp);
             let ptr = RAW(sexp);
-            for (i, &v) in bytes.into_iter().enumerate() {
+            for (i, &v) in bytes.iter().enumerate() {
                 *ptr.add(i) = v;
             }
             Raw { robj }

--- a/extendr-api/src/wrapper/raw.rs
+++ b/extendr-api/src/wrapper/raw.rs
@@ -31,7 +31,7 @@ impl Raw {
             let robj = new_owned(sexp);
             let ptr = RAW(sexp);
             for (i, &v) in bytes.into_iter().enumerate() {
-                *ptr.offset(i as isize) = v;
+                *ptr.add(i) = v;
             }
             Raw { robj }
         })

--- a/extendr-api/src/wrapper/symbol.rs
+++ b/extendr-api/src/wrapper/symbol.rs
@@ -30,7 +30,7 @@ impl Symbol {
     /// }
     /// ```
     pub fn from_str(val: &str) -> Self {
-        if val == "" || val.is_na() {
+        if val.is_empty() || val.is_na() {
             unbound_value()
         } else {
             Symbol {

--- a/extendr-macros/src/lib.rs
+++ b/extendr-macros/src/lib.rs
@@ -570,8 +570,8 @@ fn extendr_impl(mut item_impl: ItemImpl) -> TokenStream {
 pub fn extendr(attr: TokenStream, item: TokenStream) -> TokenStream {
     let args = parse_macro_input!(attr as syn::AttributeArgs);
     match parse_macro_input!(item as Item) {
-        Item::Fn(func) => return extendr_function(args, func),
-        Item::Impl(item_impl) => return extendr_impl(item_impl),
+        Item::Fn(func) => extendr_function(args, func),
+        Item::Impl(item_impl) => extendr_impl(item_impl),
         other_item => TokenStream::from(quote! {#other_item}),
     }
 }

--- a/extendr-macros/src/lib.rs
+++ b/extendr-macros/src/lib.rs
@@ -598,7 +598,7 @@ impl syn::parse::Parse for Module {
         while !input.is_empty() {
             if let Ok(kmod) = input.parse::<Token![mod]>() {
                 let name: Ident = input.parse()?;
-                if !res.modname.is_none() {
+                if res.modname.is_some() {
                     return Err(syn::Error::new(kmod.span(), "only one mod allowed"));
                 }
                 res.modname = Some(name);

--- a/extendr-macros/src/lib.rs
+++ b/extendr-macros/src/lib.rs
@@ -207,7 +207,7 @@ fn get_doc_string(attrs: &Vec<syn::Attribute>) -> String {
                     if let syn::Meta::NameValue(nv) = meta {
                         if let syn::Lit::Str(litstr) = nv.lit {
                             if !res.is_empty() {
-                                res.push_str("\n");
+                                res.push('\n');
                             }
                             res.push_str(&litstr.value());
                         }

--- a/extendr-macros/src/lib.rs
+++ b/extendr-macros/src/lib.rs
@@ -605,11 +605,11 @@ impl syn::parse::Parse for Module {
                     return Err(syn::Error::new(kmod.span(), "only one mod allowed"));
                 }
                 res.modname = Some(name);
-            } else if let Ok(_) = input.parse::<Token![fn]>() {
+            } else if input.parse::<Token![fn]>().is_ok() {
                 res.fnnames.push(input.parse()?);
-            } else if let Ok(_) = input.parse::<Token![impl]>() {
+            } else if input.parse::<Token![impl]>().is_ok() {
                 res.implnames.push(input.parse()?);
-            } else if let Ok(_) = input.parse::<Token![use]>() {
+            } else if input.parse::<Token![use]>().is_ok() {
                 res.usenames.push(input.parse()?);
             } else {
                 return Err(syn::Error::new(input.span(), "expected mod, fn or impl"));

--- a/extendr-macros/src/lib.rs
+++ b/extendr-macros/src/lib.rs
@@ -198,7 +198,7 @@ fn extendr_function(args: Vec<syn::NestedMeta>, func: ItemFn) -> TokenStream {
 }
 
 // Extract doc strings from attributes.
-fn get_doc_string(attrs: &Vec<syn::Attribute>) -> String {
+fn get_doc_string(attrs: &[syn::Attribute]) -> String {
     let mut res = String::new();
     for attr in attrs {
         if let Some(id) = attr.path.get_ident() {
@@ -275,7 +275,7 @@ fn make_function_wrappers(
     _opts: &ExtendrOptions,
     wrappers: &mut Vec<ItemFn>,
     prefix: &str,
-    attrs: &Vec<syn::Attribute>,
+    attrs: &[syn::Attribute],
     sig: &syn::Signature,
     self_ty: Option<&syn::Type>,
 ) {

--- a/extendr-macros/src/lib.rs
+++ b/extendr-macros/src/lib.rs
@@ -202,7 +202,7 @@ fn get_doc_string(attrs: &Vec<syn::Attribute>) -> String {
     let mut res = String::new();
     for attr in attrs {
         if let Some(id) = attr.path.get_ident() {
-            if id.to_string() == "doc" {
+            if *id == "doc" {
                 if let Ok(meta) = attr.parse_meta() {
                     if let syn::Meta::NameValue(nv) = meta {
                         if let syn::Lit::Str(litstr) = nv.lit {

--- a/extendr-macros/src/lib.rs
+++ b/extendr-macros/src/lib.rs
@@ -202,16 +202,16 @@ fn get_doc_string(attrs: &Vec<syn::Attribute>) -> String {
     let mut res = String::new();
     for attr in attrs {
         if let Some(id) = attr.path.get_ident() {
-            if *id == "doc" {
-                if let Ok(meta) = attr.parse_meta() {
-                    if let syn::Meta::NameValue(nv) = meta {
-                        if let syn::Lit::Str(litstr) = nv.lit {
-                            if !res.is_empty() {
-                                res.push('\n');
-                            }
-                            res.push_str(&litstr.value());
-                        }
+            if *id != "doc" {
+                continue;
+            }
+
+            if let Ok(syn::Meta::NameValue(nv)) = attr.parse_meta() {
+                if let syn::Lit::Str(litstr) = nv.lit {
+                    if !res.is_empty() {
+                        res.push('\n');
                     }
+                    res.push_str(&litstr.value());
                 }
             }
         }

--- a/extendr-macros/src/lib.rs
+++ b/extendr-macros/src/lib.rs
@@ -291,10 +291,7 @@ fn make_function_wrappers(
     let panic_str = format!("{} panicked.\0", func_name);
 
     let inputs = &sig.inputs;
-    let has_self = match inputs.iter().next() {
-        Some(FnArg::Receiver(_)) => true,
-        _ => false,
-    };
+    let has_self = matches!(inputs.iter().next(), Some(FnArg::Receiver(_)));
 
     let call_name = if has_self {
         let is_mut = match inputs.iter().next() {

--- a/extendr-macros/src/lib.rs
+++ b/extendr-macros/src/lib.rs
@@ -207,9 +207,9 @@ fn get_doc_string(attrs: &Vec<syn::Attribute>) -> String {
                     if let syn::Meta::NameValue(nv) = meta {
                         if let syn::Lit::Str(litstr) = nv.lit {
                             if !res.is_empty() {
-                                res.extend("\n".chars());
+                                res.push_str("\n");
                             }
-                            res.extend(litstr.value().chars());
+                            res.push_str(&litstr.value());
                         }
                     }
                 }
@@ -235,7 +235,7 @@ fn mangled_type_name(type_: &Type) -> String {
                 res.push(c)
             } else {
                 let f = format!("_{:02x}", c as u32);
-                res.extend(f.chars());
+                res.push_str(&f);
             }
         }
     }


### PR DESCRIPTION
Now it's a good time to look into what warnings clippy complains; some of them should be fixed, and the other might be ignorable.

full warnings: https://gist.github.com/yutannihilation/acc2fb7f4b18d2aba79cf86ae89e4654#file-clippy_warnings_20210320-txt-L360

I still see these warnings, which I don't know how to fix:

```
warning: unsafe function's docs miss `# Safety` section
  --> extendr-api/src/ownership.rs:24:1
   |
24 | / pub unsafe fn protect(sexp: SEXP) {
25 | |     let mut own = OWNERSHIP.lock().expect("protect failed");
26 | |     own.protect(sexp);
27 | | }
   | |_^
   |
   = note: `#[warn(clippy::missing_safety_doc)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#missing_safety_doc

warning: unsafe function's docs miss `# Safety` section
  --> extendr-api/src/ownership.rs:29:1
   |
29 | / pub unsafe fn unprotect(sexp: SEXP) {
30 | |     let mut own = OWNERSHIP.lock().expect("unprotect failed");
31 | |     own.unprotect(sexp);
32 | | }
   | |_^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#missing_safety_doc

warning: item `robj::Robj` has a public `len` method but no corresponding `is_empty` method
   --> extendr-api/src/robj/mod.rs:146:1
    |
146 | / impl Robj {
147 | |     /// Get a copy of the underlying SEXP.
148 | |     /// Note: this is unsafe.
149 | |     #[doc(hidden)]
...   |
689 | |     }
690 | | }
    | |_^
    |
    = note: `#[warn(clippy::len_without_is_empty)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#len_without_is_empty

warning: methods called `to_*` usually take self by reference; consider choosing a less ambiguous name
   --> extendr-api/src/robj/mod.rs:684:21
    |
684 |     pub fn to_owned(self) -> Robj {
    |                     ^^^^
    |
    = note: `#[warn(clippy::wrong_self_convention)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#wrong_self_convention

warning: method `from_str` can be confused for the standard trait method `std::str::FromStr::from_str`
  --> extendr-api/src/wrapper/character.rs:22:5
   |
22 | /     pub fn from_str(val: &str) -> Self {
23 | |         unsafe {
24 | |             Character {
25 | |                 robj: new_owned(str_to_character(val)),
26 | |             }
27 | |         }
28 | |     }
   | |_____^
   |
   = note: `#[warn(clippy::should_implement_trait)]` on by default
   = help: consider implementing the trait `std::str::FromStr` or choosing a less ambiguous method name
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#should_implement_trait

warning: methods called `new` usually take no self; consider choosing a less ambiguous name
  --> extendr-api/src/wrapper/environment.rs:17:16
   |
17 |     pub fn new(parent: Environment) -> Self {
   |                ^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#wrong_self_convention

warning: methods called `from_*` usually take no self; consider choosing a less ambiguous name
  --> extendr-api/src/wrapper/environment.rs:58:27
   |
58 |     pub fn from_pairs<NV>(parent: Environment, names_and_values: NV) -> Self
   |                           ^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#wrong_self_convention

warning: method `from_str` can be confused for the standard trait method `std::str::FromStr::from_str`
  --> extendr-api/src/wrapper/primitive.rs:30:5
   |
30 | /     pub fn from_str(val: &str) -> Result<Self> {
31 | |         single_threaded(|| unsafe {
32 | |             // Primitives have a special "SYMVALUE" entry in their symbol.
33 | |             let sym = Symbol::from_str(val);
...  |
40 | |         })
41 | |     }
   | |_____^
   |
   = help: consider implementing the trait `std::str::FromStr` or choosing a less ambiguous method name
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#should_implement_trait

warning: method `from_str` can be confused for the standard trait method `std::str::FromStr::from_str`
  --> extendr-api/src/wrapper/symbol.rs:32:5
   |
32 | /     pub fn from_str(val: &str) -> Self {
33 | |         if val.is_empty() || val.is_na() {
34 | |             unbound_value()
35 | |         } else {
...  |
39 | |         }
40 | |     }
   | |_____^
   |
   = help: consider implementing the trait `std::str::FromStr` or choosing a less ambiguous method name
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#should_implement_trait

warning: 9 warnings emitted

    Finished dev [unoptimized + debuginfo] target(s) in 0.03s
```