### PR TITLE
Get `SymPair` to return `Option<Symbol>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 - Use Use failure() to trigger steps on failures
 
+- `SymPair::sym_pair()` now returns `(Option<Robj>, Robj)`
 
 ## extendr 0.2.0
 

--- a/extendr-api/src/wrapper/environment.rs
+++ b/extendr-api/src/wrapper/environment.rs
@@ -65,7 +65,9 @@ impl Environment {
             let robj = call!("new.env", TRUE, parent, dict_len).unwrap();
             for nv in names_and_values {
                 let (n, v) = nv.sym_pair();
-                unsafe { Rf_defineVar(n.get(), v.get(), robj.get()) }
+                if let Some(n) = n {
+                    unsafe { Rf_defineVar(n.get(), v.get(), robj.get()) }
+                }
             }
             Environment { robj }
         })

--- a/extendr-api/src/wrapper/mod.rs
+++ b/extendr-api/src/wrapper/mod.rs
@@ -200,7 +200,7 @@ impl Robj {
     /// ```
     /// use extendr_api::prelude::*;
     /// test! {
-    ///     let names_and_values = vec![("a", r!(1)), ("b", r!(2)), (na_str(), r!(3))];
+    ///     let names_and_values = vec![("a", r!(1)), ("b", r!(2)), ("", r!(3))];
     ///     let pairlist = Pairlist::from_pairs(names_and_values);
     ///     let robj = r!(pairlist.clone());
     ///     assert_eq!(robj.as_pairlist().unwrap(), pairlist);
@@ -272,7 +272,7 @@ impl Robj {
 }
 
 pub trait SymPair {
-    fn sym_pair(self) -> (Robj, Robj);
+    fn sym_pair(self) -> (Option<Robj>, Robj);
 }
 
 impl<S, R> SymPair for (S, R)
@@ -280,8 +280,15 @@ where
     S: AsRef<str>,
     R: Into<Robj>,
 {
-    fn sym_pair(self) -> (Robj, Robj) {
-        (r!(Symbol::from_string(self.0.as_ref())), self.1.into())
+    fn sym_pair(self) -> (Option<Robj>, Robj) {
+        let val = self.0.as_ref();
+        // "" represents the absense of the name
+        let nm = if val.is_empty() {
+            None
+        } else {
+            Some(r!(Symbol::from_string(val)))
+        };
+        (nm, self.1.into())
     }
 }
 
@@ -291,10 +298,13 @@ where
     R: Into<Robj>,
     R: Clone,
 {
-    fn sym_pair(self) -> (Robj, Robj) {
-        (
-            r!(Symbol::from_string(self.0.as_ref())),
-            self.1.clone().into(),
-        )
+    fn sym_pair(self) -> (Option<Robj>, Robj) {
+        let val = self.0.as_ref();
+        let nm = if val.is_empty() {
+            None
+        } else {
+            Some(r!(Symbol::from_string(val)))
+        };
+        (nm, self.1.clone().into())
     }
 }

--- a/extendr-api/src/wrapper/pairlist.rs
+++ b/extendr-api/src/wrapper/pairlist.rs
@@ -150,7 +150,7 @@ impl IntoIterator for Pairlist {
     /// test! {
     ///     let pairlist = pairlist!(a=1, 2).as_pairlist().unwrap();
     ///     let vec : Vec<_> = pairlist.into_iter().collect();
-    ///     assert_eq!(vec, vec![("a", r!(1)), (na_str(), r!(2))]);
+    ///     assert_eq!(vec, vec![("a", r!(1)), ("", r!(2))]);
     /// }
     /// ```
     fn into_iter(self) -> Self::IntoIter {

--- a/extendr-api/src/wrapper/symbol.rs
+++ b/extendr-api/src/wrapper/symbol.rs
@@ -18,25 +18,17 @@ pub struct Symbol {
 impl Symbol {
     /// Make a symbol object from a string.
     ///
-    /// The values na_str() and "" give unbound_value().
-    ///
     /// ```
     /// use extendr_api::prelude::*;
     /// test! {
     ///     let chr = r!(Symbol::from_string("xyz"));
     ///     assert_eq!(chr, sym!(xyz));
-    ///     assert_eq!(Symbol::from_string(na_str()).is_unbound_value(), true);
-    ///     assert_eq!(Symbol::from_string("").is_unbound_value(), true);
     /// }
     /// ```
     pub fn from_string<S: AsRef<str>>(val: S) -> Self {
         let val = val.as_ref();
-        if val.is_empty() || val.is_na() {
-            unbound_value()
-        } else {
-            Symbol {
-                robj: unsafe { new_owned(make_symbol(val)) },
-            }
+        Symbol {
+            robj: unsafe { new_owned(make_symbol(val)) },
         }
     }
 


### PR DESCRIPTION
Fix #195 

This pull request is to remove the necessity to use unbound value to represent the absence of the name. I decided to follow [Andy's comment](https://github.com/extendr/extendr/issues/195#issuecomment-817832510). Instead, users can use `""` (empty string).

This is consistent with the behavior of R (c.f. https://github.com/extendr/extendr/issues/195#issuecomment-803497556, https://github.com/extendr/extendr/issues/195#issuecomment-803498672)

While this is a breaking change in that `SymPair::sym_pair()` now returns `(Option<Robj>, Robj)` instead of `(Robj, Robj)`, I expect this doesn't affect the existing users much as this is rather an expert-only feature at the moment.