### PR TITLE
More try_from conversions

### DIFF
--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -655,7 +655,7 @@ mod tests {
                 wrap__robjtype(Robj::from(1).get());
 
                 // General integer types.
-                assert_eq!(new_owned(wrap__return_u8()), Robj::from(123));
+                assert_eq!(new_owned(wrap__return_u8()), Robj::from(123_u8));
                 assert_eq!(new_owned(wrap__return_u16()), Robj::from(123));
                 assert_eq!(new_owned(wrap__return_u32()), Robj::from(123.));
                 assert_eq!(new_owned(wrap__return_u64()), Robj::from(123.));

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -199,8 +199,27 @@ macro_rules! impl_integer_tvv {
 impl_integer_tvv!(i8);
 impl_integer_tvv!(i16);
 impl_integer_tvv!(i32);
-impl_integer_tvv!(u8);
 impl_integer_tvv!(u16);
+
+impl ToVectorValue for u8 {
+    fn sexptype() -> SEXPTYPE {
+        RAWSXP
+    }
+
+    fn to_raw(&self) -> u8 {
+        *self as u8
+    }
+}
+
+impl ToVectorValue for &u8 {
+    fn sexptype() -> SEXPTYPE {
+        RAWSXP
+    }
+
+    fn to_raw(&self) -> u8 {
+        **self as u8
+    }
+}
 
 macro_rules! impl_str_tvv {
     ($t: ty) => {
@@ -353,6 +372,12 @@ where
                 STRSXP => {
                     for (i, v) in iter.enumerate() {
                         SET_STRING_ELT(sexp, i as isize, v.to_sexp());
+                    }
+                }
+                RAWSXP => {
+                    let ptr = RAW(sexp);
+                    for (i, v) in iter.enumerate() {
+                        *ptr.add(i) = v.to_raw();
                     }
                 }
                 _ => {

--- a/extendr-api/src/robj/tests.rs
+++ b/extendr-api/src/robj/tests.rs
@@ -161,6 +161,12 @@ fn test_try_from_robj() {
         assert_eq!(<&[Bool]>::try_from(Robj::from(TRUE)), Ok(&[TRUE][..]));
         assert_eq!(<&[u8]>::try_from(Robj::from(0_u8)), Ok(&[0_u8][..]));
 
+        // Note the Vec<> cases use the same logic as the slices.
+        assert_eq!(<&[i32]>::try_from(Robj::from(1.0)), Err(Error::ExpectedInteger(r!(1.0))));
+        assert_eq!(<&[f64]>::try_from(Robj::from(1)), Err(Error::ExpectedReal(r!(1))));
+        assert_eq!(<&[Bool]>::try_from(Robj::from(())), Err(Error::ExpectedLogical(r!(()))));
+        assert_eq!(<&[u8]>::try_from(Robj::from(())), Err(Error::ExpectedRaw(r!(()))));
+
         let hello = Robj::from("hello");
         assert_eq!(<&str>::try_from(hello), Ok("hello"));
 

--- a/extendr-api/src/robj/tests.rs
+++ b/extendr-api/src/robj/tests.rs
@@ -153,9 +153,19 @@ fn test_try_from_robj() {
 
         assert_eq!(<Vec::<i32>>::try_from(Robj::from(1)), Ok(vec![1]));
         assert_eq!(<Vec::<f64>>::try_from(Robj::from(1.)), Ok(vec![1.]));
+        assert_eq!(<Vec::<Bool>>::try_from(Robj::from(TRUE)), Ok(vec![TRUE]));
+        assert_eq!(<Vec::<u8>>::try_from(Robj::from(0_u8)), Ok(vec![0_u8]));
+
+        assert_eq!(<&[i32]>::try_from(Robj::from(1)), Ok(&[1][..]));
+        assert_eq!(<&[f64]>::try_from(Robj::from(1.)), Ok(&[1.][..]));
+        assert_eq!(<&[Bool]>::try_from(Robj::from(TRUE)), Ok(&[TRUE][..]));
+        assert_eq!(<&[u8]>::try_from(Robj::from(0_u8)), Ok(&[0_u8][..]));
 
         let hello = Robj::from("hello");
         assert_eq!(<&str>::try_from(hello), Ok("hello"));
+
+        let hello = Robj::from("hello");
+        assert_eq!(<String>::try_from(hello), Ok("hello".into()));
 
         // conversion from a vector to a scalar value
         let robj = Robj::from(vec![].as_slice() as &[i32]);

--- a/extendr-api/src/robj/try_from_robj.rs
+++ b/extendr-api/src/robj/try_from_robj.rs
@@ -7,6 +7,7 @@ macro_rules! impl_try_from_scalar_integer {
         impl TryFrom<Robj> for $t {
             type Error = Error;
 
+            /// Convert a numeric object to an integer value.
             fn try_from(robj: Robj) -> Result<Self> {
                 // Check if the value is a scalar
                 match robj.len() {
@@ -57,6 +58,7 @@ macro_rules! impl_try_from_scalar_real {
         impl TryFrom<Robj> for $t {
             type Error = Error;
 
+            /// Convert a numeric object to a real value.
             fn try_from(robj: Robj) -> Result<Self> {
                 // Check if the value is a scalar
                 match robj.len() {
@@ -100,6 +102,8 @@ impl_try_from_scalar_real!(f64);
 impl TryFrom<Robj> for Bool {
     type Error = Error;
 
+    /// Convert an LGLSXP object into a Bool (tri-state boolean).
+    /// Use `value.is_na()` to detect NA values.
     fn try_from(robj: Robj) -> Result<Self> {
         if let Some(v) = robj.as_logical_slice() {
             match v.len() {
@@ -116,6 +120,8 @@ impl TryFrom<Robj> for Bool {
 impl TryFrom<Robj> for bool {
     type Error = Error;
 
+    /// Convert an LGLSXP object into a boolean.
+    /// NAs are not allowed.
     fn try_from(robj: Robj) -> Result<Self> {
         if robj.is_na() {
             Err(Error::MustNotBeNA(robj))
@@ -128,6 +134,8 @@ impl TryFrom<Robj> for bool {
 impl TryFrom<Robj> for &str {
     type Error = Error;
 
+    /// Convert a scalar STRSXP object into a string slice.
+    /// NAs are not allowed.
     fn try_from(robj: Robj) -> Result<Self> {
         if robj.is_na() {
             return Err(Error::MustNotBeNA(robj));
@@ -149,6 +157,9 @@ impl TryFrom<Robj> for &str {
 impl TryFrom<Robj> for String {
     type Error = Error;
 
+    /// Convert an scalar STRSXP object into a String.
+    /// Note: Unless you plan to store the result, use a string slice instead.
+    /// NAs are not allowed.
     fn try_from(robj: Robj) -> Result<Self> {
         <&str>::try_from(robj).map(|s| s.to_string())
     }
@@ -157,6 +168,9 @@ impl TryFrom<Robj> for String {
 impl TryFrom<Robj> for Vec<i32> {
     type Error = Error;
 
+    /// Convert an INTSXP object into a vector of i32 (integer).
+    /// Note: Unless you plan to store the result, use a slice instead.
+    /// Use `value.is_na()` to detect NA values.
     fn try_from(robj: Robj) -> Result<Self> {
         if let Some(v) = robj.as_integer_slice() {
             Ok(Vec::from(v))
@@ -169,6 +183,9 @@ impl TryFrom<Robj> for Vec<i32> {
 impl TryFrom<Robj> for Vec<f64> {
     type Error = Error;
 
+    /// Convert a REALSXP object into a vector of f64 (double precision floating point).
+    /// Note: Unless you plan to store the result, use a slice instead.
+    /// Use `value.is_na()` to detect NA values.
     fn try_from(robj: Robj) -> Result<Self> {
         if let Some(v) = robj.as_real_slice() {
             Ok(Vec::from(v))
@@ -181,6 +198,9 @@ impl TryFrom<Robj> for Vec<f64> {
 impl TryFrom<Robj> for Vec<Bool> {
     type Error = Error;
 
+    /// Convert a LGLSXP object into a vector of Bool (tri-state booleans).
+    /// Note: Unless you plan to store the result, use a slice instead.
+    /// Use `value.is_na()` to detect NA values.
     fn try_from(robj: Robj) -> Result<Self> {
         if let Some(v) = robj.as_logical_slice() {
             Ok(Vec::from(v))
@@ -193,11 +213,13 @@ impl TryFrom<Robj> for Vec<Bool> {
 impl TryFrom<Robj> for Vec<u8> {
     type Error = Error;
 
+    /// Convert a RAWSXP object into a vector of bytes.
+    /// Note: Unless you plan to store the result, use a slice instead.
     fn try_from(robj: Robj) -> Result<Self> {
         if let Some(v) = robj.as_raw_slice() {
             Ok(Vec::from(v))
         } else {
-            Err(Error::ExpectedInteger(robj))
+            Err(Error::ExpectedRaw(robj))
         }
     }
 }
@@ -205,6 +227,8 @@ impl TryFrom<Robj> for Vec<u8> {
 impl TryFrom<Robj> for Vec<String> {
     type Error = Error;
 
+    /// Convert a STRSXP object into a vector of `String`s.
+    /// Note: Unless you plan to store the result, use a slice instead.
     fn try_from(robj: Robj) -> Result<Self> {
         if let Some(iter) = robj.as_str_iter() {
             // check for NA's in the string vector
@@ -224,6 +248,8 @@ macro_rules! impl_option {
         impl TryFrom<Robj> for Option<$type> {
             type Error = Error;
 
+            /// Convert a scalar object that may be NA type to a n `Option` of a corresponding type.
+            /// Returns `None` if the scalar is NA.
             fn try_from(robj: Robj) -> Result<Self> {
                 if robj.is_na() {
                     Ok(None)
@@ -256,6 +282,8 @@ impl_option!(Vec<String>);
 impl TryFrom<Robj> for &[i32] {
     type Error = Error;
 
+    /// Convert an INTSXP object into a slice of i32 (integer).
+    /// Use `value.is_na()` to detect NA values.
     fn try_from(robj: Robj) -> Result<Self> {
         robj.as_typed_slice()
             .ok_or_else(|| Error::ExpectedInteger(robj))
@@ -265,6 +293,8 @@ impl TryFrom<Robj> for &[i32] {
 impl TryFrom<Robj> for &[Bool] {
     type Error = Error;
 
+    /// Convert a LGLSXP object into a slice of Bool (tri-state booleans).
+    /// Use `value.is_na()` to detect NA values.
     fn try_from(robj: Robj) -> Result<Self> {
         robj.as_typed_slice()
             .ok_or_else(|| Error::ExpectedLogical(robj))
@@ -274,6 +304,7 @@ impl TryFrom<Robj> for &[Bool] {
 impl TryFrom<Robj> for &[u8] {
     type Error = Error;
 
+    /// Convert a RAWSXP object into a slice of bytes.
     fn try_from(robj: Robj) -> Result<Self> {
         robj.as_typed_slice()
             .ok_or_else(|| Error::ExpectedRaw(robj))
@@ -283,6 +314,8 @@ impl TryFrom<Robj> for &[u8] {
 impl TryFrom<Robj> for &[f64] {
     type Error = Error;
 
+    /// Convert a REALSXP object into a slice of f64 (double precision floating point).
+    /// Use `value.is_na()` to detect NA values.
     fn try_from(robj: Robj) -> Result<Self> {
         robj.as_typed_slice()
             .ok_or_else(|| Error::ExpectedReal(robj))
@@ -292,6 +325,7 @@ impl TryFrom<Robj> for &[f64] {
 impl TryFrom<Robj> for HashMap<String, Robj> {
     type Error = Error;
 
+    /// Convert a named VECSXP object into a hashmap of `String`-value pairs.
     fn try_from(robj: Robj) -> Result<Self> {
         if let Some(iter) = robj.as_list().map(|l| l.iter()) {
             Ok(iter
@@ -306,6 +340,7 @@ impl TryFrom<Robj> for HashMap<String, Robj> {
 impl TryFrom<Robj> for HashMap<&str, Robj> {
     type Error = Error;
 
+    /// Convert a named VECSXP object into a hashmap of `&str`-value pairs.
     fn try_from(robj: Robj) -> Result<Self> {
         if let Some(iter) = robj.as_list().map(|l| l.iter()) {
             Ok(iter.map(|(k, v)| (k, v)).collect::<HashMap<&str, Robj>>())

--- a/extendr-api/src/robj/try_from_robj.rs
+++ b/extendr-api/src/robj/try_from_robj.rs
@@ -178,6 +178,30 @@ impl TryFrom<Robj> for Vec<f64> {
     }
 }
 
+impl TryFrom<Robj> for Vec<Bool> {
+    type Error = Error;
+
+    fn try_from(robj: Robj) -> Result<Self> {
+        if let Some(v) = robj.as_logical_slice() {
+            Ok(Vec::from(v))
+        } else {
+            Err(Error::ExpectedInteger(robj))
+        }
+    }
+}
+
+impl TryFrom<Robj> for Vec<u8> {
+    type Error = Error;
+
+    fn try_from(robj: Robj) -> Result<Self> {
+        if let Some(v) = robj.as_raw_slice() {
+            Ok(Vec::from(v))
+        } else {
+            Err(Error::ExpectedInteger(robj))
+        }
+    }
+}
+
 impl TryFrom<Robj> for Vec<String> {
     type Error = Error;
 
@@ -194,20 +218,6 @@ impl TryFrom<Robj> for Vec<String> {
         }
     }
 }
-
-// The following fails because T could be Option<U>
-//
-// impl<T : TryFrom<Robj>> TryFrom<Robj> for Option<T> {
-//     type Error = Error;
-
-//     fn try_from(robj: Robj) -> Result<Self> {
-//         if robj.is_na() {
-//             Ok(None)
-//         } else {
-//             Ok(Some(T::try_from(robj)?))
-//         }
-//     }
-// }
 
 macro_rules! impl_option {
     ($type : ty) => {
@@ -242,6 +252,38 @@ impl_option!(String);
 impl_option!(Vec<i32>);
 impl_option!(Vec<f64>);
 impl_option!(Vec<String>);
+
+impl TryFrom<Robj> for &[i32] {
+    type Error = Error;
+
+    fn try_from(robj: Robj) -> Result<Self> {
+        robj.as_typed_slice().ok_or_else(|| Error::ExpectedInteger(robj))
+    }
+}
+
+impl TryFrom<Robj> for &[Bool] {
+    type Error = Error;
+
+    fn try_from(robj: Robj) -> Result<Self> {
+        robj.as_typed_slice().ok_or_else(|| Error::ExpectedLogical(robj))
+    }
+}
+
+impl TryFrom<Robj> for &[u8] {
+    type Error = Error;
+
+    fn try_from(robj: Robj) -> Result<Self> {
+        robj.as_typed_slice().ok_or_else(|| Error::ExpectedRaw(robj))
+    }
+}
+
+impl TryFrom<Robj> for &[f64] {
+    type Error = Error;
+
+    fn try_from(robj: Robj) -> Result<Self> {
+        robj.as_typed_slice().ok_or_else(|| Error::ExpectedReal(robj))
+    }
+}
 
 impl TryFrom<Robj> for HashMap<String, Robj> {
     type Error = Error;

--- a/extendr-api/src/robj/try_from_robj.rs
+++ b/extendr-api/src/robj/try_from_robj.rs
@@ -257,7 +257,8 @@ impl TryFrom<Robj> for &[i32] {
     type Error = Error;
 
     fn try_from(robj: Robj) -> Result<Self> {
-        robj.as_typed_slice().ok_or_else(|| Error::ExpectedInteger(robj))
+        robj.as_typed_slice()
+            .ok_or_else(|| Error::ExpectedInteger(robj))
     }
 }
 
@@ -265,7 +266,8 @@ impl TryFrom<Robj> for &[Bool] {
     type Error = Error;
 
     fn try_from(robj: Robj) -> Result<Self> {
-        robj.as_typed_slice().ok_or_else(|| Error::ExpectedLogical(robj))
+        robj.as_typed_slice()
+            .ok_or_else(|| Error::ExpectedLogical(robj))
     }
 }
 
@@ -273,7 +275,8 @@ impl TryFrom<Robj> for &[u8] {
     type Error = Error;
 
     fn try_from(robj: Robj) -> Result<Self> {
-        robj.as_typed_slice().ok_or_else(|| Error::ExpectedRaw(robj))
+        robj.as_typed_slice()
+            .ok_or_else(|| Error::ExpectedRaw(robj))
     }
 }
 
@@ -281,7 +284,8 @@ impl TryFrom<Robj> for &[f64] {
     type Error = Error;
 
     fn try_from(robj: Robj) -> Result<Self> {
-        robj.as_typed_slice().ok_or_else(|| Error::ExpectedReal(robj))
+        robj.as_typed_slice()
+            .ok_or_else(|| Error::ExpectedReal(robj))
     }
 }
 

--- a/extendr-api/src/robj/try_from_robj.rs
+++ b/extendr-api/src/robj/try_from_robj.rs
@@ -248,7 +248,7 @@ macro_rules! impl_option {
         impl TryFrom<Robj> for Option<$type> {
             type Error = Error;
 
-            /// Convert a scalar object that may be NA type to a n `Option` of a corresponding type.
+            /// Convert a scalar object that may be NA type to an `Option` of a corresponding type.
             /// Returns `None` if the scalar is NA.
             fn try_from(robj: Robj) -> Result<Self> {
                 if robj.is_na() {

--- a/extendr-api/src/wrapper/environment.rs
+++ b/extendr-api/src/wrapper/environment.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate as extendr_api;
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct Environment {


### PR DESCRIPTION
This PR covers i32, f64, Bool and u8 types in vectors and slices.

```
        assert_eq!(<Vec::<i32>>::try_from(Robj::from(1)), Ok(vec![1]));
        assert_eq!(<Vec::<f64>>::try_from(Robj::from(1.)), Ok(vec![1.]));
        assert_eq!(<Vec::<Bool>>::try_from(Robj::from(TRUE)), Ok(vec![TRUE]));
        assert_eq!(<Vec::<u8>>::try_from(Robj::from(0_u8)), Ok(vec![0_u8]));

        assert_eq!(<&[i32]>::try_from(Robj::from(1)), Ok(&[1][..]));
        assert_eq!(<&[f64]>::try_from(Robj::from(1.)), Ok(&[1.][..]));
        assert_eq!(<&[Bool]>::try_from(Robj::from(TRUE)), Ok(&[TRUE][..]));
        assert_eq!(<&[u8]>::try_from(Robj::from(0_u8)), Ok(&[0_u8][..]));
```