### PR TITLE
Fix a clippy warning, unnecessary_lazy_evaluations

### DIFF
--- a/extendr-api/src/robj/try_from_robj.rs
+++ b/extendr-api/src/robj/try_from_robj.rs
@@ -285,8 +285,7 @@ impl TryFrom<Robj> for &[i32] {
     /// Convert an INTSXP object into a slice of i32 (integer).
     /// Use `value.is_na()` to detect NA values.
     fn try_from(robj: Robj) -> Result<Self> {
-        robj.as_typed_slice()
-            .ok_or_else(|| Error::ExpectedInteger(robj))
+        robj.as_typed_slice().ok_or(Error::ExpectedInteger(robj))
     }
 }
 
@@ -296,8 +295,7 @@ impl TryFrom<Robj> for &[Bool] {
     /// Convert a LGLSXP object into a slice of Bool (tri-state booleans).
     /// Use `value.is_na()` to detect NA values.
     fn try_from(robj: Robj) -> Result<Self> {
-        robj.as_typed_slice()
-            .ok_or_else(|| Error::ExpectedLogical(robj))
+        robj.as_typed_slice().ok_or(Error::ExpectedLogical(robj))
     }
 }
 
@@ -306,8 +304,7 @@ impl TryFrom<Robj> for &[u8] {
 
     /// Convert a RAWSXP object into a slice of bytes.
     fn try_from(robj: Robj) -> Result<Self> {
-        robj.as_typed_slice()
-            .ok_or_else(|| Error::ExpectedRaw(robj))
+        robj.as_typed_slice().ok_or(Error::ExpectedRaw(robj))
     }
 }
 
@@ -317,8 +314,7 @@ impl TryFrom<Robj> for &[f64] {
     /// Convert a REALSXP object into a slice of f64 (double precision floating point).
     /// Use `value.is_na()` to detect NA values.
     fn try_from(robj: Robj) -> Result<Self> {
-        robj.as_typed_slice()
-            .ok_or_else(|| Error::ExpectedReal(robj))
+        robj.as_typed_slice().ok_or(Error::ExpectedReal(robj))
     }
 }
 


### PR DESCRIPTION
Fix this warning. Probably this check was introduced in some very recent version of Rust.

```
❯ cargo +nightly clippy
warning: unnecessary closure used to substitute value for `Option::None`
   --> extendr-api/src/robj/try_from_robj.rs:288:9
    |
288 | /         robj.as_typed_slice()
289 | |             .ok_or_else(|| Error::ExpectedInteger(robj))
    | |________________________________________________________^ help: use `ok_or` instead: `robj.as_typed_slice().ok_or(Error::ExpectedInteger(robj))`
    |
    = note: `#[warn(clippy::unnecessary_lazy_evaluations)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_lazy_evaluations

warning: unnecessary closure used to substitute value for `Option::None`
   --> extendr-api/src/robj/try_from_robj.rs:299:9
    |
299 | /         robj.as_typed_slice()
300 | |             .ok_or_else(|| Error::ExpectedLogical(robj))
    | |________________________________________________________^ help: use `ok_or` instead: `robj.as_typed_slice().ok_or(Error::ExpectedLogical(robj))`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_lazy_evaluations

warning: unnecessary closure used to substitute value for `Option::None`
   --> extendr-api/src/robj/try_from_robj.rs:309:9
    |
309 | /         robj.as_typed_slice()
310 | |             .ok_or_else(|| Error::ExpectedRaw(robj))
    | |____________________________________________________^ help: use `ok_or` instead: `robj.as_typed_slice().ok_or(Error::ExpectedRaw(robj))`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_lazy_evaluations

warning: unnecessary closure used to substitute value for `Option::None`
   --> extendr-api/src/robj/try_from_robj.rs:320:9
    |
320 | /         robj.as_typed_slice()
321 | |             .ok_or_else(|| Error::ExpectedReal(robj))
    | |_____________________________________________________^ help: use `ok_or` instead: `robj.as_typed_slice().ok_or(Error::ExpectedReal(robj))`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_lazy_evaluations

warning: `extendr-api` (lib) generated 4 warnings
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
```