### PR TITLE
Remove MSYS2 path on GitHub Actions CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,20 +91,17 @@ jobs:
         if: startsWith(runner.os, 'Windows')
         # 1. Add rust target
         # 2. Add target name to the $targets variable
-        # 3. Add mingw32/mingw64 bin folders to PATH
-        # 4. Add R x64/i386 folders to PATH
+        # 3. Add R x64/i386 folders to PATH
         run: |
           $targets=@()
           if ($env:RUST_TOOLCHAIN -notlike "*x86_64*") {
             rustup target add i686-pc-windows-gnu ;
             $targets+="i686-pc-windows-gnu"
-            echo "C:\msys64\mingw32\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
             echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\i386"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
           }
           if ($env:RUST_TOOLCHAIN -notlike "*i686*") {
             rustup target add x86_64-pc-windows-gnu ;
             $targets+="x86_64-pc-windows-gnu"
-            echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
             echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\x64"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
           }
           echo "BUILD_TARGETS=$($targets -join ',')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append ;
@@ -348,16 +345,14 @@ jobs:
       # 1. Inspect targets. If empty, assume 'x86_64' arch
       # 1.5 Make symlink to please i686 toolchain (https://github.com/rust-lang/cargo/issues/8990)
       # 2. Install msys2 packages (--needed skips already installed)
-      # 3. Add msys2/mingw{bits}/bin to path
-      # 4. Add R/{arch}/bin to path
-      # 5. Create array of correct (arch-dependent) paths to 'libclang.dll', export as env variable
+      # 3. Add R/{arch}/bin to path
+      # 4. Create array of correct (arch-dependent) paths to 'libclang.dll', export as env variable
       - name: Configure Windows
         if: startsWith(runner.os, 'Windows')
         run: |
           if (($env:BUILD_TARGETS -like "*x86_64*") -or ($env:BUILD_TARGETS -eq "")) {
             echo "::group::Setting up x86_64"
             C:\msys64\usr\bin\bash.exe -l -c "pacman -S --noconfirm  --needed mingw-w64-x86_64-clang mingw-w64-x86_64-toolchain"
-            echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
             echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\x64"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
             echo "::endgroup::"
           }
@@ -366,7 +361,6 @@ jobs:
             mkdir target\debug -ErrorAction Ignore
             new-item -Type symboliclink -Path .\target\debug\libgcc_s_dw2-1.dll -Value C:\msys64\mingw32\bin\libgcc_s_dw2-1.dll
             C:\msys64\usr\bin\bash.exe -l -c "pacman -S --noconfirm --needed mingw32/mingw-w64-i686-clang mingw-w64-i686-toolchain"
-            echo "C:\msys64\mingw32\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
             echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\i386"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
             echo "::endgroup::"
           }


### PR DESCRIPTION
As https://github.com/extendr/rextendr/issues/91 did commited on rextendr, probably we can do the same thing on extendr as well?