### PR TITLE
Fix for builds on arm32, arm64, ppc, etc

### DIFF
--- a/extendr-api/src/wrapper/mod.rs
+++ b/extendr-api/src/wrapper/mod.rs
@@ -36,7 +36,7 @@ pub(crate) fn make_symbol(name: &str) -> SEXP {
     let mut bytes = Vec::with_capacity(name.len() + 1);
     bytes.extend(name.bytes());
     bytes.push(0);
-    unsafe { Rf_install(bytes.as_ptr() as *const i8) }
+    unsafe { Rf_install(bytes.as_ptr() as *const ::std::os::raw::c_char) }
 }
 
 pub(crate) fn make_vector<T>(sexptype: u32, values: T) -> Robj


### PR DESCRIPTION
Fixes this build error on platforms where `c_char` is defined as u8:
```
error[E0308]: mismatched types
   --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/extendr-api-0.2.0/src/wrapper.rs:368:25
    |
368 |     unsafe { Rf_install(bytes.as_ptr() as *const i8) }
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `i8`
    |
    = note: expected raw pointer `*const u8`
               found raw pointer `*const i8`
```

The underlying `Rf_install` binding defines this as a C char, see e.g.: https://github.com/extendr/libR-sys/search?q=rf_install
That C char type can either be an `i8` or a `u8`, depending on platform: https://doc.rust-lang.org/src/std/os/raw/mod.rs.html#48-90