### PR TITLE
[WIP] document the conventions on conversions between R and Rust

### DIFF
--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -8,6 +8,57 @@
 //! * Users should be able to do almost everything without using libR_sys.
 //! * The interface should be friendly to R users without Rust experience.
 //!
+//! ## Conversion between R and Rust
+//!
+//! The following types of traits and methods are provided for conversions from
+//! R objects to Rust objects:
+//!
+//! - **`try_from()`** ([TryFrom] trait): This is the main way of doing
+//!   conversions from R to Rust. The conversion might fail when
+//!     1. the type or value of the R object is incompatible with the
+//!        destination type (e.g. `CHARSXP` to `i32`)
+//!     1. the value cannot be represented by the destination type (e.g. `NA` to
+//!        a non-`Option` type, and a multi-element vector to a scalar type)
+//!     1. the conversion would be lossy (e.g. `1.5` to `i32`)
+//! - **`as_xxx()`**: This is rather "casting" than conversion. This returns
+//!   `Some(T)` only when the underlying SEXP has the corresponding type (e.g.
+//!   `<INTSXP>::as_integer()` returns `Some(i32)`, while
+//!   `<REALSXP>::as_integer()` returns `None`). Note that, while this might
+//!   look a bit tricky to those who are familiar with R's `as.xxx()` functions,
+//!   which kindly converts between types. But, this just follows the Rust API
+//!   guidelines' [naming convention on conversion methods][c-conv].
+//! - **`from_robj()`** ([FromRobj] trait): (The trait in the process of
+//!   deprecation)
+//!
+//! [c-conv]:
+//! https://rust-lang.github.io/api-guidelines/naming.html#ad-hoc-conversions-follow-as_-to_-into_-conventions-c-conv
+//!
+//! Also, the following types of traits and methods are provided for conversions
+//! from Rust objects to R objects:
+//!
+//! - **`<Robj>::from()`** ([From] trait): This conversion never fails and is
+//!   lossless.
+//! - **`<a subtype of Robj>::from_xxx()`**: This is conversion constructor.
+//!   This might be fallible or non-fallible depending on the case.
+//!   (TODO: maybe we need to review if fallible conversion correctly returns `Result`?)
+//! 
+//! ### Integer types and floating-point types
+//! 
+//! * (TODO: explain `u32`, `u64` and `i64` are converted to `REALSXP`, not `INTSXP`).
+//! * (TODO: explain the check on the limits and the roundings of R-to-Rust conversion)
+//! 
+//! ### Scalar and Vector
+//! 
+//! TBD
+//! 
+//! ### Missing values
+//! 
+//! TBD
+//! 
+//! ### `NULL`
+//! 
+//! * (TODO: explain [Nullable])
+//! 
 
 use libR_sys::*;
 use std::os::raw;

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -45,21 +45,28 @@
 //!   This might be fallible or non-fallible depending on the case. (TODO: maybe
 //!   we need to review if fallible conversion correctly returns `Result`?)
 //!
-//! ### Vector
+//! ### Vector vs Scalar
 //!
 //! A vector of primitive types (e.g. integer and double) can be converted to
-//! `Vec<T>` via `TryFrom` trait.
+//! `Vec<T>` or `&[T]` via [TryFrom] trait. For efficiency purposes, the
+//! conversion rule of a vector is stricter than that of a scalar.
 //!
-//! ### Missing values
-//!
-//! A scalar that possibly be a missing value can be converted to `Option<T>`.
-//!
-//! ### Integer types and floating-point types
-//!
-//! * (TODO: explain `u32`, `u64` and `i64` are converted to `REALSXP`, not
-//!   `INTSXP`).
-//! * (TODO: explain the check on the limits and the roundings of R-to-Rust
-//!   conversion)
+//! - **Missing values**: A scalar that possibly be a missing value can be
+//!   converted to `Option<T>`. But, for a vector, there's no conversion like
+//!   `Vec<Option<T>>` or `&[Option<T>]`. If you need to handle a vector with
+//!   possible missing values on Rust's side, you need to use proxy types (e.g.,
+//!   [`Real`], [`Int`], or [`Robj`] directly) and check with [`Robj::is_na()`].
+//! - **Ineger and floating-point types**: Basically, `REALSXP` has `f64`
+//!   representation, and `INTSXP` has `i32` one, so these vectors can naturally
+//!   be converted to the corresponding types (almost) for free. But, if we want
+//!   to convert them to another variants of the integer and floating-point
+//!   types, it requires some checking on the limit and rounding (e.g. are `i32`
+//!   values within the `i16` range?), which might take some time. Thus, for
+//!   efficiency purposes, extendr doesn't provide the direct conversion from a
+//!   vector to `Vec<T>` or `&[T]` of other variants. On the other hand, a
+//!   scalar can be converted to any variants (i.e., `i8`, `i16`, `i64`, `u8`,
+//!   `u16`, `u32`, `u64`, `f32`, `f64`). Of course it fails if the conversion
+//!   is lossy (e.g. `1.5_f32` cannot be converted to integer-alikes).
 //!
 //! ### `NULL`
 //!

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -27,6 +27,9 @@
 //!   look a bit tricky to those who are familiar with R's `as.xxx()` functions,
 //!   which kindly converts between types. But, this just follows the Rust API
 //!   guidelines' [naming convention on conversion methods][c-conv].
+//! - **`to_xxx()`**: This is a conversion that changes one representation to
+//!   another. Unlike other conversions, this can be lossy, or require some
+//!   complex work to complete.
 //! - **`from_robj()`** ([FromRobj] trait): (The trait in the process of
 //!   deprecation)
 //!
@@ -39,13 +42,15 @@
 //! - **`<Robj>::from()`** ([From] trait): This conversion never fails and is
 //!   lossless.
 //! - **`<a subtype of Robj>::from_xxx()`**: This is conversion constructor.
-//!   This might be fallible or non-fallible depending on the case.
-//!   (TODO: maybe we need to review if fallible conversion correctly returns `Result`?)
+//!   This might be fallible or non-fallible depending on the case. (TODO: maybe
+//!   we need to review if fallible conversion correctly returns `Result`?)
 //!
 //! ### Integer types and floating-point types
 //!
-//! * (TODO: explain `u32`, `u64` and `i64` are converted to `REALSXP`, not `INTSXP`).
-//! * (TODO: explain the check on the limits and the roundings of R-to-Rust conversion)
+//! * (TODO: explain `u32`, `u64` and `i64` are converted to `REALSXP`, not
+//!   `INTSXP`).
+//! * (TODO: explain the check on the limits and the roundings of R-to-Rust
+//!   conversion)
 //!
 //! ### Scalar and Vector
 //!

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -41,24 +41,24 @@
 //! - **`<a subtype of Robj>::from_xxx()`**: This is conversion constructor.
 //!   This might be fallible or non-fallible depending on the case.
 //!   (TODO: maybe we need to review if fallible conversion correctly returns `Result`?)
-//! 
+//!
 //! ### Integer types and floating-point types
-//! 
+//!
 //! * (TODO: explain `u32`, `u64` and `i64` are converted to `REALSXP`, not `INTSXP`).
 //! * (TODO: explain the check on the limits and the roundings of R-to-Rust conversion)
-//! 
+//!
 //! ### Scalar and Vector
-//! 
+//!
 //! TBD
-//! 
+//!
 //! ### Missing values
-//! 
+//!
 //! TBD
-//! 
+//!
 //! ### `NULL`
-//! 
+//!
 //! * (TODO: explain [Nullable])
-//! 
+//!
 
 use libR_sys::*;
 use std::os::raw;

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -45,20 +45,21 @@
 //!   This might be fallible or non-fallible depending on the case. (TODO: maybe
 //!   we need to review if fallible conversion correctly returns `Result`?)
 //!
+//! ### Vector
+//!
+//! A vector of primitive types (e.g. integer and double) can be converted to
+//! `Vec<T>` via `TryFrom` trait.
+//!
+//! ### Missing values
+//!
+//! A scalar that possibly be a missing value can be converted to `Option<T>`.
+//!
 //! ### Integer types and floating-point types
 //!
 //! * (TODO: explain `u32`, `u64` and `i64` are converted to `REALSXP`, not
 //!   `INTSXP`).
 //! * (TODO: explain the check on the limits and the roundings of R-to-Rust
 //!   conversion)
-//!
-//! ### Scalar and Vector
-//!
-//! TBD
-//!
-//! ### Missing values
-//!
-//! TBD
 //!
 //! ### `NULL`
 //!


### PR DESCRIPTION
Now `TryFrom` infrastructure is maturing, but we still have `FromRobj`, in addition to other methods. So, I think it's good time to have some document about the conventions (or semantics?) on various types of conversions to avoid confusion. I feel it's not only users but also us who don't get the sense of when to use what. Though I think I'm not the right person to address this, but here's my attempt to document the current status, mainly to start a discussion, rather than to actually get merged. Feedback is welcome, and if it's better to discuss on an issue instead of this pull request, I'll file a new one.

Here's an appendix, in case this is useful:
<https://gist.github.com/yutannihilation/15e1f90099985f35c331ea78b8edb4cd#file-99_appendix-md>