### PR TITLE
Updating `IsNA` trait

### DIFF
--- a/extendr-api/src/functions.rs
+++ b/extendr-api/src/functions.rs
@@ -198,19 +198,6 @@ pub fn blank_scalar_string() -> Robj {
     unsafe { new_sys(R_BlankScalarString) }
 }
 
-/// Special "NA" string that represents null strings.
-/// ```
-/// use extendr_api::prelude::*;
-/// test! {
-///     assert!(na_str().as_ptr() != "NA".as_ptr());
-///     assert_eq!(na_str(), "NA");
-///     assert_eq!("NA".is_na(), false);
-///     assert_eq!(na_str().is_na(), true);
-/// }
-/// ```
-pub fn na_str() -> &'static str {
-    unsafe { std::str::from_utf8_unchecked(&[b'N', b'A']) }
-}
 
 /// Parse a string into an R executable object
 /// ```

--- a/extendr-api/src/functions.rs
+++ b/extendr-api/src/functions.rs
@@ -198,7 +198,6 @@ pub fn blank_scalar_string() -> Robj {
     unsafe { new_sys(R_BlankScalarString) }
 }
 
-
 /// Parse a string into an R executable object
 /// ```
 /// use extendr_api::prelude::*;

--- a/extendr-api/src/iter.rs
+++ b/extendr-api/src/iter.rs
@@ -157,17 +157,17 @@ impl StrIter {
 fn str_from_strsxp<'a>(sexp: SEXP, index: isize) -> &'a str {
     unsafe {
         if index < 0 || index >= Rf_xlength(sexp) {
-            na_str()
+            <&str>::na()
         } else {
             let charsxp = STRING_ELT(sexp, index);
             if charsxp == R_NaString {
-                na_str()
+                <&str>::na()
             } else if TYPEOF(charsxp) == CHARSXP as i32 {
                 let ptr = R_CHAR(charsxp) as *const u8;
                 let slice = std::slice::from_raw_parts(ptr, Rf_xlength(charsxp) as usize);
                 std::str::from_utf8_unchecked(slice)
             } else {
-                na_str()
+                <&str>::na()
             }
         }
     }
@@ -193,7 +193,7 @@ impl Iterator for StrIter {
                 let j = *(INTEGER(vector).add(i));
                 Some(str_from_strsxp(self.levels, j as isize - 1))
             } else if TYPEOF(vector) as u32 == NILSXP {
-                Some(na_str())
+                Some(<&str>::na())
             } else {
                 None
             }
@@ -254,7 +254,7 @@ impl Robj {
     ///     let obj = Robj::from(vec![Some("a"), Some("b"), None]);
     ///     assert_eq!(obj.as_str_iter().unwrap().map(|s| s.is_na()).collect::<Vec<_>>(), vec![false, false, true]);
     ///
-    ///     let obj = Robj::from(vec!["a", "b", na_str()]);
+    ///     let obj = Robj::from(vec!["a", "b", <&str>::na()]);
     ///     assert_eq!(obj.as_str_iter().unwrap().map(|s| s.is_na()).collect::<Vec<_>>(), vec![false, false, true]);
     ///
     ///     let obj = Robj::from(vec!["a", "b", "NA"]);

--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -237,6 +237,8 @@ pub mod scalar;
 pub mod thread_safety;
 pub mod wrapper;
 
+pub mod na;
+
 #[cfg(feature = "ndarray")]
 pub mod robj_ndarray;
 
@@ -251,6 +253,7 @@ pub use std::ops::DerefMut;
 //
 // instead.
 
+pub use na::*;
 pub use error::*;
 pub use functions::*;
 pub use lang_macros::*;
@@ -366,35 +369,7 @@ pub unsafe fn register_call_methods(info: *mut libR_sys::DllInfo, metadata: Meta
     libR_sys::R_forceSymbols(info, 0);
 }
 
-/// Return true if this primitive is NA.
-pub trait IsNA {
-    fn is_na(&self) -> bool;
-}
 
-impl IsNA for f64 {
-    fn is_na(&self) -> bool {
-        unsafe { R_IsNA(*self) != 0 }
-    }
-}
-
-impl IsNA for i32 {
-    fn is_na(&self) -> bool {
-        *self == std::i32::MIN
-    }
-}
-
-impl IsNA for Bool {
-    fn is_na(&self) -> bool {
-        self.0 == std::i32::MIN
-    }
-}
-
-impl IsNA for &str {
-    /// Check for NA in a string by address.
-    fn is_na(&self) -> bool {
-        self.as_ptr() == na_str().as_ptr()
-    }
-}
 
 /// Type of R objects used by [Robj::rtype].
 #[derive(Debug, PartialEq)]

--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -253,11 +253,11 @@ pub use std::ops::DerefMut;
 //
 // instead.
 
-pub use na::*;
 pub use error::*;
 pub use functions::*;
 pub use lang_macros::*;
 pub use logical::*;
+pub use na::*;
 pub use rmacros::*;
 pub use robj::*;
 pub use thread_safety::{
@@ -368,8 +368,6 @@ pub unsafe fn register_call_methods(info: *mut libR_sys::DllInfo, metadata: Meta
     libR_sys::R_useDynamicSymbols(info, 0);
     libR_sys::R_forceSymbols(info, 0);
 }
-
-
 
 /// Type of R objects used by [Robj::rtype].
 #[derive(Debug, PartialEq)]

--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -814,10 +814,10 @@ mod tests {
 
     #[test]
     fn test_na_str() {
-        assert!(na_str().as_ptr() != "NA".as_ptr());
-        assert_eq!(na_str(), "NA");
+        assert_ne!(<&str>::na().as_ptr(), "NA".as_ptr());
+        assert_eq!(<&str>::na(), "NA");
         assert_eq!("NA".is_na(), false);
-        assert_eq!(na_str().is_na(), true);
+        assert_eq!(<&str>::na().is_na(), true);
     }
 
     #[test]

--- a/extendr-api/src/na.rs
+++ b/extendr-api/src/na.rs
@@ -1,5 +1,5 @@
 use libR_sys::{R_IsNA, R_NaReal};
-use crate::{Bool, na_str};
+use crate::Bool;
 /// Return true if this primitive is NA.
 pub trait CanBeNA {
     fn is_na(&self) -> bool;
@@ -45,4 +45,18 @@ impl CanBeNA for &str {
     fn na() -> Self {
         na_str()
     }
+}
+
+/// Special "NA" string that represents null strings.
+/// ```
+/// use extendr_api::prelude::*;
+/// test! {
+///     assert!(na_str().as_ptr() != "NA".as_ptr());
+///     assert_eq!(na_str(), "NA");
+///     assert_eq!("NA".is_na(), false);
+///     assert_eq!(na_str().is_na(), true);
+/// }
+/// ```
+pub fn na_str() -> &'static str {
+    unsafe { std::str::from_utf8_unchecked(&[b'N', b'A']) }
 }

--- a/extendr-api/src/na.rs
+++ b/extendr-api/src/na.rs
@@ -1,0 +1,31 @@
+use libR_sys::R_IsNA;
+use crate::{Bool, na_str};
+/// Return true if this primitive is NA.
+pub trait IsNA {
+    fn is_na(&self) -> bool;
+}
+
+impl IsNA for f64 {
+    fn is_na(&self) -> bool {
+        unsafe { R_IsNA(*self) != 0 }
+    }
+}
+
+impl IsNA for i32 {
+    fn is_na(&self) -> bool {
+        *self == std::i32::MIN
+    }
+}
+
+impl IsNA for Bool {
+    fn is_na(&self) -> bool {
+        self.0 == std::i32::MIN
+    }
+}
+
+impl IsNA for &str {
+    /// Check for NA in a string by address.
+    fn is_na(&self) -> bool {
+        self.as_ptr() == na_str().as_ptr()
+    }
+}

--- a/extendr-api/src/na.rs
+++ b/extendr-api/src/na.rs
@@ -9,7 +9,7 @@ pub trait CanBeNA {
 /// ```
 /// use extendr_api::prelude::*;
 /// test! {
-///     assert!(<f64>::na().is_na());
+///     assert!(f64::na().is_na());
 /// }
 /// ```
 impl CanBeNA for f64 {
@@ -25,7 +25,7 @@ impl CanBeNA for f64 {
 /// ```
 /// use extendr_api::prelude::*;
 /// test! {
-///     assert!(<i32>::na().is_na());
+///     assert!(i32::na().is_na());
 /// }
 /// ```
 impl CanBeNA for i32 {
@@ -41,7 +41,7 @@ impl CanBeNA for i32 {
 /// ```
 /// use extendr_api::prelude::*;
 /// test! {
-///     assert!(<Bool>::na().is_na());
+///     assert!(Bool::na().is_na());
 /// }
 /// ```
 impl CanBeNA for Bool {

--- a/extendr-api/src/na.rs
+++ b/extendr-api/src/na.rs
@@ -3,6 +3,7 @@ use crate::{Bool, na_str};
 /// Return true if this primitive is NA.
 pub trait IsNA {
     fn is_na(&self) -> bool;
+    fn na() -> Self;
 }
 
 impl IsNA for f64 {

--- a/extendr-api/src/na.rs
+++ b/extendr-api/src/na.rs
@@ -1,5 +1,5 @@
-use libR_sys::{R_IsNA, R_NaReal};
 use crate::Bool;
+use libR_sys::{R_IsNA, R_NaReal};
 /// Return true if this primitive is NA.
 pub trait CanBeNA {
     fn is_na(&self) -> bool;
@@ -18,7 +18,7 @@ impl CanBeNA for f64 {
     }
 
     fn na() -> f64 {
-        unsafe{R_NaReal}
+        unsafe { R_NaReal }
     }
 }
 

--- a/extendr-api/src/na.rs
+++ b/extendr-api/src/na.rs
@@ -18,7 +18,7 @@ impl CanBeNA for f64 {
 
 impl CanBeNA for i32 {
     fn is_na(&self) -> bool {
-        *self == i32::MIN
+        *self == i32::na()
     }
 
     fn na() -> i32 {
@@ -28,7 +28,7 @@ impl CanBeNA for i32 {
 
 impl CanBeNA for Bool {
     fn is_na(&self) -> bool {
-        self.0 == i32::MIN
+        self.0 == Bool::na().0
     }
 
     fn na() -> Bool {
@@ -39,11 +39,11 @@ impl CanBeNA for Bool {
 impl CanBeNA for &str {
     /// Check for NA in a string by address.
     fn is_na(&self) -> bool {
-        self.as_ptr() == na_str().as_ptr()
+        self.as_ptr() == <&str>::na().as_ptr()
     }
 
     fn na() -> Self {
-        na_str()
+        unsafe { std::str::from_utf8_unchecked(&[b'N', b'A']) }
     }
 }
 
@@ -58,5 +58,5 @@ impl CanBeNA for &str {
 /// }
 /// ```
 pub fn na_str() -> &'static str {
-    unsafe { std::str::from_utf8_unchecked(&[b'N', b'A']) }
+    <&str>::na()
 }

--- a/extendr-api/src/na.rs
+++ b/extendr-api/src/na.rs
@@ -6,6 +6,12 @@ pub trait CanBeNA {
     fn na() -> Self;
 }
 
+/// ```
+/// use extendr_api::prelude::*;
+/// test! {
+///     assert!(<f64>::na().is_na());
+/// }
+/// ```
 impl CanBeNA for f64 {
     fn is_na(&self) -> bool {
         unsafe { R_IsNA(*self) != 0 }
@@ -16,6 +22,12 @@ impl CanBeNA for f64 {
     }
 }
 
+/// ```
+/// use extendr_api::prelude::*;
+/// test! {
+///     assert!(<i32>::na().is_na());
+/// }
+/// ```
 impl CanBeNA for i32 {
     fn is_na(&self) -> bool {
         *self == i32::na()
@@ -26,6 +38,12 @@ impl CanBeNA for i32 {
     }
 }
 
+/// ```
+/// use extendr_api::prelude::*;
+/// test! {
+///     assert!(<Bool>::na().is_na());
+/// }
+/// ```
 impl CanBeNA for Bool {
     fn is_na(&self) -> bool {
         self.0 == Bool::na().0
@@ -36,22 +54,22 @@ impl CanBeNA for Bool {
     }
 }
 
+/// Special "NA" string that represents null strings.
+/// ```
+/// use extendr_api::prelude::*;
+/// test! {
+///     assert_ne!(<&str>::na().as_ptr(), "NA".as_ptr());
+///     assert_eq!(<&str>::na(), "NA");
+///     assert_eq!("NA".is_na(), false);
+///     assert_eq!(<&str>::na().is_na(), true);
+/// }
+/// ```
 impl CanBeNA for &str {
     /// Check for NA in a string by address.
     fn is_na(&self) -> bool {
         self.as_ptr() == <&str>::na().as_ptr()
     }
 
-    /// Special "NA" string that represents null strings.
-    /// ```
-    /// use extendr_api::prelude::*;
-    /// test! {
-    ///     assert_ne!(<&str>::na().as_ptr(), "NA".as_ptr());
-    ///     assert_eq!(<&str>::na(), "NA");
-    ///     assert_eq!("NA".is_na(), false);
-    ///     assert_eq!(<&str>::na().is_na(), true);
-    /// }
-    /// ```
     fn na() -> Self {
         unsafe { std::str::from_utf8_unchecked(&[b'N', b'A']) }
     }

--- a/extendr-api/src/na.rs
+++ b/extendr-api/src/na.rs
@@ -1,12 +1,12 @@
 use libR_sys::{R_IsNA, R_NaReal};
 use crate::{Bool, na_str};
 /// Return true if this primitive is NA.
-pub trait IsNA {
+pub trait CanBeNA {
     fn is_na(&self) -> bool;
     fn na() -> Self;
 }
 
-impl IsNA for f64 {
+impl CanBeNA for f64 {
     fn is_na(&self) -> bool {
         unsafe { R_IsNA(*self) != 0 }
     }
@@ -16,7 +16,7 @@ impl IsNA for f64 {
     }
 }
 
-impl IsNA for i32 {
+impl CanBeNA for i32 {
     fn is_na(&self) -> bool {
         *self == i32::MIN
     }
@@ -26,7 +26,7 @@ impl IsNA for i32 {
     }
 }
 
-impl IsNA for Bool {
+impl CanBeNA for Bool {
     fn is_na(&self) -> bool {
         self.0 == i32::MIN
     }
@@ -36,7 +36,7 @@ impl IsNA for Bool {
     }
 }
 
-impl IsNA for &str {
+impl CanBeNA for &str {
     /// Check for NA in a string by address.
     fn is_na(&self) -> bool {
         self.as_ptr() == na_str().as_ptr()

--- a/extendr-api/src/na.rs
+++ b/extendr-api/src/na.rs
@@ -1,4 +1,4 @@
-use libR_sys::R_IsNA;
+use libR_sys::{R_IsNA, R_NaReal};
 use crate::{Bool, na_str};
 /// Return true if this primitive is NA.
 pub trait IsNA {
@@ -10,17 +10,29 @@ impl IsNA for f64 {
     fn is_na(&self) -> bool {
         unsafe { R_IsNA(*self) != 0 }
     }
+
+    fn na() -> f64 {
+        unsafe{R_NaReal}
+    }
 }
 
 impl IsNA for i32 {
     fn is_na(&self) -> bool {
-        *self == std::i32::MIN
+        *self == i32::MIN
+    }
+
+    fn na() -> i32 {
+        i32::MIN
     }
 }
 
 impl IsNA for Bool {
     fn is_na(&self) -> bool {
-        self.0 == std::i32::MIN
+        self.0 == i32::MIN
+    }
+
+    fn na() -> Bool {
+        Bool::from(i32::MIN)
     }
 }
 
@@ -28,5 +40,9 @@ impl IsNA for &str {
     /// Check for NA in a string by address.
     fn is_na(&self) -> bool {
         self.as_ptr() == na_str().as_ptr()
+    }
+
+    fn na() -> Self {
+        na_str()
     }
 }

--- a/extendr-api/src/na.rs
+++ b/extendr-api/src/na.rs
@@ -42,21 +42,17 @@ impl CanBeNA for &str {
         self.as_ptr() == <&str>::na().as_ptr()
     }
 
+    /// Special "NA" string that represents null strings.
+    /// ```
+    /// use extendr_api::prelude::*;
+    /// test! {
+    ///     assert_ne!(<&str>::na().as_ptr(), "NA".as_ptr());
+    ///     assert_eq!(<&str>::na(), "NA");
+    ///     assert_eq!("NA".is_na(), false);
+    ///     assert_eq!(<&str>::na().is_na(), true);
+    /// }
+    /// ```
     fn na() -> Self {
         unsafe { std::str::from_utf8_unchecked(&[b'N', b'A']) }
     }
-}
-
-/// Special "NA" string that represents null strings.
-/// ```
-/// use extendr_api::prelude::*;
-/// test! {
-///     assert!(na_str().as_ptr() != "NA".as_ptr());
-///     assert_eq!(na_str(), "NA");
-///     assert_eq!("NA".is_na(), false);
-///     assert_eq!(na_str().is_na(), true);
-/// }
-/// ```
-pub fn na_str() -> &'static str {
-    <&str>::na()
 }

--- a/extendr-api/src/prelude.rs
+++ b/extendr-api/src/prelude.rs
@@ -15,7 +15,7 @@ pub use super::error::{Error, Result};
 pub use super::functions::{
     base_env, base_namespace, blank_scalar_string, blank_string, current_env, empty_env,
     eval_string, eval_string_with_params, find_namespace, find_namespaced_function, global_env,
-    global_function, global_var, local_var, na_str, na_string, namespace_registry, new_env,
+    global_function, global_var, local_var, na_string, namespace_registry, new_env,
     nil_value, parse, srcref,
 };
 

--- a/extendr-api/src/prelude.rs
+++ b/extendr-api/src/prelude.rs
@@ -4,9 +4,11 @@
 //! using deprecated features.
 
 pub use super::{
-    new_owned, print_r_error, print_r_output, FromRobj, IsNA, RType, FALSE, NA_INTEGER, NA_LOGICAL,
+    new_owned, print_r_error, print_r_output, FromRobj, RType, FALSE, NA_INTEGER, NA_LOGICAL,
     NA_REAL, NA_STRING, NULL, TRUE,
 };
+
+pub use super::na::*;
 
 pub use super::error::{Error, Result};
 

--- a/extendr-api/src/prelude.rs
+++ b/extendr-api/src/prelude.rs
@@ -15,8 +15,8 @@ pub use super::error::{Error, Result};
 pub use super::functions::{
     base_env, base_namespace, blank_scalar_string, blank_string, current_env, empty_env,
     eval_string, eval_string_with_params, find_namespace, find_namespaced_function, global_env,
-    global_function, global_var, local_var, na_string, namespace_registry, new_env,
-    nil_value, parse, srcref,
+    global_function, global_var, local_var, na_string, namespace_registry, new_env, nil_value,
+    parse, srcref,
 };
 
 pub use super::wrapper::symbol::{

--- a/extendr-api/src/robj/from_robj.rs
+++ b/extendr-api/src/robj/from_robj.rs
@@ -126,7 +126,7 @@ impl<'a> FromRobj<'a> for Vec<String> {
         } else if let Some(v) = robj.as_string_vector() {
             let str_vec = v.to_vec();
             // check for NA's in the string vector
-            if let Some(_str) = str_vec.iter().find(|&s| *s == na_str()) {
+            if let Some(_str) = str_vec.iter().find(|&s| *s == <&str>::na()) {
                 Err("Input vector cannot contain NA's.")
             } else {
                 Ok(str_vec)

--- a/extendr-api/src/robj/from_robj.rs
+++ b/extendr-api/src/robj/from_robj.rs
@@ -126,6 +126,7 @@ impl<'a> FromRobj<'a> for Vec<String> {
         } else if let Some(v) = robj.as_string_vector() {
             let str_vec = v.to_vec();
             // check for NA's in the string vector
+            // The check is by-value, so `<&str>::is_na()` cannot be used
             if let Some(_str) = str_vec.iter().find(|&s| *s == <&str>::na()) {
                 Err("Input vector cannot contain NA's.")
             } else {

--- a/extendr-api/src/scalar/macros.rs
+++ b/extendr-api/src/scalar/macros.rs
@@ -198,7 +198,7 @@ macro_rules! gen_trait_impl {
             #[doc = "    assert!((<" $type ">::na()).is_na());"]
             #[doc = "}"]
             #[doc = "```"]
-            impl IsNA for $type {
+            impl CanBeNA for $type {
                 /// Return true is the is a NA value.
                 fn is_na(&self) -> bool {
                     $na_check(self)

--- a/extendr-api/src/scalar/macros.rs
+++ b/extendr-api/src/scalar/macros.rs
@@ -167,12 +167,7 @@ macro_rules! gen_from_scalar {
 /// 1. static `na()`
 /// 2. instance `inner()`
 macro_rules! gen_impl {
-    ($type : ident, $type_prim : ty, $na_val : expr) => {
-        /// Construct a NA.
-        pub fn na() -> Self {
-            $type($na_val)
-        }
-
+    ($type : ident, $type_prim : ty) => {
         /// Get underlying value.
         pub fn inner(&self) -> $type_prim {
             self.0
@@ -187,7 +182,7 @@ macro_rules! gen_impl {
 /// 4. `Debug`
 /// 5. `PartialEq`
 macro_rules! gen_trait_impl {
-    ($type : ident, $type_prim : ty, $na_check : expr) => {
+    ($type : ident, $type_prim : ty, $na_check : expr, $na_val : expr) => {
         impl Clone for $type {
             fn clone(&self) -> Self {
                 Self(self.0)
@@ -207,6 +202,10 @@ macro_rules! gen_trait_impl {
                 /// Return true is the is a NA value.
                 fn is_na(&self) -> bool {
                     $na_check(self)
+                }
+                /// Construct a NA.
+                fn na() -> Self {
+                    $type($na_val)
                 }
             }
         }

--- a/extendr-api/src/scalar/rfloat.rs
+++ b/extendr-api/src/scalar/rfloat.rs
@@ -31,8 +31,12 @@ impl Rfloat {
 }
 // `NA_real_` is a `NaN` with specific bit representation.
 // Check that underlying `f64` equals (bitwise) to `NA_real_`.
-gen_trait_impl!(Rfloat, f64, |x: &Rfloat| x.0.to_bits()
-    == unsafe { libR_sys::R_NaReal.to_bits() }, unsafe { libR_sys::R_NaReal });
+gen_trait_impl!(
+    Rfloat,
+    f64,
+    |x: &Rfloat| x.0.to_bits() == unsafe { libR_sys::R_NaReal.to_bits() },
+    unsafe { libR_sys::R_NaReal }
+);
 gen_from_primitive!(Rfloat, f64);
 gen_from_scalar!(Rfloat, f64);
 gen_sum_iter!(Rfloat, 0f64);

--- a/extendr-api/src/scalar/rfloat.rs
+++ b/extendr-api/src/scalar/rfloat.rs
@@ -11,7 +11,7 @@ use std::ops::{Add, Div, Mul, Neg, Sub};
 pub struct Rfloat(pub f64);
 
 impl Rfloat {
-    gen_impl!(Rfloat, f64, unsafe { libR_sys::R_NaReal });
+    gen_impl!(Rfloat, f64);
 
     pub fn is_nan(&self) -> bool {
         self.0.is_nan()
@@ -32,7 +32,7 @@ impl Rfloat {
 // `NA_real_` is a `NaN` with specific bit representation.
 // Check that underlying `f64` equals (bitwise) to `NA_real_`.
 gen_trait_impl!(Rfloat, f64, |x: &Rfloat| x.0.to_bits()
-    == unsafe { libR_sys::R_NaReal.to_bits() });
+    == unsafe { libR_sys::R_NaReal.to_bits() }, unsafe { libR_sys::R_NaReal });
 gen_from_primitive!(Rfloat, f64);
 gen_from_scalar!(Rfloat, f64);
 gen_sum_iter!(Rfloat, 0f64);

--- a/extendr-api/src/scalar/rint.rs
+++ b/extendr-api/src/scalar/rint.rs
@@ -13,10 +13,10 @@ use std::ops::{Add, Div, Mul, Neg, Not, Sub};
 pub struct Rint(pub i32);
 
 impl Rint {
-    gen_impl!(Rint, i32, i32::MIN);
+    gen_impl!(Rint, i32);
 }
 
-gen_trait_impl!(Rint, i32, |x: &Rint| x.0 == i32::MIN);
+gen_trait_impl!(Rint, i32, |x: &Rint| x.0 == i32::MIN, i32::MIN);
 gen_from_primitive!(Rint, i32);
 gen_from_scalar!(Rint, i32);
 gen_sum_iter!(Rint, 0i32);

--- a/extendr-api/src/wrapper/char.rs
+++ b/extendr-api/src/wrapper/char.rs
@@ -33,7 +33,7 @@ impl Rstr {
         unsafe {
             let sexp = self.robj.get();
             if sexp == R_NaString {
-                na_str()
+                <&str>::na()
             } else {
                 to_str(R_CHAR(sexp) as *const u8)
             }


### PR DESCRIPTION
Trait `IsNA` is modified and renamed to`CanBeNA`.
New static function (i.e. function with no `self` arg) is introduced::
`fn CanBeNA::na() -> Self`
which can be used to obtain `NA` value of a given type.

Modified code in key places to switch to `<type>::na()` instead of helper functions.

I did not remove implementations of `CanBeNA` for primitive types (like `f64` or `i32`).
This may be deprecated in the future.