### PR TITLE
Fix clippy warnings

### DIFF
--- a/extendr-api/src/metadata.rs
+++ b/extendr-api/src/metadata.rs
@@ -274,13 +274,14 @@ fn write_impl_wrapper(
     if exported {
         writeln!(w, "#' @rdname {}", imp.name)?;
         writeln!(w, "#' @usage NULL")?;
-        writeln!(w, "#' @export")?;
-    } else {
-        // we always export the `$` method so the method is correctly
-        // added to the NAMESPACE even if we don't export the class
-        // itself and its initializers.
-        writeln!(w, "#' @export")?;
     }
+
+    // This is needed no matter whether the user added `@export` or
+    // not; even if we don't export the class itself and its
+    // initializers, we always export the `$` method so the method is
+    // correctly added to the NAMESPACE.
+    writeln!(w, "#' @export")?;
+
     // LHS with dollar operator is wrapped in ``, so pass name as is,
     // but in the body `imp_name_fixed` is called as valid R function,
     // so we pass preprocessed value

--- a/extendr-api/src/wrapper/environment.rs
+++ b/extendr-api/src/wrapper/environment.rs
@@ -213,7 +213,7 @@ impl Iterator for EnvIter {
         loop {
             // Environments are a hash table (list) or pair lists (pairlist)
             // Get the first available value from the pair list.
-            while let Some((key, value)) = self.pairlist.next() {
+            for (key, value) in &mut self.pairlist {
                 // if the key and value are valid, return a pair.
                 if !key.is_na() && !value.is_unbound_value() {
                     return Some((key, value));

--- a/extendr-macros/src/extendr_impl.rs
+++ b/extendr-macros/src/extendr_impl.rs
@@ -64,7 +64,7 @@ pub fn extendr_impl(mut item_impl: ItemImpl) -> TokenStream {
 
     let opts = wrappers::ExtendrOptions {};
     let self_ty = item_impl.self_ty.as_ref();
-    let self_ty_name = wrappers::type_name(&self_ty);
+    let self_ty_name = wrappers::type_name(self_ty);
     let prefix = format!("{}__", self_ty_name);
     let mut method_meta_names = Vec::new();
     let doc_string = wrappers::get_doc_string(&item_impl.attrs);

--- a/extendr-macros/src/wrappers.rs
+++ b/extendr-macros/src/wrappers.rs
@@ -23,7 +23,7 @@ pub fn make_function_wrappers(
 
     let name_str = format!("{}", func_name);
     let doc_string = get_doc_string(attrs);
-    let return_type_string = get_return_type(&sig);
+    let return_type_string = get_return_type(sig);
 
     let panic_str = format!("{} panicked.\0", func_name);
 


### PR DESCRIPTION
Since Rust 1.53 is released, I tried clippy for the first time in a while, and found 3 new types of warnings. One thing I'm not sure is which is better the explicit (but redundant) `else` branch or no `else` branch, but the other two are straightforward.

<details>

```
❯ cargo +nightly clippy
   Compiling syn v1.0.52
    Checking extendr-macros v0.2.0 (/home/yutani/repo/extendr/extendr-macros)
warning: this expression borrows a reference (`&syn::Type`) that is immediately dereferenced by the compiler
  --> extendr-macros/src/extendr_impl.rs:67:44
   |
67 |     let self_ty_name = wrappers::type_name(&self_ty);
   |                                            ^^^^^^^^ help: change this to: `self_ty`
   |
   = note: `#[warn(clippy::needless_borrow)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: this expression borrows a reference (`&syn::Signature`) that is immediately dereferenced by the compiler
  --> extendr-macros/src/wrappers.rs:26:46
   |
26 |     let return_type_string = get_return_type(&sig);
   |                                              ^^^^ help: change this to: `sig`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: 2 warnings emitted

warning: this expression borrows a reference (`&syn::Type`) that is immediately dereferenced by the compiler
  --> extendr-macros/src/extendr_impl.rs:67:44
   |
67 |     let self_ty_name = wrappers::type_name(&self_ty);
   |                                            ^^^^^^^^ help: change this to: `self_ty`
   |
   = note: `#[warn(clippy::needless_borrow)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: this expression borrows a reference (`&syn::Signature`) that is immediately dereferenced by the compiler
  --> extendr-macros/src/wrappers.rs:26:46
   |
26 |     let return_type_string = get_return_type(&sig);
   |                                              ^^^^ help: change this to: `sig`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: 2 warnings emitted

    Checking extendr-api v0.2.0 (/home/yutani/repo/extendr/extendr-api)
warning: all if blocks contain the same code at the end
   --> extendr-api/src/metadata.rs:282:5
    |
282 | /         writeln!(w, "#' @export")?;
283 | |     }
    | |_____^
    |
    = note: `#[warn(clippy::branches_sharing_code)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#branches_sharing_code
help: consider moving the end statements out like this
    |
282 |     }
283 |     writeln!(w, "#' @export")?;
    |

warning: this loop could be written as a `for` loop
   --> extendr-api/src/wrapper/environment.rs:216:13
    |
216 |             while let Some((key, value)) = self.pairlist.next() {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for (key, value) in &mut self.pairlist`
    |
    = note: `#[warn(clippy::while_let_on_iterator)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#while_let_on_iterator

warning: 2 warnings emitted

    Finished dev [unoptimized + debuginfo] target(s) in 11.43s

```

</details>