### PR TITLE
[WIP] Check length of input in <&str>::try_from()

### DIFF
--- a/extendr-api/src/robj/try_from_robj.rs
+++ b/extendr-api/src/robj/try_from_robj.rs
@@ -84,11 +84,18 @@ impl TryFrom<Robj> for &str {
 
     fn try_from(robj: Robj) -> Result<Self> {
         if robj.is_na() {
-            Err(Error::MustNotBeNA(robj))
-        } else if let Some(s) = robj.as_str() {
-            Ok(s)
-        } else {
-            Err(Error::ExpectedString(robj))
+            return Err(Error::MustNotBeNA(robj));
+        }
+        match robj.len() {
+            0 => Err(Error::ExpectedNonZeroLength(robj)),
+            1 => {
+                if let Some(s) = robj.as_str() {
+                    Ok(s)
+                } else {
+                    Err(Error::ExpectedString(robj))
+                }
+            }
+            _ => Err(Error::ExpectedScalar(robj)),
         }
     }
 }


### PR DESCRIPTION
Fix #102

While other `try_from()` implementations use the following logic, `&str` is a bit tricky in that it fails with `cannot return value referencing local variable` error, 

``` rust
        if let Some(v) = robj.as_<type>_slice() {
            match v.len() {
                0 => Err(Error::ExpectedNonZeroLength(robj)),
                1 => Ok(v[0]),
                _ => Err(Error::ExpectedScalar(robj)),
            }
        } else {
            Err(Error::ExpectedLogical(robj))
        }
```

so I chose to check the length before trying to convert the input to the actual variable.