### PR TITLE
ndarray improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@
 
 - `SymPair::sym_pair()` now returns `(Option<Robj>, Robj)`
 
+- Bump `ndarray` to 0.15.3. Under [RFC 1977](https://github.com/rust-lang/rfcs/pull/1977) this is a "public dependency" change, and therefore can be considered a breaking change, as consumers of `extendr` that use an older version of `ndarray` will no longer be compatible until they also bump `ndarray` to a compatible version.
+
+- Implement `TryFrom<&ArrayBase> for Robj`, allowing `extendr`-annotated functions to return Arrays from the `ndarray` crate and have them automatically converted to R arrays. Note, even if 1D arrays are returned they will not be returned as vectors.
+
 ## extendr 0.2.0
 
 - Added contributing guidelines and code of conduct.

--- a/extendr-api/Cargo.toml
+++ b/extendr-api/Cargo.toml
@@ -17,7 +17,7 @@ repository = "https://github.com/extendr/extendr"
 libR-sys = "0.2.2"
 extendr-macros = { path = "../extendr-macros", version="0.2.0" }
 extendr-engine = { path = "../extendr-engine", version="0.2.0" }
-ndarray = { version = "0.13.1", optional = true }
+ndarray = { version = "0.15.3", optional = true }
 lazy_static = "1.4"
 
 [features]

--- a/extendr-api/src/robj_ndarray.rs
+++ b/extendr-api/src/robj_ndarray.rs
@@ -6,8 +6,8 @@ use crate::prelude::{class_symbol, dim_symbol};
 use crate::*;
 
 impl<'a, T> FromRobj<'a> for ArrayView1<'a, T>
-    where
-        Robj: AsTypedSlice<'a, T>,
+where
+    Robj: AsTypedSlice<'a, T>,
 {
     /// Convert an R object to a `ndarray` ArrayView1.
     fn from_robj(robj: &'a Robj) -> std::result::Result<Self, &'static str> {
@@ -58,10 +58,10 @@ make_array_view_2!(f64, "Not a floating point matrix.");
 //     }
 // }
 impl<A, S, D> From<ArrayBase<S, D>> for Robj
-    where
-        S: Data<Elem=A>,
-        A: Copy + ToVectorValue,
-        D: Dimension,
+where
+    S: Data<Elem = A>,
+    A: Copy + ToVectorValue,
+    D: Dimension,
 {
     fn from(arr: ArrayBase<S, D>) -> Self {
         let dims: Vec<i32> = arr.shape().iter().map(|x| *x as i32).collect();
@@ -159,15 +159,19 @@ fn test_from_robj() {
 }
 
 fn compare_robj_arrays<'a, T>(a: &Robj, b: &Robj)
-    where T: 'a + std::fmt::Debug + PartialEq,
-          Robj: AsTypedSlice<'a, T>
+where
+    T: 'a + std::fmt::Debug + PartialEq,
+    Robj: AsTypedSlice<'a, T>,
 {
     assert!(a.is_vector() || a.is_array());
     assert!(b.is_vector() || b.is_array());
     assert_eq!(a.len(), b.len());
     // assert_eq!(a.get_attrib(class_symbol()), b.get_attrib(class_symbol()));
     assert_eq!(a.get_attrib(dim_symbol()), b.get_attrib(dim_symbol()));
-    assert_eq!(AsTypedSlice::<T>::as_typed_slice(a), AsTypedSlice::<T>::as_typed_slice(b));
+    assert_eq!(
+        AsTypedSlice::<T>::as_typed_slice(a),
+        AsTypedSlice::<T>::as_typed_slice(b)
+    );
 }
 
 #[test]

--- a/extendr-api/src/robj_ndarray.rs
+++ b/extendr-api/src/robj_ndarray.rs
@@ -182,10 +182,10 @@ fn test_to_robj() {
         &R!("c(1, 2, 3)").unwrap()
     );
 
-    // compare_robj_arrays::<i32>(
-    //     &Robj::from(array![[1, 2, 3], [4, 5, 6]]),
-    //     &R!("matrix(c(1, 2, 3, 4, 5, 6), nrow=2, byrow=T)").unwrap()
-    // );
+    compare_robj_arrays::<i32>(
+        &Robj::from(array![[1, 2, 3], [4, 5, 6]]),
+        &R!("matrix(c(1, 2, 3, 4, 5, 6), nrow=2, byrow=T)").unwrap()
+    );
 
     compare_robj_arrays::<i32>(
         &Robj::from( array![[[1, 2], [3, 4]], [[5, 6], [7, 8]]]),

--- a/extendr-api/src/robj_ndarray.rs
+++ b/extendr-api/src/robj_ndarray.rs
@@ -163,9 +163,7 @@ where
     T: 'a + std::fmt::Debug + PartialEq,
     Robj: AsTypedSlice<'a, T>,
 {
-    assert!(a.is_vector() || a.is_array());
-    assert!(b.is_vector() || b.is_array());
-    assert_eq!(a.sexptype(), b.sexptype());
+    assert_eq!(a.rtype(), b.rtype());
     assert_eq!(a.len(), b.len());
     // assert_eq!(a.get_attrib(class_symbol()), b.get_attrib(class_symbol()));
     assert_eq!(a.get_attrib(dim_symbol()), b.get_attrib(dim_symbol()));

--- a/extendr-api/src/robj_ndarray.rs
+++ b/extendr-api/src/robj_ndarray.rs
@@ -82,7 +82,7 @@ where
             .iter()
             .copied()
             .collect_robj()
-            .set_attrib(dim_symbol(), dims.clone())
+            .set_attrib(dim_symbol(), dims)
             .unwrap()
     }
 }

--- a/extendr-api/src/robj_ndarray.rs
+++ b/extendr-api/src/robj_ndarray.rs
@@ -1,8 +1,8 @@
 #[doc(hidden)]
 use ndarray::prelude::*;
-use ndarray::{Data, IntoDimension, ShapeBuilder};
+use ndarray::{Data, ShapeBuilder};
 
-use crate::prelude::{class_symbol, dim_symbol};
+use crate::prelude::dim_symbol;
 use crate::*;
 
 impl<'a, T> FromRobj<'a> for ArrayView1<'a, T>
@@ -65,8 +65,8 @@ where
 {
     fn from(arr: ArrayBase<S, D>) -> Self {
         let dims: Vec<i32>;
-        let inverse = arr.t();
         let reshaped: ArrayView<A, D>;
+        let inverse = arr.t();
         if arr.is_standard_layout() {
             // If we have a standard layout array, we have to keep the current dimensions
             // but transpose the memory layout
@@ -78,13 +78,12 @@ where
             reshaped = arr.view();
             dims = inverse.shape().iter().map(|x| *x as i32).collect();
         }
-        let mut ret = reshaped.iter().copied().collect_robj();
-
-        if dims.len() > 1 {
-            ret = ret.set_attrib(dim_symbol(), dims.clone()).unwrap();
-        }
-
-        ret
+        reshaped
+            .iter()
+            .copied()
+            .collect_robj()
+            .set_attrib(dim_symbol(), dims.clone())
+            .unwrap()
     }
 }
 
@@ -165,7 +164,7 @@ fn test_to_robj() {
     test! {
     assert_eq!(
         &Robj::from(array![1., 2., 3.]),
-        &R!("c(1, 2, 3)").unwrap()
+        &R!("array(c(1, 2, 3))").unwrap()
     );
 
     assert_eq!(

--- a/extendr-api/src/robj_ndarray.rs
+++ b/extendr-api/src/robj_ndarray.rs
@@ -165,6 +165,7 @@ where
 {
     assert!(a.is_vector() || a.is_array());
     assert!(b.is_vector() || b.is_array());
+    assert_eq!(a.sexptype(), b.sexptype());
     assert_eq!(a.len(), b.len());
     // assert_eq!(a.get_attrib(class_symbol()), b.get_attrib(class_symbol()));
     assert_eq!(a.get_attrib(dim_symbol()), b.get_attrib(dim_symbol()));
@@ -183,12 +184,12 @@ fn test_to_robj() {
     );
 
     compare_robj_arrays::<i32>(
-        &Robj::from(array![[1, 2, 3], [4, 5, 6]]),
+        &Robj::from(array![[1., 2., 3.], [4., 5., 6.]]),
         &R!("matrix(c(1, 2, 3, 4, 5, 6), nrow=2, byrow=T)").unwrap()
     );
 
     compare_robj_arrays::<i32>(
-        &Robj::from( array![[[1, 2], [3, 4]], [[5, 6], [7, 8]]]),
+        &Robj::from(array![[[1, 2], [3, 4]], [[5, 6], [7, 8]]]),
         &R!("array(1:8, dim=c(2, 2, 2))").unwrap()
     );
     }

--- a/extendr-api/src/robj_ndarray.rs
+++ b/extendr-api/src/robj_ndarray.rs
@@ -60,7 +60,7 @@ make_array_view_2!(f64, "Not a floating point matrix.");
 impl<A, S, D> From<ArrayBase<S, D>> for Robj
 where
     S: Data<Elem = A>,
-    A: Copy + ToVectorValue + std::fmt::Debug,
+    A: Copy + ToVectorValue,
     D: Dimension,
 {
     fn from(arr: ArrayBase<S, D>) -> Self {

--- a/extendr-api/src/robj_ndarray.rs
+++ b/extendr-api/src/robj_ndarray.rs
@@ -163,6 +163,12 @@ fn test_from_robj() {
 #[test]
 fn test_to_robj() {
     test! {
+        // An empty array should still convert to an empty R array with the same shape
+        assert_eq!(
+            &Robj::try_from(&Array4::<i32>::zeros((0, 1, 2, 3).f()))?,
+            &R!("array(integer(), c(0, 1, 2, 3))")?
+        );
+
         assert_eq!(
             &Robj::try_from(&array![1., 2., 3.])?,
             &R!("array(c(1, 2, 3))")?
@@ -172,14 +178,14 @@ fn test_to_robj() {
         // in C order. Therefore these arrays should be the same.
         assert_eq!(
             &Robj::try_from(&Array::from_shape_vec((2, 3), vec![1., 2., 3., 4., 5., 6.]).unwrap())?,
-            &R!("matrix(c(1, 2, 3, 4, 5, 6), nrow=2, byrow=T)")?
+            &R!("matrix(c(1, 2, 3, 4, 5, 6), nrow=2, byrow=TRUE)")?
         );
 
         // We give both R and Rust the same 1d vector and tell them both to read it as a matrix
         // in fortran order. Therefore these arrays should be the same.
         assert_eq!(
             &Robj::try_from(&Array::from_shape_vec((2, 3).f(), vec![1., 2., 3., 4., 5., 6.]).unwrap())?,
-            &R!("matrix(c(1, 2, 3, 4, 5, 6), nrow=2, byrow=F)")?
+            &R!("matrix(c(1, 2, 3, 4, 5, 6), nrow=2, byrow=FALSE)")?
         );
 
         // We give both R and Rust the same 1d vector and tell them both to read it as a 3d array


### PR DESCRIPTION
Changes:
* Bump ndarray. This is needed because the current 0.13.x version that we are using is not compatible with projects using the more modern 0.15.x versions, and interop between arrays from different versions of the library will fail in confusing ways
* Implement `From<ArrayBase<S, D>> for Robj` ie conversion from any ndarray to an Robj, with tests

Outstanding questions:
* ~~How can we actually compare R objects in Rust? My tests are failing I assume because the pointers are not the same, even though the string representation seems identical~~
* ~~Why do the arrays created using `R!` not have any classes set when I `a.get_attrib(class_symbol())`?~~