### PR TITLE
Remove unused lazy_static from extendr-macro

### DIFF
--- a/extendr-macros/Cargo.toml
+++ b/extendr-macros/Cargo.toml
@@ -19,4 +19,3 @@ proc_macro = true
 [dependencies]
 syn = { version = "1.0.22", features = ["full", "extra-traits"] }
 quote = "1.0.6"
-lazy_static = "1.4.0"


### PR DESCRIPTION
Currently, lazy_static is used only in extendr-api, so it seems we can remove this line.