### PR TITLE
Altrep Integers class.

### DIFF
--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -233,6 +233,7 @@ pub mod prelude;
 pub mod rmacros;
 
 pub mod robj;
+pub mod scalar;
 pub mod thread_safety;
 pub mod wrapper;
 

--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -242,6 +242,7 @@ pub mod robj_ndarray;
 
 pub use std::convert::{TryFrom, TryInto};
 pub use std::ops::Deref;
+pub use std::ops::DerefMut;
 
 //////////////////////////////////////////////////
 // Note these pub use statements are deprectaed

--- a/extendr-api/src/prelude.rs
+++ b/extendr-api/src/prelude.rs
@@ -51,8 +51,8 @@ pub use super::thread_safety::{
 };
 
 pub use super::wrapper::{
-    EnvIter, Environment, Expression, FromList, Function, Language, List, ListIter, Nullable,
-    Pairlist, Primitive, Promise, Raw, Rstr, Symbol,
+    EnvIter, Environment, Expression, FromList, Function, Integers, Language, List, ListIter,
+    Nullable, Pairlist, Primitive, Promise, Raw, Rstr, Symbol,
 };
 
 #[cfg(feature = "ndarray")]

--- a/extendr-api/src/prelude.rs
+++ b/extendr-api/src/prelude.rs
@@ -68,3 +68,5 @@ pub use super::iter::{Int, Logical, Real, StrIter};
 pub use std::convert::{TryFrom, TryInto};
 
 pub use std::ops::Index;
+
+pub use super::scalar::*;

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -14,6 +14,7 @@ use std::os::raw;
 
 use crate::*;
 
+use crate::scalar::Rint;
 use std::collections::HashMap;
 use std::iter::IntoIterator;
 use std::ops::{Range, RangeInclusive};
@@ -707,6 +708,7 @@ macro_rules! make_typed_slice {
 
 make_typed_slice!(Bool, INTEGER, LGLSXP);
 make_typed_slice!(i32, INTEGER, INTSXP);
+make_typed_slice!(Rint, INTEGER, INTSXP);
 make_typed_slice!(f64, REAL, REALSXP);
 make_typed_slice!(u8, RAW, RAWSXP);
 

--- a/extendr-api/src/robj/try_from_robj.rs
+++ b/extendr-api/src/robj/try_from_robj.rs
@@ -40,7 +40,7 @@ macro_rules! impl_try_from_scalar_integer {
                 // might eventually become available in future, though.
                 if let Some(v) = robj.as_real() {
                     let result = v as Self;
-                    if ((result as f64 - v).abs() < f64::EPSILON) {
+                    if (result as f64 - v).abs() < f64::EPSILON {
                         return Ok(result);
                     } else {
                         return Err(Error::ExpectedWholeNumber(robj));

--- a/extendr-api/src/scalar/mod.rs
+++ b/extendr-api/src/scalar/mod.rs
@@ -1,0 +1,3 @@
+mod rint;
+
+pub use rint::Rint;

--- a/extendr-api/src/scalar/rint.rs
+++ b/extendr-api/src/scalar/rint.rs
@@ -208,3 +208,18 @@ gen_unnop!(
     |lhs: i32| Some(!lhs),
     "Logical not a Rint value, overflows to NA."
 );
+
+impl std::iter::Sum for Rint {
+    /// Sum an integer iterator over Rint.
+    /// Yields NA on overflow of NAs present.
+    fn sum<I: Iterator<Item = Rint>>(iter: I) -> Rint {
+        iter.fold(Rint::from(0), |a, b| a + b)
+    }
+}
+
+impl PartialEq<i32> for Rint {
+    /// Compare a Rint with an integer. NA always fails.
+    fn eq(&self, other: &i32) -> bool {
+        !self.is_na() && self.0 == *other
+    }
+}

--- a/extendr-api/src/scalar/rint.rs
+++ b/extendr-api/src/scalar/rint.rs
@@ -169,6 +169,7 @@ macro_rules! gen_unnop {
     };
 }
 
+// Generate binary ops for +, -, * and /
 gen_binop!(
     Add,
     add,
@@ -193,6 +194,8 @@ gen_binop!(
     |lhs: i32, rhs| lhs.checked_div(rhs),
     "Divide two Rint values or an option of i32, overflows to NA."
 );
+
+// Generate unary ops for -, !
 gen_unnop!(
     Neg,
     neg,

--- a/extendr-api/src/scalar/rint.rs
+++ b/extendr-api/src/scalar/rint.rs
@@ -1,4 +1,5 @@
-use super::super::IsNA;
+use crate::*;
+use std::convert::TryFrom;
 use std::ops::{Add, Div, Mul, Neg, Not, Sub};
 
 /// Rint is a wrapper for i32 in the context of an R's integer vector.
@@ -15,6 +16,11 @@ impl Rint {
     /// Construct a NA Rint.
     pub fn na() -> Self {
         Rint(i32::MIN)
+    }
+
+    /// Get an integer or i32::MIN for NA.
+    pub fn inner(&self) -> i32 {
+        self.0
     }
 }
 
@@ -221,5 +227,58 @@ impl PartialEq<i32> for Rint {
     /// Compare a Rint with an integer. NA always fails.
     fn eq(&self, other: &i32) -> bool {
         !self.is_na() && self.0 == *other
+    }
+}
+
+impl TryFrom<Robj> for Rint {
+    type Error = Error;
+
+    fn try_from(robj: Robj) -> Result<Self> {
+        // Check if the value is a scalar
+        match robj.len() {
+            0 => return Err(Error::ExpectedNonZeroLength(robj)),
+            1 => {}
+            _ => return Err(Error::ExpectedScalar(robj)),
+        };
+
+        // Check if the value is not a missing value
+        if robj.is_na() {
+            return Ok(Rint::na());
+        }
+
+        // If the conversion is int-to-int, check the limits. This
+        // needs to be done by `TryFrom` because the conversion by `as`
+        // is problematic when converting a negative value to unsigned
+        // integer types (e.g. `-1i32 as u8` becomes 255).
+        if let Some(v) = robj.as_integer() {
+            if let Ok(v) = Self::try_from(v) {
+                return Ok(v);
+            } else {
+                return Err(Error::OutOfLimits(robj));
+            }
+        }
+
+        // If the conversion is float-to-int, check if the value is
+        // integer-like (i.e., an integer, or a float representing a
+        // whole number). This needs to be down with `as`, as no
+        // `TryFrom` is implemented for float types. `FloatToInt` trait
+        // might eventually become available in future, though.
+        if let Some(v) = robj.as_real() {
+            let result = v as i32;
+            if (result as f64 - v).abs() < f64::EPSILON {
+                return Ok(Rint::from(result));
+            } else {
+                return Err(Error::ExpectedWholeNumber(robj));
+            }
+        }
+
+        Err(Error::ExpectedNumeric(robj))
+    }
+}
+
+impl From<Rint> for Robj {
+    /// Convert am Rint into an robj.
+    fn from(value: Rint) -> Self {
+        Robj::from(value.0)
     }
 }

--- a/extendr-api/src/scalar/rint.rs
+++ b/extendr-api/src/scalar/rint.rs
@@ -1,0 +1,207 @@
+use super::super::IsNA;
+use std::ops::{Add, Div, Mul, Neg, Not, Sub};
+
+/// Rint is a wrapper for i32 in the context of an R's integer vector.
+///
+/// Rint can have a value between i32::MIN+1 and i32::MAX
+///
+/// The value i32::MIN is used as "NA".
+///
+/// Rint has the same footprint as an i32 value allowing us to use it in zero copy slices.
+#[derive(PartialEq, Eq)]
+pub struct Rint(pub i32);
+
+impl Rint {
+    /// Construct a NA Rint.
+    pub fn na() -> Self {
+        Rint(i32::MIN)
+    }
+}
+
+impl Clone for Rint {
+    fn clone(&self) -> Self {
+        Self(self.0)
+    }
+}
+
+impl Copy for Rint {}
+
+impl IsNA for Rint {
+    /// Return true is the is a NA value.
+    fn is_na(&self) -> bool {
+        self.0 == std::i32::MIN
+    }
+}
+
+impl From<i32> for Rint {
+    /// Construct a Rint from an integer.
+    /// i32::MIN gives an NA.
+    fn from(v: i32) -> Self {
+        Self(v)
+    }
+}
+
+impl From<Option<i32>> for Rint {
+    /// Construct an Rint from an optional integer.
+    /// None or Some(i32::MIN) gives an NA.
+    fn from(v: Option<i32>) -> Self {
+        if let Some(v) = v {
+            v.into()
+        } else {
+            Rint::na()
+        }
+    }
+}
+
+impl From<Rint> for Option<i32> {
+    /// Convert an Rint to an optional integer.
+    /// NA gives None.
+    fn from(v: Rint) -> Self {
+        if v.is_na() {
+            None
+        } else {
+            Some(v.0)
+        }
+    }
+}
+
+impl std::fmt::Debug for Rint {
+    /// Debug format an Rint.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let z: Option<i32> = (*self).into();
+        if let Some(val) = z {
+            write!(f, "{}", val)
+        } else {
+            write!(f, "na")
+        }
+    }
+}
+
+macro_rules! gen_binop {
+    ($opname1 : ident, $opname2: ident, $expr: expr, $docstring: expr) => {
+        impl $opname1<Rint> for Rint {
+            type Output = Rint;
+
+            #[doc = $docstring]
+            fn $opname2(self, rhs: Rint) -> Self::Output {
+                if let Some(lhs) = self.clone().into() {
+                    if let Some(rhs) = rhs.into() {
+                        let f = $expr;
+                        if let Some(res) = f(lhs, rhs) {
+                            // Note that if res = i32::MIN, this will also be NA.
+                            return Rint::from(res);
+                        }
+                    }
+                }
+                Rint::na()
+            }
+        }
+
+        impl $opname1<Rint> for &Rint {
+            type Output = Rint;
+
+            #[doc = $docstring]
+            fn $opname2(self, rhs: Rint) -> Self::Output {
+                if let Some(lhs) = self.clone().into() {
+                    if let Some(rhs) = rhs.into() {
+                        let f = $expr;
+                        if let Some(res) = f(lhs, rhs) {
+                            // Note that if res = i32::MIN, this will also be NA.
+                            return Rint::from(res);
+                        }
+                    }
+                }
+                Rint::na()
+            }
+        }
+
+        impl $opname1<i32> for Rint {
+            type Output = Rint;
+
+            #[doc = $docstring]
+            fn $opname2(self, rhs: i32) -> Self::Output {
+                if let Some(lhs) = self.clone().into() {
+                    let f = $expr;
+                    if let Some(res) = f(lhs, rhs) {
+                        // Note that if res = i32::MIN, this will also be NA.
+                        return Rint::from(res);
+                    }
+                }
+                Rint::na()
+            }
+        }
+    };
+}
+
+macro_rules! gen_unnop {
+    ($opname1 : ident, $opname2: ident, $expr: expr, $docstring: expr) => {
+        impl $opname1 for Rint {
+            type Output = Rint;
+
+            #[doc = $docstring]
+            fn $opname2(self) -> Self::Output {
+                if let Some(lhs) = self.into() {
+                    let f = $expr;
+                    if let Some(res) = f(lhs) {
+                        // Note that if res = i32::MIN, this will also be NA.
+                        return Rint::from(res);
+                    }
+                }
+                Rint::na()
+            }
+        }
+
+        impl $opname1 for &Rint {
+            type Output = Rint;
+
+            #[doc = $docstring]
+            fn $opname2(self) -> Self::Output {
+                if let Some(lhs) = (*self).into() {
+                    let f = $expr;
+                    if let Some(res) = f(lhs) {
+                        // Note that if res = i32::MIN, this will also be NA.
+                        return Rint::from(res);
+                    }
+                }
+                Rint::na()
+            }
+        }
+    };
+}
+
+gen_binop!(
+    Add,
+    add,
+    |lhs: i32, rhs| lhs.checked_add(rhs),
+    "Add two Rint values or an option of i32, overflows to NA."
+);
+gen_binop!(
+    Sub,
+    sub,
+    |lhs: i32, rhs| lhs.checked_sub(rhs),
+    "Subtract two Rint values or an option of i32, overflows to NA."
+);
+gen_binop!(
+    Mul,
+    mul,
+    |lhs: i32, rhs| lhs.checked_mul(rhs),
+    "Multiply two Rint values or an option of i32, overflows to NA."
+);
+gen_binop!(
+    Div,
+    div,
+    |lhs: i32, rhs| lhs.checked_div(rhs),
+    "Divide two Rint values or an option of i32, overflows to NA."
+);
+gen_unnop!(
+    Neg,
+    neg,
+    |lhs: i32| Some(-lhs),
+    "Negate a Rint value, overflows to NA."
+);
+gen_unnop!(
+    Not,
+    not,
+    |lhs: i32| Some(!lhs),
+    "Logical not a Rint value, overflows to NA."
+);

--- a/extendr-api/src/wrapper/integers.rs
+++ b/extendr-api/src/wrapper/integers.rs
@@ -136,23 +136,23 @@ impl Integers {
     }
 }
 
-impl FromIterator<i32> for Integers {
+impl FromIterator<Rint> for Integers {
     /// A more generalised iterator collector for small vectors.
     /// Generates a non-ALTREP vector.
     /// ```
     /// use extendr_api::prelude::*;
     /// test! {
-    ///     let vec : Integers = (0..3).collect();
+    ///     let vec : Integers = (0..3).map(|i| i.into()).collect();
     ///     assert_eq!(vec, Integers::from_values([0, 1, 2]));
     /// }
     /// ```
-    fn from_iter<T: IntoIterator<Item = i32>>(iter: T) -> Self {
+    fn from_iter<T: IntoIterator<Item = Rint>>(iter: T) -> Self {
         // Collect into a vector first.
         // TODO: specialise for ExactSizeIterator.
-        let values: Vec<i32> = iter.into_iter().collect();
+        let values: Vec<Rint> = iter.into_iter().collect();
 
         let mut robj = Robj::alloc_vector(INTSXP, values.len());
-        let dest: &mut [i32] = robj.as_typed_slice_mut().unwrap();
+        let dest: &mut [Rint] = robj.as_typed_slice_mut().unwrap();
 
         for (d, v) in dest.iter_mut().zip(values) {
             *d = v;

--- a/extendr-api/src/wrapper/integers.rs
+++ b/extendr-api/src/wrapper/integers.rs
@@ -1,0 +1,101 @@
+use super::*;
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct Integers {
+    pub(crate) robj: Robj,
+}
+
+impl Default for Integers {
+    fn default() -> Self {
+        Integers::new(0)
+    }
+}
+
+impl Integers {
+    /// Create a new vector of integers.
+    /// ```
+    /// use extendr_api::prelude::*;
+    /// test! {
+    ///     let vec = Integers::new(10);
+    ///     assert_eq!(vec.is_integer(), true);
+    ///     assert_eq!(vec.len(), 10);
+    /// }
+    /// ```
+    pub fn new(len: usize) -> Integers {
+        let iter = (0..len).map(|_| 0);
+        Integers::from_values(iter)
+    }
+
+    /// Wrapper for creating ALTREP integer (INTSXP) vectors from iterators.
+    /// The iterator must be exact, clonable and implement Debug.
+    ///
+    /// ```
+    /// use extendr_api::prelude::*;
+    /// test! {
+    ///     // Short (<64k) vectors are allocated.
+    ///     let vec = Integers::from_values((0..3).map(|i| 2-i));
+    ///     assert_eq!(vec.is_altrep(), false);
+    ///     assert_eq!(r!(vec.clone()), r!([2, 1, 0]));
+    ///     assert_eq!(vec.elt(1), 1);
+    ///     let mut dest = [0; 2];
+    ///     vec.get_region(1, &mut dest);
+    ///     assert_eq!(dest, [1, 0]);
+    ///
+    ///     // Long (>=64k) vectors are lazy altrep objects.
+    ///     let vec = Integers::from_values(0..1000000000);
+    ///     assert_eq!(vec.is_altrep(), true);
+    ///     assert_eq!(vec.elt(12345678), 12345678);
+    ///     let mut dest = [0; 2];
+    ///     vec.get_region(12345678, &mut dest);
+    ///     assert_eq!(dest, [12345678, 12345679]);
+    /// }
+    /// ```
+    pub fn from_values<V>(values: V) -> Self
+    where
+        V: IntoIterator,
+        V::IntoIter: ExactSizeIterator + std::fmt::Debug + Clone + 'static + std::any::Any,
+        V::Item: Into<i32>,
+    {
+        single_threaded(|| {
+            let values: V::IntoIter = values.into_iter();
+
+            let robj = if values.len() >= 65536 {
+                Altrep::make_altinteger_from_iterator(values)
+                    .try_into()
+                    .unwrap()
+            } else {
+                let mut robj = Robj::alloc_vector(INTSXP, values.len());
+                let dest: &mut [i32] = robj.as_typed_slice_mut().unwrap();
+
+                for (d, v) in dest.iter_mut().zip(values) {
+                    *d = v.into();
+                }
+                robj
+            };
+            Self { robj }
+        })
+    }
+
+    /// Get a single element from the vector.
+    pub fn elt(&self, index: usize) -> i32 {
+        unsafe { INTEGER_ELT(self.get(), index as R_xlen_t) }
+    }
+
+    /// Get a region of elements from the vector.
+    pub fn get_region(&self, index: usize, dest: &mut [i32]) {
+        unsafe {
+            let ptr = dest.as_mut_ptr();
+            INTEGER_GET_REGION(self.get(), index as R_xlen_t, dest.len() as R_xlen_t, ptr);
+        }
+    }
+
+    /// Return TRUE if the vector is sorted, FALSE if not, or NA_BOOL if unknown.
+    pub fn is_sorted(&self) -> Bool {
+        unsafe { INTEGER_IS_SORTED(self.get()).into() }
+    }
+
+    /// Return TRUE if the vector has NAs, FALSE if not, or NA_BOOL if unknown.
+    pub fn no_na(&self) -> Bool {
+        unsafe { INTEGER_NO_NA(self.get()).into() }
+    }
+}

--- a/extendr-api/src/wrapper/integers.rs
+++ b/extendr-api/src/wrapper/integers.rs
@@ -1,3 +1,4 @@
+use super::scalar::Rint;
 use super::*;
 use std::iter::FromIterator;
 
@@ -13,7 +14,7 @@ impl Default for Integers {
 }
 
 // Under this size, vectors are manifest.
-// Above this size, vectors are lazy altrep objects.
+// Above this size, vectors are lazy ALTREP objects.
 const SHORT_VECTOR_LENGTH: usize = 64 * 1024;
 
 impl Integers {
@@ -48,7 +49,7 @@ impl Integers {
     ///     vec.get_region(1, &mut dest);
     ///     assert_eq!(dest, [1, 0]);
     ///
-    ///     // Long (>=64k) vectors are lazy altrep objects.
+    ///     // Long (>=64k) vectors are lazy ALTREP objects.
     ///     let vec = Integers::from_values(0..1000000000);
     ///     assert_eq!(vec.is_altrep(), true);
     ///     assert_eq!(vec.elt(12345678), 12345678);
@@ -85,8 +86,8 @@ impl Integers {
 
     /// Get a single element from the vector.
     /// Note that this is very inefficient in a tight loop.
-    pub fn elt(&self, index: usize) -> i32 {
-        unsafe { INTEGER_ELT(self.get(), index as R_xlen_t) }
+    pub fn elt(&self, index: usize) -> Rint {
+        unsafe { INTEGER_ELT(self.get(), index as R_xlen_t).into() }
     }
 
     /// Get a region of elements from the vector.
@@ -107,37 +108,37 @@ impl Integers {
         unsafe { INTEGER_NO_NA(self.get()).into() }
     }
 
-    /// Return an iterator for a non-altrep object.
-    /// Suitable for short vectors.
+    /// Return an iterator for for an integer object.
+    /// Forces ALTREP objects to manifest.
     /// ```
     /// use extendr_api::prelude::*;
     /// test! {
     ///     let vec = Integers::from_values(0..3);
-    ///     assert_eq!(vec.iter().cloned().sum::<i32>(), 3);
+    ///     assert_eq!(vec.iter().sum::<Rint>(), 3);
     /// }
     /// ```
-    pub fn iter(&self) -> impl Iterator<Item = &i32> {
-        self.as_typed_slice().unwrap().iter()
+    pub fn iter(&self) -> impl Iterator<Item = Rint> {
+        self.as_typed_slice().unwrap().iter().cloned()
     }
 
-    /// Return a writable iterator for a non-altrep object.
-    /// Suitable for short vectors.
+    /// Return a writable iterator for an integer object.
+    /// Forces ALTREP objects to manifest.
     /// ```
     /// use extendr_api::prelude::*;
     /// test! {
     ///     let mut vec = Integers::from_values(0..3);
-    ///     vec.iter_mut().for_each(|v| *v += 1);
+    ///     vec.iter_mut().for_each(|v| *v = *v + 1);
     ///     assert_eq!(vec, Integers::from_values(1..4));
     /// }
     /// ```
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut i32> {
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Rint> {
         self.as_typed_slice_mut().unwrap().iter_mut()
     }
 }
 
 impl FromIterator<i32> for Integers {
-    /// A more genralised iterator converter for small vectors.
-    /// Generates a non-altvec vector.
+    /// A more generalised iterator collector for small vectors.
+    /// Generates a non-ALTREP vector.
     /// ```
     /// use extendr_api::prelude::*;
     /// test! {

--- a/extendr-api/src/wrapper/mod.rs
+++ b/extendr-api/src/wrapper/mod.rs
@@ -9,6 +9,7 @@ pub mod char;
 pub mod environment;
 pub mod expr;
 pub mod function;
+pub mod integers;
 pub mod lang;
 pub mod list;
 pub mod matrix;
@@ -28,6 +29,7 @@ pub use altrep::{
 pub use environment::{EnvIter, Environment};
 pub use expr::Expression;
 pub use function::Function;
+pub use integers::Integers;
 pub use lang::Language;
 pub use list::{FromList, List, ListIter};
 pub use matrix::{RArray, RColumn, RMatrix, RMatrix3D};
@@ -156,6 +158,8 @@ make_conversions!(Promise, ExpectedPromise, is_promise, "Not a Promise object");
 make_conversions!(Altrep, ExpectedAltrep, is_altrep, "Not an Altrep type");
 
 make_conversions!(S4, ExpectedS4, is_s4, "Not a S4 type");
+
+make_conversions!(Integers, ExpectedInteger, is_integer, "Not an integer type");
 
 impl Robj {
     /// Convert a symbol object to a Symbol wrapper.

--- a/extendr-api/src/wrapper/mod.rs
+++ b/extendr-api/src/wrapper/mod.rs
@@ -105,6 +105,13 @@ macro_rules! make_conversions {
                 &self.robj
             }
         }
+
+        impl DerefMut for $typename {
+            /// Make a wrapper behave like a writable Robj.
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut self.robj
+            }
+        }
     };
 }
 

--- a/extendr-api/tests/extendr_macro.rs
+++ b/extendr-api/tests/extendr_macro.rs
@@ -37,6 +37,26 @@ fn test_option_i16(val: Option<i16>) -> i16 {
     }
 }
 
+#[extendr(use_try_from = true)]
+fn test_rint(val: Rint) -> Rint {
+    val
+}
+
+#[extendr(use_try_from = true)]
+fn test_integers(val: Integers) -> Integers {
+    val
+}
+
+#[extendr(use_try_from = true)]
+fn test_integers2(val: Integers) -> Integers {
+    val.iter().map(|i| i + 1).collect()
+}
+
+#[extendr(use_try_from = true)]
+fn test_integers3(val: Integers) -> Rint {
+    val.iter().sum()
+}
+
 #[test]
 fn tests_with_successful_outcomes() {
     unsafe {
@@ -85,6 +105,16 @@ fn tests_with_successful_outcomes() {
 
             // NA input.
             assert_eq!(new_owned(wrap__test_option_f64(r!(NA_INTEGER).get())), r!(-1.0));
+
+            // Rint.
+            assert_eq!(new_owned(wrap__test_rint(r!(1).get())), r!(1));
+            assert_eq!(new_owned(wrap__test_rint(r!(1.0).get())), r!(1));
+            assert_eq!(new_owned(wrap__test_rint(r!(NA_INTEGER).get())), r!(NA_INTEGER));
+
+            // Integers
+            assert_eq!(new_owned(wrap__test_integers(r!([1, 2]).get())), r!([1, 2]));
+            assert_eq!(new_owned(wrap__test_integers2(r!([1, 2]).get())), r!([2, 3]));
+            assert_eq!(new_owned(wrap__test_integers3(r!(0..4).get())), r!(6));
         }
     }
 }
@@ -108,8 +138,10 @@ fn tests_with_unsuccessful_outcomes() {
             assert!(catch_r_error(|| wrap__test_i32(r!(pairlist!(x=1)).get())).is_err());
             assert!(catch_r_error(|| wrap__test_i32(r!(list!(1, 2, 3)).get())).is_err());
 
-            // TODO: check for overflow.
-            // assert!(catch_r_error(|| wrap__test_i16(r!(1234567890).get())).is_err());
+            assert!(catch_r_error(|| wrap__test_rint(r!([1, 2]).get())).is_err());
+            assert!(catch_r_error(|| wrap__test_integers(r!([1.0, 2.0]).get())).is_err());
+
+            assert!(catch_r_error(|| wrap__test_i16(r!(1234567890).get())).is_err());
             std::panic::set_hook(old_hook);
         }
     });

--- a/extendr-api/tests/scalar_tests.rs
+++ b/extendr-api/tests/scalar_tests.rs
@@ -1,0 +1,50 @@
+use extendr_api::prelude::*;
+
+#[test]
+fn test_rint() {
+    let a = Rint::from(20);
+    let b = Rint::from(10);
+    assert_eq!(a + b, Rint::from(30));
+    assert_eq!(a - b, Rint::from(10));
+    assert_eq!(a * b, Rint::from(200));
+    assert_eq!(a / b, Rint::from(2));
+    assert_eq!(-a, Rint::from(-20));
+    assert_eq!(!a, Rint::from(-21));
+
+    assert_eq!(&a + b, Rint::from(30));
+    assert_eq!(&a - b, Rint::from(10));
+    assert_eq!(&a * b, Rint::from(200));
+    assert_eq!(&a / b, Rint::from(2));
+    assert_eq!(-&a, Rint::from(-20));
+    assert_eq!(!&a, Rint::from(-21));
+
+    // NA lhs
+    let a = Rint::na();
+    let b = Rint::from(10);
+    assert_eq!(a + b, Rint::na());
+    assert_eq!(a - b, Rint::na());
+    assert_eq!(a * b, Rint::na());
+    assert_eq!(a / b, Rint::na());
+    assert_eq!(-a, Rint::na());
+    assert_eq!(!a, Rint::na());
+
+    // NA rhs
+    let a = Rint::from(10);
+    let b = Rint::na();
+    assert_eq!(a + b, Rint::na());
+    assert_eq!(a - b, Rint::na());
+    assert_eq!(a * b, Rint::na());
+    assert_eq!(a / b, Rint::na());
+
+    // Overflow
+    let a = Rint::from(i32::MAX - 1);
+    let b = Rint::from(10);
+    assert_eq!(a * b, Rint::na());
+    assert_eq!(Rint::from(1) / Rint::from(0), Rint::na());
+    assert_eq!(Rint::from(-1) / Rint::na(), Rint::na());
+
+    // Underflow
+    let a = Rint::from(i32::MIN + 1);
+    let b = Rint::from(-10);
+    assert_eq!(a + b, Rint::na());
+}


### PR DESCRIPTION
This is a sample for an Integers class that uses Altrep
methods to handle very large vectors.

There are no iterators at present as we would need to implement
Rint first.

The USP of this is the ability to make vectors from iterators without
allocating memory.

We support elt(), get_region(), is_sorted() and no_na() correctly.

We do not have access to altrep min() and max() since these were removed
from Rinternals.h

Suggestions on a postcard...