### PR TITLE
Rename Character to Char

### DIFF
--- a/extendr-api/src/error.rs
+++ b/extendr-api/src/error.rs
@@ -42,7 +42,7 @@ pub enum Error {
     ExpectedLanguage(Robj),
     ExpectedSpecial(Robj),
     ExpectedBuiltin(Robj),
-    ExpectedCharacter(Robj),
+    ExpectedChar(Robj),
     ExpectedLogical(Robj),
     ExpectedInteger(Robj),
     ExpectedReal(Robj),
@@ -99,8 +99,8 @@ impl std::fmt::Display for Error {
             Error::ExpectedLanguage(robj) => write!(f, "Expected Language got {:?}", robj.rtype()),
             Error::ExpectedSpecial(robj) => write!(f, "Expected Special got {:?}", robj.rtype()),
             Error::ExpectedBuiltin(robj) => write!(f, "Expected Builtin got {:?}", robj.rtype()),
-            Error::ExpectedCharacter(robj) => {
-                write!(f, "Expected Character got {:?}", robj.rtype())
+            Error::ExpectedChar(robj) => {
+                write!(f, "Expected Char got {:?}", robj.rtype())
             }
             Error::ExpectedLogical(robj) => write!(f, "Expected Logical got {:?}", robj.rtype()),
             Error::ExpectedInteger(robj) => write!(f, "Expected Integer got {:?}", robj.rtype()),

--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -406,7 +406,7 @@ pub enum RType {
     Language,    // LANGSXP
     Special,     // SPECIALSXP
     Builtin,     // BUILTINSXP
-    Character,   // CHARSXP
+    Char,        // CHARSXP
     Logical,     // LGLSXP
     Integer,     // INTSXP
     Real,        // REALSXP
@@ -438,7 +438,7 @@ pub fn rtype_to_sxp(rtype: RType) -> i32 {
         Language => LANGSXP,
         Special => SPECIALSXP,
         Builtin => BUILTINSXP,
-        Character => CHARSXP,
+        Char => CHARSXP,
         Logical => LGLSXP,
         Integer => INTSXP,
         Real => REALSXP,
@@ -470,7 +470,7 @@ pub fn sxp_to_rtype(sxptype: i32) -> RType {
         LANGSXP => Language,
         SPECIALSXP => Special,
         BUILTINSXP => Builtin,
-        CHARSXP => Character,
+        CHARSXP => Char,
         LGLSXP => Logical,
         INTSXP => Integer,
         REALSXP => Real,

--- a/extendr-api/src/prelude.rs
+++ b/extendr-api/src/prelude.rs
@@ -49,8 +49,8 @@ pub use super::thread_safety::{
 };
 
 pub use super::wrapper::{
-    Character, EnvIter, Environment, Expression, FromList, Function, Language, List, ListIter,
-    Nullable, Pairlist, Primitive, Promise, Raw, Symbol,
+    Char, EnvIter, Environment, Expression, FromList, Function, Language, List, ListIter, Nullable,
+    Pairlist, Primitive, Promise, Raw, Symbol,
 };
 
 #[cfg(feature = "ndarray")]

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -172,7 +172,7 @@ impl Robj {
     ///     assert_eq!(lang!("+", 1, 2).rtype(), RType::Language);
     ///     assert_eq!(r!(Primitive::from_string("if")).rtype(), RType::Special);
     ///     assert_eq!(r!(Primitive::from_string("+")).rtype(), RType::Builtin);
-    ///     assert_eq!(r!(Character::from_string("hello")).rtype(), RType::Character);
+    ///     assert_eq!(r!(Char::from_string("hello")).rtype(), RType::Char);
     ///     assert_eq!(r!(TRUE).rtype(), RType::Logical);
     ///     assert_eq!(r!(1).rtype(), RType::Integer);
     ///     assert_eq!(r!(1.0).rtype(), RType::Real);
@@ -193,7 +193,7 @@ impl Robj {
             LANGSXP => RType::Language,
             SPECIALSXP => RType::Special,
             BUILTINSXP => RType::Builtin,
-            CHARSXP => RType::Character,
+            CHARSXP => RType::Char,
             LGLSXP => RType::Logical,
             INTSXP => RType::Integer,
             REALSXP => RType::Real,
@@ -1024,8 +1024,8 @@ impl std::fmt::Debug for Robj {
             SPECIALSXP => write!(f, "r!(Special())"),
             BUILTINSXP => write!(f, "r!(Builtin())"),
             CHARSXP => {
-                let c = Character::try_from(self.clone()).unwrap();
-                write!(f, "r!(Character::from_string({:?}))", c.as_str())
+                let c = Char::try_from(self.clone()).unwrap();
+                write!(f, "r!(Char::from_string({:?}))", c.as_str())
             }
             LGLSXP => {
                 let slice = self.as_logical_slice().unwrap();

--- a/extendr-api/src/robj/rinternals.rs
+++ b/extendr-api/src/robj/rinternals.rs
@@ -66,7 +66,7 @@ impl Robj {
     }
 
     /// Convert to a string vector.
-    pub fn as_char(&self) -> Robj {
+    pub fn as_character_vector(&self) -> Robj {
         unsafe { new_owned(Rf_asChar(self.get())) }
     }
 
@@ -381,8 +381,8 @@ impl Robj {
     }
 
     /// Return true if this is CHARSXP.
-    pub fn is_character(&self) -> bool {
-        self.rtype() == RType::Character
+    pub fn is_char(&self) -> bool {
+        self.rtype() == RType::Char
     }
 
     /// Check an external pointer tag.

--- a/extendr-api/src/robj/tests.rs
+++ b/extendr-api/src/robj/tests.rs
@@ -22,7 +22,7 @@ fn test_debug() {
 
         // Wrappers
         assert_eq!(format!("{:?}", r!(Symbol::from_string("x"))), "sym!(x)");
-        assert_eq!(format!("{:?}", r!(Character::from_string("x"))), "r!(Character::from_string(\"x\"))");
+        assert_eq!(format!("{:?}", r!(Char::from_string("x"))), "r!(Char::from_string(\"x\"))");
         assert_eq!(
             format!("{:?}", r!(Language::from_values(&[r!(Symbol::from_string("x"))]))),
             "r!(Language::from_values([sym!(x)]))"

--- a/extendr-api/src/wrapper/char.rs
+++ b/extendr-api/src/wrapper/char.rs
@@ -1,27 +1,27 @@
 use super::*;
 
-/// Wrapper for creating character objects.
+/// Wrapper for creating CHARSXP objects.
 /// These are used only as the contents of a character
 /// vector.
 ///
 /// ```
 /// use extendr_api::prelude::*;
 /// test! {
-///     let chr = r!(Character::from_string("xyz"));
-///     assert_eq!(chr.as_character().unwrap().as_str(), "xyz");
+///     let chr = r!(Char::from_string("xyz"));
+///     assert_eq!(chr.as_char().unwrap().as_str(), "xyz");
 /// }
 /// ```
 ///
 #[derive(Debug, PartialEq, Clone)]
-pub struct Character {
+pub struct Char {
     pub(crate) robj: Robj,
 }
 
-impl Character {
+impl Char {
     /// Make a character object from a string.
     pub fn from_string(val: &str) -> Self {
         unsafe {
-            Character {
+            Char {
                 robj: new_owned(str_to_character(val)),
             }
         }

--- a/extendr-api/src/wrapper/mod.rs
+++ b/extendr-api/src/wrapper/mod.rs
@@ -5,7 +5,7 @@ use crate::*;
 use libR_sys::*;
 
 pub mod altrep;
-pub mod character;
+pub mod char;
 pub mod environment;
 pub mod expr;
 pub mod function;
@@ -19,11 +19,11 @@ pub mod promise;
 pub mod raw;
 pub mod symbol;
 
+pub use self::char::Char;
 pub use altrep::{
     AltComplexImpl, AltIntegerImpl, AltLogicalImpl, AltRawImpl, AltRealImpl, AltStringImpl, Altrep,
     AltrepImpl,
 };
-pub use character::Character;
 pub use environment::{EnvIter, Environment};
 pub use expr::Expression;
 pub use function::Function;
@@ -115,12 +115,7 @@ make_conversions!(
 
 make_conversions!(Raw, ExpectedRaw, is_raw, "Not a raw object");
 
-make_conversions!(
-    Character,
-    ExpectedCharacter,
-    is_character,
-    "Not a character object"
-);
+make_conversions!(Char, ExpectedChar, is_char, "Not a character object");
 
 make_conversions!(
     Environment,
@@ -171,19 +166,19 @@ impl Robj {
         Symbol::try_from(self.clone()).ok()
     }
 
-    /// Convert a character object to a Character wrapper.
+    /// Convert a CHARSXP object to a Char wrapper.
     /// ```
     /// use extendr_api::prelude::*;
     /// test! {
-    ///     let fred = r!(Character::from_string("fred"));
-    ///     assert_eq!(fred.as_character(), Some(Character::from_string("fred")));
+    ///     let fred = r!(Char::from_string("fred"));
+    ///     assert_eq!(fred.as_char(), Some(Char::from_string("fred")));
     /// }
     /// ```
-    pub fn as_character(&self) -> Option<Character> {
-        Character::try_from(self.clone()).ok()
+    pub fn as_char(&self) -> Option<Char> {
+        Char::try_from(self.clone()).ok()
     }
 
-    /// Convert a raw object to a Character wrapper.
+    /// Convert a raw object to a Char wrapper.
     /// ```
     /// use extendr_api::prelude::*;
     /// test! {


### PR DESCRIPTION
This PR is a prelude to introducing a Character wrapper around
string vectors.

The existing Character wrapper referred to CHARSXP instead
of STRSXP.