### PR TITLE
Reduce robj to a single pointer

### DIFF
--- a/extendr-api/src/functions.rs
+++ b/extendr-api/src/functions.rs
@@ -83,7 +83,7 @@ pub fn find_namespace<K: Into<Robj>>(key: K) -> Result<Environment> {
 /// }
 /// ```
 pub fn current_env() -> Environment {
-    unsafe { new_owned(R_GetCurrentEnv()).try_into().unwrap() }
+    unsafe { Robj::from_sexp(R_GetCurrentEnv()).try_into().unwrap() }
 }
 
 /// The "global" environment
@@ -96,12 +96,12 @@ pub fn current_env() -> Environment {
 /// }
 /// ```
 pub fn global_env() -> Environment {
-    unsafe { new_sys(R_GlobalEnv).try_into().unwrap() }
+    unsafe { Robj::from_sexp(R_GlobalEnv).try_into().unwrap() }
 }
 
 /// An empty environment at the root of the environment tree
 pub fn empty_env() -> Environment {
-    unsafe { new_sys(R_EmptyEnv).try_into().unwrap() }
+    unsafe { Robj::from_sexp(R_EmptyEnv).try_into().unwrap() }
 }
 
 /// Create a new environment
@@ -118,7 +118,7 @@ pub fn empty_env() -> Environment {
 pub fn new_env(parent: Environment, hash: bool, capacity: i32) -> Environment {
     unsafe {
         let env = R_NewEnv(parent.robj.get(), hash as i32, capacity);
-        new_sys(env).try_into().unwrap()
+        Robj::from_sexp(env).try_into().unwrap()
     }
 }
 
@@ -141,7 +141,7 @@ pub fn new_env(parent: Environment, hash: bool, capacity: i32) -> Environment {
 /// }
 /// ```
 pub fn base_env() -> Environment {
-    unsafe { new_sys(R_BaseEnv).try_into().unwrap() }
+    unsafe { Robj::from_sexp(R_BaseEnv).try_into().unwrap() }
 }
 
 /// The namespace for base.
@@ -153,7 +153,7 @@ pub fn base_env() -> Environment {
 /// }
 /// ```
 pub fn base_namespace() -> Environment {
-    unsafe { new_sys(R_BaseNamespace).try_into().unwrap() }
+    unsafe { Robj::from_sexp(R_BaseNamespace).try_into().unwrap() }
 }
 
 /// For registered namespaces.
@@ -165,37 +165,37 @@ pub fn base_namespace() -> Environment {
 /// }
 /// ```
 pub fn namespace_registry() -> Environment {
-    unsafe { new_sys(R_NamespaceRegistry).try_into().unwrap() }
+    unsafe { Robj::from_sexp(R_NamespaceRegistry).try_into().unwrap() }
 }
 
 /// Current srcref, for debuggers
 pub fn srcref() -> Robj {
-    unsafe { new_sys(R_Srcref) }
+    unsafe { Robj::from_sexp(R_Srcref) }
 }
 
 /// The nil object
 pub fn nil_value() -> Robj {
-    unsafe { new_sys(R_NilValue) }
+    unsafe { Robj::from_sexp(R_NilValue) }
 }
 
 /* fix version issues.
 /// ".Generic"
-pub fn dot_Generic() -> Robj { unsafe { new_sys(R_dot_Generic) }}
+pub fn dot_Generic() -> Robj { unsafe { Robj::from_sexp(R_dot_Generic) }}
 */
 
 /// NA_STRING as a CHARSXP
 pub fn na_string() -> Robj {
-    unsafe { new_sys(R_NaString) }
+    unsafe { Robj::from_sexp(R_NaString) }
 }
 
 /// "" as a CHARSXP
 pub fn blank_string() -> Robj {
-    unsafe { new_sys(R_BlankString) }
+    unsafe { Robj::from_sexp(R_BlankString) }
 }
 
 /// "" as a STRSXP
 pub fn blank_scalar_string() -> Robj {
-    unsafe { new_sys(R_BlankScalarString) }
+    unsafe { Robj::from_sexp(R_BlankScalarString) }
 }
 
 /// Special "NA" string that represents null strings.
@@ -226,7 +226,7 @@ pub fn parse(code: &str) -> Result<Robj> {
         let mut status = 0_u32;
         let status_ptr = &mut status as *mut u32;
         let codeobj: Robj = code.into();
-        let parsed = new_owned(R_ParseVector(codeobj.get(), -1, status_ptr, R_NilValue));
+        let parsed = Robj::from_sexp(R_ParseVector(codeobj.get(), -1, status_ptr, R_NilValue));
         match status {
             1 => Ok(parsed),
             _ => Err(Error::ParseError(code.into())),

--- a/extendr-api/src/graphics/mod.rs
+++ b/extendr-api/src/graphics/mod.rs
@@ -3,11 +3,8 @@ use libR_sys::*;
 
 pub mod color;
 
-<<<<<<< HEAD
 use color::Color;
 
-=======
->>>>>>> Change uses of new_owned to Robj::from_sexp
 pub struct Context {
     context: R_GE_gcontext,
     xscale: (f64, f64),
@@ -73,15 +70,9 @@ pub enum LineType {
     Solid,
     Dashed,
     Dotted,
-<<<<<<< HEAD
     DotDash,
     LongDash,
     TwoDash,
-=======
-    Dotdash,
-    Longdash,
-    Twodash,
->>>>>>> Change uses of new_owned to Robj::from_sexp
 }
 
 #[derive(PartialEq, Debug, Clone)]
@@ -126,13 +117,8 @@ impl Context {
             let scalar = (xscale.0 * yscale.1 - xscale.1 * yscale.0).abs().sqrt();
 
             let mut context = R_GE_gcontext {
-<<<<<<< HEAD
                 col: Color::rgb(0xff, 0xff, 0xff).to_i32(),
                 fill: Color::rgb(0xc0, 0xc0, 0xc0).to_i32(),
-=======
-                col: color::rgb(0xff, 0xff, 0xff).to_i32(),
-                fill: color::rgb(0xc0, 0xc0, 0xc0).to_i32(),
->>>>>>> Change uses of new_owned to Robj::from_sexp
                 gamma: 1.0,
                 lwd: 1.0,
                 lty: 0,
@@ -166,21 +152,13 @@ impl Context {
     }
 
     /// Set the line or text color of a primitive.
-<<<<<<< HEAD
     pub fn color(&mut self, col: Color) -> &mut Self {
-=======
-    pub fn color(&mut self, col: color::Color) -> &mut Self {
->>>>>>> Change uses of new_owned to Robj::from_sexp
         self.context.col = col.to_i32();
         self
     }
 
     /// Set the fill color of a primitive.
-<<<<<<< HEAD
     pub fn fill(&mut self, fill: Color) -> &mut Self {
-=======
-    pub fn fill(&mut self, fill: color::Color) -> &mut Self {
->>>>>>> Change uses of new_owned to Robj::from_sexp
         self.context.fill = fill.to_i32();
         self
     }
@@ -198,24 +176,14 @@ impl Context {
     }
 
     /// Set the type of the line.
-<<<<<<< HEAD
     /// ```ignore
-=======
-    /// ```norun
->>>>>>> Change uses of new_owned to Robj::from_sexp
     /// Blank    => <invisible>
     /// Solid    => ------
     /// Dashed   => - - - -
     /// Dotted   => . . . .
-<<<<<<< HEAD
     /// DotDash  => . - . -
     /// LongDash => --  --
     /// TwoDash  => . . - -
-=======
-    /// Dotdash  => . - . -
-    /// Longdash => --  --
-    /// Twodash  => . . - -
->>>>>>> Change uses of new_owned to Robj::from_sexp
     /// ```
     pub fn line_type(&mut self, lty: LineType) -> &mut Self {
         use LineType::*;
@@ -224,25 +192,15 @@ impl Context {
             Solid => 0,
             Dashed => 4 + (4 << 4),
             Dotted => 1 + (3 << 4),
-<<<<<<< HEAD
             DotDash => 1 + (3 << 4) + (4 << 8) + (3 << 12),
             LongDash => 7 + (3 << 4),
             TwoDash => 2 + (2 << 4) + (6 << 8) + (2 << 12),
-=======
-            Dotdash => 1 + (3 << 4) + (4 << 8) + (3 << 12),
-            Longdash => 7 + (3 << 4),
-            Twodash => 2 + (2 << 4) + (6 << 8) + (2 << 12),
->>>>>>> Change uses of new_owned to Robj::from_sexp
         };
         self
     }
 
     /// Set the line end type.
-<<<<<<< HEAD
     /// ```ignore
-=======
-    /// ```norun
->>>>>>> Change uses of new_owned to Robj::from_sexp
     ///   LineEnd::RoundCap
     ///   LineEnd::ButtCap  
     ///   LineEnd::SquareCap
@@ -257,11 +215,7 @@ impl Context {
     }
 
     /// Set the line join type.
-<<<<<<< HEAD
     /// ```ignore
-=======
-    /// ```norun
->>>>>>> Change uses of new_owned to Robj::from_sexp
     ///   LineJoin::RoundJoin
     ///   LineJoin::MitreJoin
     ///   LineJoin::BevelJoin
@@ -298,11 +252,7 @@ impl Context {
     // }
 
     /// Set the font face.
-<<<<<<< HEAD
     /// ```ignore
-=======
-    /// ```norun
->>>>>>> Change uses of new_owned to Robj::from_sexp
     ///   FontFace::PlainFont
     ///   FontFace::BoldFont
     ///   FontFace::ItalicFont
@@ -390,7 +340,6 @@ impl Context {
 #[allow(non_snake_case)]
 impl Device {
     /// Get the current device.
-<<<<<<< HEAD
     pub fn current() -> Result<Device> {
         // At present we can't trap an R error from a function
         // that does not return a SEXP.
@@ -398,18 +347,10 @@ impl Device {
             Ok(Device {
                 inner: GEcurrentDevice(),
             })
-=======
-    pub fn current() -> Device {
-        unsafe {
-            Device {
-                inner: GEcurrentDevice(),
-            }
->>>>>>> Change uses of new_owned to Robj::from_sexp
         }
     }
 
     /// Enable device rendering.
-<<<<<<< HEAD
     pub fn mode_on(&self) -> Result<()> {
         unsafe {
             if Rf_NoDevices() != 0 {
@@ -418,16 +359,10 @@ impl Device {
                 GEMode(1, self.inner());
                 Ok(())
             }
-=======
-    pub fn mode_on(&self) {
-        unsafe {
-            GEMode(1, self.inner());
->>>>>>> Change uses of new_owned to Robj::from_sexp
         }
     }
 
     /// Disable device rendering and flush.
-<<<<<<< HEAD
     pub fn mode_off(&self) -> Result<()> {
         unsafe {
             if Rf_NoDevices() != 0 {
@@ -436,11 +371,6 @@ impl Device {
                 GEMode(0, self.inner());
                 Ok(())
             }
-=======
-    pub fn mode_off(&self) {
-        unsafe {
-            GEMode(0, self.inner());
->>>>>>> Change uses of new_owned to Robj::from_sexp
         }
     }
 
@@ -450,7 +380,6 @@ impl Device {
     }
 
     /// Get a device by number.
-<<<<<<< HEAD
     pub fn get_device(number: i32) -> Result<Device> {
         unsafe {
             if number < 0 || number >= Rf_NumDevices() {
@@ -459,12 +388,6 @@ impl Device {
                 Ok(Device {
                     inner: GEgetDevice(number),
                 })
-=======
-    pub fn get_device(number: i32) -> Device {
-        unsafe {
-            Device {
-                inner: GEgetDevice(number),
->>>>>>> Change uses of new_owned to Robj::from_sexp
             }
         }
     }
@@ -595,11 +518,7 @@ impl Device {
     //     let yptr = y.as_mut_slice().as_mut_ptr();
     //     let sptr = s.as_mut_slice().as_mut_ptr();
     //     unsafe {
-<<<<<<< HEAD
     //         new_owned(GEXspline(
-=======
-    //         Robj::from_sexp(GEXspline(
->>>>>>> Change uses of new_owned to Robj::from_sexp
     //             x.len() as std::os::raw::c_int,
     //             xptr,
     //             yptr,
@@ -674,11 +593,7 @@ impl Device {
 
     /// Screen capture. Returns an integer matrix representing pixels if it is able.
     pub fn capture(&self) -> Robj {
-<<<<<<< HEAD
         unsafe { new_owned(GECap(self.inner())) }
-=======
-        unsafe { Robj::from_sexp(GECap(self.inner())) }
->>>>>>> Change uses of new_owned to Robj::from_sexp
     }
 
     /// Draw a bitmap.

--- a/extendr-api/src/graphics/mod.rs
+++ b/extendr-api/src/graphics/mod.rs
@@ -3,8 +3,11 @@ use libR_sys::*;
 
 pub mod color;
 
+<<<<<<< HEAD
 use color::Color;
 
+=======
+>>>>>>> Change uses of new_owned to Robj::from_sexp
 pub struct Context {
     context: R_GE_gcontext,
     xscale: (f64, f64),
@@ -70,9 +73,15 @@ pub enum LineType {
     Solid,
     Dashed,
     Dotted,
+<<<<<<< HEAD
     DotDash,
     LongDash,
     TwoDash,
+=======
+    Dotdash,
+    Longdash,
+    Twodash,
+>>>>>>> Change uses of new_owned to Robj::from_sexp
 }
 
 #[derive(PartialEq, Debug, Clone)]
@@ -117,8 +126,13 @@ impl Context {
             let scalar = (xscale.0 * yscale.1 - xscale.1 * yscale.0).abs().sqrt();
 
             let mut context = R_GE_gcontext {
+<<<<<<< HEAD
                 col: Color::rgb(0xff, 0xff, 0xff).to_i32(),
                 fill: Color::rgb(0xc0, 0xc0, 0xc0).to_i32(),
+=======
+                col: color::rgb(0xff, 0xff, 0xff).to_i32(),
+                fill: color::rgb(0xc0, 0xc0, 0xc0).to_i32(),
+>>>>>>> Change uses of new_owned to Robj::from_sexp
                 gamma: 1.0,
                 lwd: 1.0,
                 lty: 0,
@@ -152,13 +166,21 @@ impl Context {
     }
 
     /// Set the line or text color of a primitive.
+<<<<<<< HEAD
     pub fn color(&mut self, col: Color) -> &mut Self {
+=======
+    pub fn color(&mut self, col: color::Color) -> &mut Self {
+>>>>>>> Change uses of new_owned to Robj::from_sexp
         self.context.col = col.to_i32();
         self
     }
 
     /// Set the fill color of a primitive.
+<<<<<<< HEAD
     pub fn fill(&mut self, fill: Color) -> &mut Self {
+=======
+    pub fn fill(&mut self, fill: color::Color) -> &mut Self {
+>>>>>>> Change uses of new_owned to Robj::from_sexp
         self.context.fill = fill.to_i32();
         self
     }
@@ -176,14 +198,24 @@ impl Context {
     }
 
     /// Set the type of the line.
+<<<<<<< HEAD
     /// ```ignore
+=======
+    /// ```norun
+>>>>>>> Change uses of new_owned to Robj::from_sexp
     /// Blank    => <invisible>
     /// Solid    => ------
     /// Dashed   => - - - -
     /// Dotted   => . . . .
+<<<<<<< HEAD
     /// DotDash  => . - . -
     /// LongDash => --  --
     /// TwoDash  => . . - -
+=======
+    /// Dotdash  => . - . -
+    /// Longdash => --  --
+    /// Twodash  => . . - -
+>>>>>>> Change uses of new_owned to Robj::from_sexp
     /// ```
     pub fn line_type(&mut self, lty: LineType) -> &mut Self {
         use LineType::*;
@@ -192,15 +224,25 @@ impl Context {
             Solid => 0,
             Dashed => 4 + (4 << 4),
             Dotted => 1 + (3 << 4),
+<<<<<<< HEAD
             DotDash => 1 + (3 << 4) + (4 << 8) + (3 << 12),
             LongDash => 7 + (3 << 4),
             TwoDash => 2 + (2 << 4) + (6 << 8) + (2 << 12),
+=======
+            Dotdash => 1 + (3 << 4) + (4 << 8) + (3 << 12),
+            Longdash => 7 + (3 << 4),
+            Twodash => 2 + (2 << 4) + (6 << 8) + (2 << 12),
+>>>>>>> Change uses of new_owned to Robj::from_sexp
         };
         self
     }
 
     /// Set the line end type.
+<<<<<<< HEAD
     /// ```ignore
+=======
+    /// ```norun
+>>>>>>> Change uses of new_owned to Robj::from_sexp
     ///   LineEnd::RoundCap
     ///   LineEnd::ButtCap  
     ///   LineEnd::SquareCap
@@ -215,7 +257,11 @@ impl Context {
     }
 
     /// Set the line join type.
+<<<<<<< HEAD
     /// ```ignore
+=======
+    /// ```norun
+>>>>>>> Change uses of new_owned to Robj::from_sexp
     ///   LineJoin::RoundJoin
     ///   LineJoin::MitreJoin
     ///   LineJoin::BevelJoin
@@ -252,7 +298,11 @@ impl Context {
     // }
 
     /// Set the font face.
+<<<<<<< HEAD
     /// ```ignore
+=======
+    /// ```norun
+>>>>>>> Change uses of new_owned to Robj::from_sexp
     ///   FontFace::PlainFont
     ///   FontFace::BoldFont
     ///   FontFace::ItalicFont
@@ -340,6 +390,7 @@ impl Context {
 #[allow(non_snake_case)]
 impl Device {
     /// Get the current device.
+<<<<<<< HEAD
     pub fn current() -> Result<Device> {
         // At present we can't trap an R error from a function
         // that does not return a SEXP.
@@ -347,10 +398,18 @@ impl Device {
             Ok(Device {
                 inner: GEcurrentDevice(),
             })
+=======
+    pub fn current() -> Device {
+        unsafe {
+            Device {
+                inner: GEcurrentDevice(),
+            }
+>>>>>>> Change uses of new_owned to Robj::from_sexp
         }
     }
 
     /// Enable device rendering.
+<<<<<<< HEAD
     pub fn mode_on(&self) -> Result<()> {
         unsafe {
             if Rf_NoDevices() != 0 {
@@ -359,10 +418,16 @@ impl Device {
                 GEMode(1, self.inner());
                 Ok(())
             }
+=======
+    pub fn mode_on(&self) {
+        unsafe {
+            GEMode(1, self.inner());
+>>>>>>> Change uses of new_owned to Robj::from_sexp
         }
     }
 
     /// Disable device rendering and flush.
+<<<<<<< HEAD
     pub fn mode_off(&self) -> Result<()> {
         unsafe {
             if Rf_NoDevices() != 0 {
@@ -371,6 +436,11 @@ impl Device {
                 GEMode(0, self.inner());
                 Ok(())
             }
+=======
+    pub fn mode_off(&self) {
+        unsafe {
+            GEMode(0, self.inner());
+>>>>>>> Change uses of new_owned to Robj::from_sexp
         }
     }
 
@@ -380,6 +450,7 @@ impl Device {
     }
 
     /// Get a device by number.
+<<<<<<< HEAD
     pub fn get_device(number: i32) -> Result<Device> {
         unsafe {
             if number < 0 || number >= Rf_NumDevices() {
@@ -388,6 +459,12 @@ impl Device {
                 Ok(Device {
                     inner: GEgetDevice(number),
                 })
+=======
+    pub fn get_device(number: i32) -> Device {
+        unsafe {
+            Device {
+                inner: GEgetDevice(number),
+>>>>>>> Change uses of new_owned to Robj::from_sexp
             }
         }
     }
@@ -518,7 +595,11 @@ impl Device {
     //     let yptr = y.as_mut_slice().as_mut_ptr();
     //     let sptr = s.as_mut_slice().as_mut_ptr();
     //     unsafe {
+<<<<<<< HEAD
     //         new_owned(GEXspline(
+=======
+    //         Robj::from_sexp(GEXspline(
+>>>>>>> Change uses of new_owned to Robj::from_sexp
     //             x.len() as std::os::raw::c_int,
     //             xptr,
     //             yptr,
@@ -593,7 +674,11 @@ impl Device {
 
     /// Screen capture. Returns an integer matrix representing pixels if it is able.
     pub fn capture(&self) -> Robj {
+<<<<<<< HEAD
         unsafe { new_owned(GECap(self.inner())) }
+=======
+        unsafe { Robj::from_sexp(GECap(self.inner())) }
+>>>>>>> Change uses of new_owned to Robj::from_sexp
     }
 
     /// Draw a bitmap.

--- a/extendr-api/src/lang_macros.rs
+++ b/extendr-api/src/lang_macros.rs
@@ -4,7 +4,7 @@
 use libR_sys::*;
 //use crate::robj::*;
 use crate::robj::Robj;
-use crate::{new_owned, single_threaded};
+use crate::single_threaded;
 
 /// Convert a list of tokens to an array of tuples.
 #[doc(hidden)]
@@ -69,7 +69,7 @@ pub unsafe fn make_lang(sym: &str) -> Robj {
     name.push(0);
     let sexp =
         single_threaded(|| Rf_lang1(Rf_install(name.as_ptr() as *const std::os::raw::c_char)));
-    new_owned(sexp)
+    Robj::from_sexp(sexp)
 }
 
 /// Convert a list of tokens to an array of tuples.

--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -245,6 +245,8 @@ pub use std::convert::{TryFrom, TryInto};
 pub use std::ops::Deref;
 pub use std::ops::DerefMut;
 
+pub use robj::Robj;
+
 //////////////////////////////////////////////////
 // Note these pub use statements are deprectaed
 //
@@ -725,18 +727,18 @@ mod tests {
                 wrap__robjtype(Robj::from(1).get());
 
                 // General integer types.
-                assert_eq!(new_owned(wrap__return_u8()), Robj::from(123_u8));
-                assert_eq!(new_owned(wrap__return_u16()), Robj::from(123));
-                assert_eq!(new_owned(wrap__return_u32()), Robj::from(123.));
-                assert_eq!(new_owned(wrap__return_u64()), Robj::from(123.));
-                assert_eq!(new_owned(wrap__return_i8()), Robj::from(123));
-                assert_eq!(new_owned(wrap__return_i16()), Robj::from(123));
-                assert_eq!(new_owned(wrap__return_i32()), Robj::from(123));
-                assert_eq!(new_owned(wrap__return_i64()), Robj::from(123.));
+                assert_eq!(Robj::from_sexp(wrap__return_u8()), Robj::from(123_u8));
+                assert_eq!(Robj::from_sexp(wrap__return_u16()), Robj::from(123));
+                assert_eq!(Robj::from_sexp(wrap__return_u32()), Robj::from(123.));
+                assert_eq!(Robj::from_sexp(wrap__return_u64()), Robj::from(123.));
+                assert_eq!(Robj::from_sexp(wrap__return_i8()), Robj::from(123));
+                assert_eq!(Robj::from_sexp(wrap__return_i16()), Robj::from(123));
+                assert_eq!(Robj::from_sexp(wrap__return_i32()), Robj::from(123));
+                assert_eq!(Robj::from_sexp(wrap__return_i64()), Robj::from(123.));
 
                 // Floating point types.
-                assert_eq!(new_owned(wrap__return_f32()), Robj::from(123.));
-                assert_eq!(new_owned(wrap__return_f64()), Robj::from(123.));
+                assert_eq!(Robj::from_sexp(wrap__return_f32()), Robj::from(123.));
+                assert_eq!(Robj::from_sexp(wrap__return_f64()), Robj::from(123.));
             }
         }
     }
@@ -761,56 +763,56 @@ mod tests {
                 // pub fn f64_slice(x: &[f64]) -> &[f64] { x }
 
                 let robj = r!([1., 2., 3.]);
-                assert_eq!(new_owned(wrap__f64_slice(robj.get())), robj);
+                assert_eq!(Robj::from_sexp(wrap__f64_slice(robj.get())), robj);
 
                 // #[extendr]
                 // pub fn i32_slice(x: &[i32]) -> &[i32] { x }
 
                 let robj = r!([1, 2, 3]);
-                assert_eq!(new_owned(wrap__i32_slice(robj.get())), robj);
+                assert_eq!(Robj::from_sexp(wrap__i32_slice(robj.get())), robj);
 
                 // #[extendr]
                 // pub fn bool_slice(x: &[Bool]) -> &[Bool] { x }
 
                 let robj = r!([TRUE, FALSE, TRUE]);
-                assert_eq!(new_owned(wrap__bool_slice(robj.get())), robj);
+                assert_eq!(Robj::from_sexp(wrap__bool_slice(robj.get())), robj);
 
                 // #[extendr]
                 // pub fn f64_iter(x: Real) -> Real { x }
 
                 let robj = r!([1., 2., 3.]);
-                assert_eq!(new_owned(wrap__f64_iter(robj.get())), robj);
+                assert_eq!(Robj::from_sexp(wrap__f64_iter(robj.get())), robj);
 
                 // #[extendr]
                 // pub fn i32_iter(x: Int) -> Int { x }
 
                 let robj = r!([1, 2, 3]);
-                assert_eq!(new_owned(wrap__i32_iter(robj.get())), robj);
+                assert_eq!(Robj::from_sexp(wrap__i32_iter(robj.get())), robj);
 
                 // #[extendr]
                 // pub fn bool_iter(x: Logical) -> Logical { x }
 
                 let robj = r!([TRUE, FALSE, TRUE]);
-                assert_eq!(new_owned(wrap__bool_iter(robj.get())), robj);
+                assert_eq!(Robj::from_sexp(wrap__bool_iter(robj.get())), robj);
 
                 // #[extendr]
                 // pub fn symbol(x: Symbol) -> Symbol { x }
 
                 let robj = sym!(fred);
-                assert_eq!(new_owned(wrap__symbol(robj.get())), robj);
+                assert_eq!(Robj::from_sexp(wrap__symbol(robj.get())), robj);
 
                 // #[extendr]
                 // pub fn matrix(x: Matrix<&[f64]>) -> Matrix<&[f64]> { x }
 
                 let m = RMatrix::new_matrix(1, 2, |r, c| if r == c {1.0} else {0.});
                 let robj = r!(m);
-                assert_eq!(new_owned(wrap__matrix(robj.get())), robj);
+                assert_eq!(Robj::from_sexp(wrap__matrix(robj.get())), robj);
 
                 // #[extendr]
                 // pub fn hash_map(x: HashMap<&str, Robj>) -> HashMap<&str, Robj> { x }
                 let robj = r!(List::from_values(&[1, 2]));
                 robj.set_attrib(names_symbol(), r!(["a", "b"]))?;
-                let res = new_owned(wrap__hash_map(robj.get()));
+                let res = Robj::from_sexp(wrap__hash_map(robj.get()));
                 assert_eq!(res.len(), 2);
             }
         }
@@ -859,7 +861,7 @@ mod tests {
             assert_eq!(metadata.impls[0].methods.len(), 3);
 
             // R interface
-            let robj = unsafe { new_owned(wrap__get_my_module_metadata()) };
+            let robj = Robj::from_sexp(wrap__get_my_module_metadata());
             let functions = robj.dollar("functions").unwrap();
             let impls = robj.dollar("impls").unwrap();
             assert_eq!(functions.len(), 3);

--- a/extendr-api/src/prelude.rs
+++ b/extendr-api/src/prelude.rs
@@ -4,8 +4,8 @@
 //! using deprecated features.
 
 pub use super::{
-    new_owned, print_r_error, print_r_output, FromRobj, IsNA, RType, FALSE, NA_INTEGER, NA_LOGICAL,
-    NA_REAL, NA_STRING, NULL, TRUE,
+    print_r_error, print_r_output, FromRobj, IsNA, RType, FALSE, NA_INTEGER, NA_LOGICAL, NA_REAL,
+    NA_STRING, NULL, TRUE,
 };
 
 pub use super::error::{Error, Result};

--- a/extendr-api/src/robj/from_robj.rs
+++ b/extendr-api/src/robj/from_robj.rs
@@ -159,7 +159,7 @@ impl_iter_from_robj!(Logical, as_logical_iter, "Not a logical vector.");
 /// Pass-through Robj conversion, essentially a clone.
 impl<'a> FromRobj<'a> for Robj {
     fn from_robj(robj: &'a Robj) -> std::result::Result<Self, &'static str> {
-        Ok(unsafe { new_owned(robj.get()) })
+        Ok(unsafe { Robj::from_sexp(robj.get()) })
     }
 }
 

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -16,7 +16,7 @@ pub(crate) fn str_to_character(s: &str) -> SEXP {
 impl From<()> for Robj {
     fn from(_: ()) -> Self {
         // Note: we do not need to protect this.
-        unsafe { new_owned(R_NilValue) }
+        unsafe { Robj::from_sexp(R_NilValue) }
     }
 }
 
@@ -49,7 +49,7 @@ impl From<&Robj> for Robj {
     // Note: we should probably have a much better reference
     // mechanism as double-free or underprotection is a distinct possibility.
     fn from(val: &Robj) -> Self {
-        unsafe { new_owned(val.get()) }
+        unsafe { Robj::from_sexp(val.get()) }
     }
 }
 

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -16,7 +16,7 @@ pub(crate) fn str_to_character(s: &str) -> SEXP {
 impl From<()> for Robj {
     fn from(_: ()) -> Self {
         // Note: we do not need to protect this.
-        unsafe { Robj::Sys(R_NilValue) }
+        unsafe { new_owned(R_NilValue) }
     }
 }
 
@@ -348,8 +348,8 @@ where
         // Length of the vector is known in advance.
         let sexptype = I::Item::sexptype();
         if sexptype != 0 {
-            let sexp = Rf_allocVector(sexptype, len as R_xlen_t);
-            ownership::protect(sexp);
+            let res = Robj::alloc_vector(sexptype, len);
+            let sexp = res.get();
             match sexptype {
                 REALSXP => {
                     let ptr = REAL(sexp);
@@ -384,7 +384,7 @@ where
                     panic!("unexpected SEXPTYPE in collect_robj");
                 }
             }
-            Robj::Owned(sexp)
+            res
         } else {
             Robj::from(())
         }

--- a/extendr-api/src/robj/operators.rs
+++ b/extendr-api/src/robj/operators.rs
@@ -102,7 +102,7 @@ impl Robj {
     pub fn call(&self, args: Pairlist) -> Result<Robj> {
         if self.is_function() {
             unsafe {
-                let call = new_owned(Rf_lcons(self.get(), args.get()));
+                let call = Robj::from_sexp(Rf_lcons(self.get(), args.get()));
                 call.eval()
             }
         } else {

--- a/extendr-api/src/wrapper/char.rs
+++ b/extendr-api/src/wrapper/char.rs
@@ -20,10 +20,8 @@ pub struct Rstr {
 impl Rstr {
     /// Make a character object from a string.
     pub fn from_string(val: &str) -> Self {
-        unsafe {
-            Rstr {
-                robj: new_owned(str_to_character(val)),
-            }
+        Rstr {
+            robj: Robj::from_sexp(str_to_character(val)),
         }
     }
 

--- a/extendr-api/src/wrapper/function.rs
+++ b/extendr-api/src/wrapper/function.rs
@@ -43,7 +43,7 @@ impl Function {
     pub fn from_parts(formals: Pairlist, body: Language, env: Environment) -> Result<Self> {
         unsafe {
             let sexp = Rf_allocSExp(CLOSXP);
-            let robj = new_owned(sexp);
+            let robj = Robj::from_sexp(sexp);
             SET_FORMALS(sexp, formals.get());
             SET_BODY(sexp, body.get());
             SET_CLOENV(sexp, env.get());
@@ -61,7 +61,7 @@ impl Function {
     /// ```
     pub fn call(&self, args: Pairlist) -> Result<Robj> {
         unsafe {
-            let call = new_owned(Rf_lcons(self.get(), args.get()));
+            let call = Robj::from_sexp(Rf_lcons(self.get(), args.get()));
             call.eval()
         }
     }
@@ -71,7 +71,7 @@ impl Function {
         unsafe {
             if self.rtype() == RType::Function {
                 let sexp = self.robj.get();
-                Some(new_owned(FORMALS(sexp)).try_into().unwrap())
+                Some(Robj::from_sexp(FORMALS(sexp)).try_into().unwrap())
             } else {
                 None
             }
@@ -83,7 +83,7 @@ impl Function {
         unsafe {
             if self.rtype() == RType::Function {
                 let sexp = self.robj.get();
-                Some(new_owned(BODY(sexp)))
+                Some(Robj::from_sexp(BODY(sexp)))
             } else {
                 None
             }
@@ -96,7 +96,7 @@ impl Function {
             if self.rtype() == RType::Function {
                 let sexp = self.robj.get();
                 Some(
-                    new_owned(CLOENV(sexp))
+                    Robj::from_sexp(CLOENV(sexp))
                         .try_into()
                         .expect("Should be an environment"),
                 )

--- a/extendr-api/src/wrapper/lang.rs
+++ b/extendr-api/src/wrapper/lang.rs
@@ -31,7 +31,7 @@ impl Language {
                 res = Rf_protect(Rf_lcons(val, res));
                 num_protected += 2;
             }
-            let robj = new_owned(res);
+            let robj = Robj::from_sexp(res);
             Rf_unprotect(num_protected);
             Language { robj }
         })

--- a/extendr-api/src/wrapper/list.rs
+++ b/extendr-api/src/wrapper/list.rs
@@ -169,7 +169,7 @@ impl Iterator for ListIter {
         if i >= self.len {
             None
         } else {
-            Some(unsafe { new_owned(VECTOR_ELT(self.robj.get(), i as isize)) })
+            Some(unsafe { Robj::from_sexp(VECTOR_ELT(self.robj.get(), i as isize)) })
         }
     }
 

--- a/extendr-api/src/wrapper/mod.rs
+++ b/extendr-api/src/wrapper/mod.rs
@@ -61,12 +61,12 @@ where
 {
     single_threaded(|| unsafe {
         let values = values.into_iter();
-        let sexp = Rf_allocVector(sexptype, values.len() as R_xlen_t);
-        ownership::protect(sexp);
+        let res = Robj::alloc_vector(sexptype, values.len());
+        let sexp = res.get();
         for (i, val) in values.enumerate() {
             SET_VECTOR_ELT(sexp, i as R_xlen_t, val.into().get());
         }
-        Robj::Owned(sexp)
+        res
     })
 }
 

--- a/extendr-api/src/wrapper/pairlist.rs
+++ b/extendr-api/src/wrapper/pairlist.rs
@@ -47,7 +47,7 @@ impl Pairlist {
                 }
             }
             let res = Pairlist {
-                robj: new_owned(res),
+                robj: Robj::from_sexp(res),
             };
             Rf_unprotect(num_protects as i32);
             res
@@ -135,7 +135,7 @@ impl Iterator for PairlistIter {
                 None
             } else {
                 let tag = TAG(sexp);
-                let value = new_owned(CAR(sexp));
+                let value = Robj::from_sexp(CAR(sexp));
                 self.list_elem = CDR(sexp);
                 if TYPEOF(tag) == SYMSXP as i32 {
                     let printname = PRINTNAME(tag);

--- a/extendr-api/src/wrapper/primitive.rs
+++ b/extendr-api/src/wrapper/primitive.rs
@@ -31,7 +31,7 @@ impl Primitive {
         single_threaded(|| unsafe {
             // Primitives have a special "SYMVALUE" entry in their symbol.
             let sym = Symbol::from_string(val);
-            let symvalue = new_owned(SYMVALUE(sym.get()));
+            let symvalue = Robj::from_sexp(SYMVALUE(sym.get()));
             if symvalue.is_primitive() {
                 Ok(Primitive { robj: symvalue })
             } else {

--- a/extendr-api/src/wrapper/promise.rs
+++ b/extendr-api/src/wrapper/promise.rs
@@ -20,7 +20,7 @@ impl Promise {
     pub fn from_parts(code: Robj, environment: Environment) -> Result<Self> {
         unsafe {
             let sexp = Rf_allocSExp(PROMSXP);
-            let robj = new_owned(sexp);
+            let robj = Robj::from_sexp(sexp);
             SET_PRCODE(sexp, code.get());
             SET_PRENV(sexp, environment.robj.get());
             SET_PRVALUE(sexp, R_UnboundValue);
@@ -32,7 +32,7 @@ impl Promise {
     pub fn code(&self) -> Robj {
         unsafe {
             let sexp = self.robj.get();
-            new_owned(PRCODE(sexp))
+            Robj::from_sexp(PRCODE(sexp))
         }
     }
 
@@ -40,7 +40,7 @@ impl Promise {
     pub fn environment(&self) -> Environment {
         unsafe {
             let sexp = self.robj.get();
-            new_owned(PRENV(sexp)).try_into().unwrap()
+            Robj::from_sexp(PRENV(sexp)).try_into().unwrap()
         }
     }
 
@@ -48,7 +48,7 @@ impl Promise {
     pub fn value(&self) -> Robj {
         unsafe {
             let sexp = self.robj.get();
-            new_owned(PRVALUE(sexp))
+            Robj::from_sexp(PRVALUE(sexp))
         }
     }
 

--- a/extendr-api/src/wrapper/raw.rs
+++ b/extendr-api/src/wrapper/raw.rs
@@ -28,7 +28,7 @@ impl Raw {
     pub fn from_bytes(bytes: &[u8]) -> Self {
         single_threaded(|| unsafe {
             let sexp = Rf_allocVector(RAWSXP, bytes.len() as R_xlen_t);
-            let robj = new_owned(sexp);
+            let robj = Robj::from_sexp(sexp);
             let ptr = RAW(sexp);
             for (i, &v) in bytes.iter().enumerate() {
                 *ptr.add(i) = v;

--- a/extendr-api/src/wrapper/s4.rs
+++ b/extendr-api/src/wrapper/s4.rs
@@ -61,7 +61,7 @@ impl S4 {
         let name = Robj::from(name);
         unsafe {
             if R_has_slot(self.get(), name.get()) != 0 {
-                Some(new_owned(R_do_slot(self.get(), name.get())))
+                Some(Robj::from_sexp(R_do_slot(self.get(), name.get())))
             } else {
                 None
             }

--- a/extendr-api/src/wrapper/symbol.rs
+++ b/extendr-api/src/wrapper/symbol.rs
@@ -28,7 +28,7 @@ impl Symbol {
     pub fn from_string<S: AsRef<str>>(val: S) -> Self {
         let val = val.as_ref();
         Symbol {
-            robj: unsafe { new_owned(make_symbol(val)) },
+            robj: Robj::from_sexp(make_symbol(val)),
         }
     }
 
@@ -38,7 +38,7 @@ impl Symbol {
             assert!(TYPEOF(sexp) == SYMSXP as i32);
         }
         Symbol {
-            robj: unsafe { new_sys(sexp) },
+            robj: Robj::from_sexp(sexp),
         }
     }
 

--- a/extendr-api/tests/extendr_macro.rs
+++ b/extendr-api/tests/extendr_macro.rs
@@ -62,59 +62,59 @@ fn tests_with_successful_outcomes() {
     unsafe {
         test! {
             // Matching integer.
-            assert_eq!(new_owned(wrap__test_i32(r!(1).get())), r!(1));
+            assert_eq!(Robj::from_sexp(wrap__test_i32(r!(1).get())), r!(1));
 
             // i32 takes any numeric.
-            assert_eq!(new_owned(wrap__test_i32(r!(1.0).get())), r!(1));
+            assert_eq!(Robj::from_sexp(wrap__test_i32(r!(1.0).get())), r!(1));
 
 
             // Matching integer.
-            assert_eq!(new_owned(wrap__test_option_i32(r!(1).get())), r!(1));
+            assert_eq!(Robj::from_sexp(wrap__test_option_i32(r!(1).get())), r!(1));
 
             // Option<i32> takes any numeric.
-            assert_eq!(new_owned(wrap__test_option_i32(r!(1.0).get())), r!(1));
+            assert_eq!(Robj::from_sexp(wrap__test_option_i32(r!(1.0).get())), r!(1));
 
             // NA input.
-            assert_eq!(new_owned(wrap__test_option_i32(r!(NA_REAL).get())), r!(-1));
+            assert_eq!(Robj::from_sexp(wrap__test_option_i32(r!(NA_REAL).get())), r!(-1));
 
             // NA input.
-            assert_eq!(new_owned(wrap__test_option_i32(r!(NA_INTEGER).get())), r!(-1));
+            assert_eq!(Robj::from_sexp(wrap__test_option_i32(r!(NA_INTEGER).get())), r!(-1));
 
 
             // Matching integer.
-            assert_eq!(new_owned(wrap__test_option_i16(r!(1).get())), r!(1));
+            assert_eq!(Robj::from_sexp(wrap__test_option_i16(r!(1).get())), r!(1));
 
             // Option<i16> takes any numeric.
-            assert_eq!(new_owned(wrap__test_option_i16(r!(1.0).get())), r!(1));
+            assert_eq!(Robj::from_sexp(wrap__test_option_i16(r!(1.0).get())), r!(1));
 
             // NA input.
-            assert_eq!(new_owned(wrap__test_option_i16(r!(NA_REAL).get())), r!(-1));
+            assert_eq!(Robj::from_sexp(wrap__test_option_i16(r!(NA_REAL).get())), r!(-1));
 
             // NA input.
-            assert_eq!(new_owned(wrap__test_option_i16(r!(NA_INTEGER).get())), r!(-1));
+            assert_eq!(Robj::from_sexp(wrap__test_option_i16(r!(NA_INTEGER).get())), r!(-1));
 
 
             // Matching integer.
-            assert_eq!(new_owned(wrap__test_option_f64(r!(1).get())), r!(1.0));
+            assert_eq!(Robj::from_sexp(wrap__test_option_f64(r!(1).get())), r!(1.0));
 
             // Option<f64> takes any numeric.
-            assert_eq!(new_owned(wrap__test_option_f64(r!(1.0).get())), r!(1.0));
+            assert_eq!(Robj::from_sexp(wrap__test_option_f64(r!(1.0).get())), r!(1.0));
 
             // NA input.
-            assert_eq!(new_owned(wrap__test_option_f64(r!(NA_REAL).get())), r!(-1.0));
+            assert_eq!(Robj::from_sexp(wrap__test_option_f64(r!(NA_REAL).get())), r!(-1.0));
 
             // NA input.
-            assert_eq!(new_owned(wrap__test_option_f64(r!(NA_INTEGER).get())), r!(-1.0));
+            assert_eq!(Robj::from_sexp(wrap__test_option_f64(r!(NA_INTEGER).get())), r!(-1.0));
 
             // Rint.
-            assert_eq!(new_owned(wrap__test_rint(r!(1).get())), r!(1));
-            assert_eq!(new_owned(wrap__test_rint(r!(1.0).get())), r!(1));
-            assert_eq!(new_owned(wrap__test_rint(r!(NA_INTEGER).get())), r!(NA_INTEGER));
+            assert_eq!(Robj::from_sexp(wrap__test_rint(r!(1).get())), r!(1));
+            assert_eq!(Robj::from_sexp(wrap__test_rint(r!(1.0).get())), r!(1));
+            assert_eq!(Robj::from_sexp(wrap__test_rint(r!(NA_INTEGER).get())), r!(NA_INTEGER));
 
             // Integers
-            assert_eq!(new_owned(wrap__test_integers(r!([1, 2]).get())), r!([1, 2]));
-            assert_eq!(new_owned(wrap__test_integers2(r!([1, 2]).get())), r!([2, 3]));
-            assert_eq!(new_owned(wrap__test_integers3(r!(0..4).get())), r!(6));
+            assert_eq!(Robj::from_sexp(wrap__test_integers(r!([1, 2]).get())), r!([1, 2]));
+            assert_eq!(Robj::from_sexp(wrap__test_integers2(r!([1, 2]).get())), r!([2, 3]));
+            assert_eq!(Robj::from_sexp(wrap__test_integers3(r!(0..4).get())), r!(6));
         }
     }
 }


### PR DESCRIPTION
This PR make Robj (and most wrappers like Rstr) the same layout as a SEXP.

This will enable read-only slices of Robs for lists and slices of Rstr for strings.

There is a small extra overhead as system objects have to be reference counted
by `ownership::protect()` but the ability to reference list may counteract this.

We may want to check system objects in `ownership`, especially `RNilValue`.