### PR TITLE
Add AddAssign, SubAssign, MulAssign, DivAssign support for Rint and Rfloat

### DIFF
--- a/extendr-api/src/scalar/macros.rs
+++ b/extendr-api/src/scalar/macros.rs
@@ -131,12 +131,12 @@ macro_rules! gen_binopassign {
         // - impl $opname:snake<$type_prim> for $type {}
         // - impl $opname:snake<$type_prim> for &mut $type {}
         // - impl $opname:snake<$type> for Option<$type_prim> {}
-        // 
+        //
         // Note: $opname:snake snake cases the Trait name, i.e. AddAssign -> add_assign
 
         // Example call to this macro. The expansion examples below are all
         // derived from this example macro call.
-        // 
+        //
         // gen_binopassign!(
         //     Rint,                                    <= The Type the Trait is implemented for
         //     i32,                                     <= The generic for the Trait
@@ -144,7 +144,7 @@ macro_rules! gen_binopassign {
         //     |lhs: i32, rhs| lhs.checked_add(rhs),    <= Closure, provides the math logic
         //     "Doc Comment"                            <= Documentation comment for Traits
         // );
-        //  
+        //
 
         // This impl block expands to:
         //

--- a/extendr-api/src/scalar/macros.rs
+++ b/extendr-api/src/scalar/macros.rs
@@ -128,6 +128,7 @@ macro_rules! gen_binopassign {
             paste::paste! {
                 #[doc = $docstring]
                 fn [< $opname:snake >](&mut self, other: $type) {
+                    // `.clone()` is needed to convert &mut Rint -> Rint -> Option<$type_prim>
                     match (self.clone().into(), other.into()) {
                         (Some(lhs), Some(rhs)) => {
                             let f = $expr;
@@ -146,6 +147,7 @@ macro_rules! gen_binopassign {
             paste::paste! {
                 #[doc = $docstring]
                 fn [< $opname:snake >](&mut self, other: $type) {
+                    // `.clone()` is needed to convert &mut &mut Rint -> Rint -> Option<$type_prim>
                     match (self.clone().into(), other.into()) {
                         (Some(lhs), Some(rhs)) => {
                             let f = $expr;
@@ -164,6 +166,7 @@ macro_rules! gen_binopassign {
             paste::paste! {
                 #[doc = $docstring]
                 fn [< $opname:snake >](&mut self, other: $type_prim) {
+                    // `.clone()` is needed to convert &mut Rint -> Rint -> Option<$type_prim>
                     match self.clone().into() {
                         Some(lhs) => {
                             let f = $expr;
@@ -182,6 +185,7 @@ macro_rules! gen_binopassign {
             paste::paste! {
                 #[doc = $docstring]
                 fn [< $opname:snake >](&mut self, other: $type_prim) {
+                    // `.clone()` is needed to convert &mut &mut Rint -> Rint -> Option<$type_prim>
                     match self.clone().into() {
                         Some(lhs) => {
                             let f = $expr;
@@ -200,7 +204,7 @@ macro_rules! gen_binopassign {
             paste::paste! {
                 #[doc = $docstring]
                 fn [< $opname:snake >](&mut self, other: $type) {
-                    match (self.clone(), other.clone().into()) {
+                    match (*self, other.into()) {
                         (Some(lhs), Some(rhs)) => {
                             let f = $expr;
                             *self = f(lhs, rhs);

--- a/extendr-api/src/scalar/rfloat.rs
+++ b/extendr-api/src/scalar/rfloat.rs
@@ -2,6 +2,7 @@ use crate::scalar::macros::*;
 use crate::*;
 use std::convert::TryFrom;
 use std::ops::{Add, Div, Mul, Neg, Sub};
+use std::ops::{AddAssign, DivAssign, MulAssign, SubAssign};
 
 /// Rfloat is a wrapper for f64 in the context of an R's integer vector.
 ///
@@ -69,6 +70,34 @@ gen_binop!(
     Div,
     |lhs: f64, rhs: f64| Some(lhs / rhs),
     "Divide two Rfloat values or an option of f64."
+);
+gen_binopassign!(
+    Rfloat,
+    f64,
+    AddAssign,
+    |lhs: f64, rhs: f64| Some(lhs + rhs),
+    "Add two Rfloat values or an option of f64, modifying the left-hand side in place. Overflows to NA."
+);
+gen_binopassign!(
+    Rfloat,
+    f64,
+    SubAssign,
+    |lhs: f64, rhs: f64| Some(lhs - rhs),
+    "Subtract two Rfloat values or an option of f64, modifying the left-hand side in place. Overflows to NA."
+);
+gen_binopassign!(
+    Rfloat,
+    f64,
+    MulAssign,
+    |lhs: f64, rhs: f64| Some(lhs * rhs),
+    "Multiply two Rfloat values or an option of f64, modifying the left-hand side in place. Overflows to NA."
+);
+gen_binopassign!(
+    Rfloat,
+    f64,
+    DivAssign,
+    |lhs: f64, rhs: f64| Some(lhs / rhs),
+    "Divide two Rfloat values or an option of f64, modifying the left-hand side in place. Overflows to NA."
 );
 
 // Generate unary ops for -, !

--- a/extendr-api/src/scalar/rint.rs
+++ b/extendr-api/src/scalar/rint.rs
@@ -2,7 +2,7 @@ use crate::scalar::macros::*;
 use crate::*;
 use std::convert::TryFrom;
 use std::ops::{Add, Div, Mul, Neg, Not, Sub};
-use std::ops::{AddAssign, SubAssign, MulAssign, DivAssign};
+use std::ops::{AddAssign, DivAssign, MulAssign, SubAssign};
 
 /// Rint is a wrapper for i32 in the context of an R's integer vector.
 ///
@@ -79,7 +79,6 @@ gen_binopassign!(
     |lhs: i32, rhs| lhs.checked_div(rhs),
     "Divide two Rint values or an option of i32, modifying the left-hand side in place. Overflows to NA."
 );
-
 
 // Generate unary ops for -, !
 gen_unop!(

--- a/extendr-api/src/scalar/rint.rs
+++ b/extendr-api/src/scalar/rint.rs
@@ -2,6 +2,7 @@ use crate::scalar::macros::*;
 use crate::*;
 use std::convert::TryFrom;
 use std::ops::{Add, Div, Mul, Neg, Not, Sub};
+use std::ops::{AddAssign, SubAssign, MulAssign, DivAssign};
 
 /// Rint is a wrapper for i32 in the context of an R's integer vector.
 ///
@@ -50,6 +51,35 @@ gen_binop!(
     |lhs: i32, rhs| lhs.checked_div(rhs),
     "Divide two Rint values or an option of i32, overflows to NA."
 );
+gen_binopassign!(
+    Rint,
+    i32,
+    AddAssign,
+    |lhs: i32, rhs| lhs.checked_add(rhs),
+    "Add two Rint values or an option of i32, modifying the left-hand side in place. Overflows to NA."
+);
+gen_binopassign!(
+    Rint,
+    i32,
+    SubAssign,
+    |lhs: i32, rhs| lhs.checked_sub(rhs),
+    "Subtract two Rint values or an option of i32, modifying the left-hand side in place. Overflows to NA."
+);
+gen_binopassign!(
+    Rint,
+    i32,
+    MulAssign,
+    |lhs: i32, rhs| lhs.checked_mul(rhs),
+    "Multiply two Rint values or an option of i32, modifying the left-hand side in place. Overflows to NA."
+);
+gen_binopassign!(
+    Rint,
+    i32,
+    DivAssign,
+    |lhs: i32, rhs| lhs.checked_div(rhs),
+    "Divide two Rint values or an option of i32, modifying the left-hand side in place. Overflows to NA."
+);
+
 
 // Generate unary ops for -, !
 gen_unop!(

--- a/extendr-api/tests/scalar_tests.rs
+++ b/extendr-api/tests/scalar_tests.rs
@@ -50,6 +50,69 @@ fn test_rint() {
 }
 
 #[test]
+fn test_rint_opassign() {
+    // LHS Rint, RHS Rint
+    let mut a = Rint::from(20);
+    a += Rint::from(10);  assert_eq!(a, Rint::from(30));
+    a -= Rint::from(20);  assert_eq!(a, Rint::from(10));
+    a *= Rint::from(20);  assert_eq!(a, Rint::from(200));
+    a /= Rint::from(100); assert_eq!(a, Rint::from(2));
+
+    // LHS &mut Rint, RHS Rint
+    let mut a = Rint::from(20);
+    let mut b = &mut a;
+    b += Rint::from(10);  assert_eq!(b, &Rint::from(30));
+    b -= Rint::from(20);  assert_eq!(b, &Rint::from(10));
+    b *= Rint::from(20);  assert_eq!(b, &Rint::from(200));
+    b /= Rint::from(100); assert_eq!(b, &Rint::from(2));
+
+    // LHS Rint, RHS i32
+    let mut a = Rint::from(20);
+    a += 10;  assert_eq!(a, Rint::from(30));
+    a -= 20;  assert_eq!(a, Rint::from(10));
+    a *= 20;  assert_eq!(a, Rint::from(200));
+    a /= 100; assert_eq!(a, Rint::from(2));
+
+    // LHS &mut Rint, RHS i32
+    let mut a = Rint::from(20);
+    let mut b = &mut a;
+    b += 10;  assert_eq!(b, &Rint::from(30));
+    b -= 20;  assert_eq!(b, &Rint::from(10));
+    b *= 20;  assert_eq!(b, &Rint::from(200));
+    b /= 100; assert_eq!(b, &Rint::from(2));
+
+    // LHS Option<i32>, RHS Rint
+    let mut a = Some(20);
+    a += Rint::from(10);  assert_eq!(a, Some(30));
+    a -= Rint::from(20);  assert_eq!(a, Some(10));
+    a *= Rint::from(20);  assert_eq!(a, Some(200));
+    a /= Rint::from(100); assert_eq!(a, Some(2));
+
+    // LHS NA
+    let mut a = Rint::na();
+    a += Rint::from(10);  assert!(a.is_na());
+    a -= Rint::from(20);  assert!(a.is_na());
+    a *= Rint::from(20);  assert!(a.is_na());
+    a /= Rint::from(100); assert!(a.is_na());
+
+    // RHS NA
+    let mut a = Rint::from(20); a += Rint::na(); assert!(a.is_na());
+    let mut a = Rint::from(20); a -= Rint::na(); assert!(a.is_na());
+    let mut a = Rint::from(20); a *= Rint::na(); assert!(a.is_na());
+    let mut a = Rint::from(20); a /= Rint::na(); assert!(a.is_na());
+
+    // Overflow | LHS Rint, RHS Rint
+    let mut a = Rint::from(i32::MAX - 1); a += Rint::from(10); assert!(a.is_na());
+    let mut a = Rint::from(i32::MAX - 1); a *= Rint::from(10); assert!(a.is_na());
+
+    let mut a = Rint::from(1);  a /= Rint::from(0); assert!(a.is_na());
+    let mut a = Rint::from(-1); a /= Rint::na();    assert!(a.is_na());
+
+    // Underflow | LHS Rint, RHS Rint
+    let mut a = Rint::from(i32::MIN + 1); a += Rint::from(-10); assert!(a.is_na());
+}
+
+#[test]
 fn test_rfloat() {
     let a = Rfloat::from(20.);
     let b = Rfloat::from(10.);

--- a/extendr-api/tests/scalar_tests.rs
+++ b/extendr-api/tests/scalar_tests.rs
@@ -53,63 +53,105 @@ fn test_rint() {
 fn test_rint_opassign() {
     // LHS Rint, RHS Rint
     let mut a = Rint::from(20);
-    a += Rint::from(10);  assert_eq!(a, Rint::from(30));
-    a -= Rint::from(20);  assert_eq!(a, Rint::from(10));
-    a *= Rint::from(20);  assert_eq!(a, Rint::from(200));
-    a /= Rint::from(100); assert_eq!(a, Rint::from(2));
+    a += Rint::from(10);
+    assert_eq!(a, Rint::from(30));
+    a -= Rint::from(20);
+    assert_eq!(a, Rint::from(10));
+    a *= Rint::from(20);
+    assert_eq!(a, Rint::from(200));
+    a /= Rint::from(100);
+    assert_eq!(a, Rint::from(2));
 
     // LHS &mut Rint, RHS Rint
     let mut a = Rint::from(20);
     let mut b = &mut a;
-    b += Rint::from(10);  assert_eq!(b, &Rint::from(30));
-    b -= Rint::from(20);  assert_eq!(b, &Rint::from(10));
-    b *= Rint::from(20);  assert_eq!(b, &Rint::from(200));
-    b /= Rint::from(100); assert_eq!(b, &Rint::from(2));
+    b += Rint::from(10);
+    assert_eq!(b, &Rint::from(30));
+    b -= Rint::from(20);
+    assert_eq!(b, &Rint::from(10));
+    b *= Rint::from(20);
+    assert_eq!(b, &Rint::from(200));
+    b /= Rint::from(100);
+    assert_eq!(b, &Rint::from(2));
 
     // LHS Rint, RHS i32
     let mut a = Rint::from(20);
-    a += 10;  assert_eq!(a, Rint::from(30));
-    a -= 20;  assert_eq!(a, Rint::from(10));
-    a *= 20;  assert_eq!(a, Rint::from(200));
-    a /= 100; assert_eq!(a, Rint::from(2));
+    a += 10;
+    assert_eq!(a, Rint::from(30));
+    a -= 20;
+    assert_eq!(a, Rint::from(10));
+    a *= 20;
+    assert_eq!(a, Rint::from(200));
+    a /= 100;
+    assert_eq!(a, Rint::from(2));
 
     // LHS &mut Rint, RHS i32
     let mut a = Rint::from(20);
     let mut b = &mut a;
-    b += 10;  assert_eq!(b, &Rint::from(30));
-    b -= 20;  assert_eq!(b, &Rint::from(10));
-    b *= 20;  assert_eq!(b, &Rint::from(200));
-    b /= 100; assert_eq!(b, &Rint::from(2));
+    b += 10;
+    assert_eq!(b, &Rint::from(30));
+    b -= 20;
+    assert_eq!(b, &Rint::from(10));
+    b *= 20;
+    assert_eq!(b, &Rint::from(200));
+    b /= 100;
+    assert_eq!(b, &Rint::from(2));
 
     // LHS Option<i32>, RHS Rint
     let mut a = Some(20);
-    a += Rint::from(10);  assert_eq!(a, Some(30));
-    a -= Rint::from(20);  assert_eq!(a, Some(10));
-    a *= Rint::from(20);  assert_eq!(a, Some(200));
-    a /= Rint::from(100); assert_eq!(a, Some(2));
+    a += Rint::from(10);
+    assert_eq!(a, Some(30));
+    a -= Rint::from(20);
+    assert_eq!(a, Some(10));
+    a *= Rint::from(20);
+    assert_eq!(a, Some(200));
+    a /= Rint::from(100);
+    assert_eq!(a, Some(2));
 
     // LHS NA
     let mut a = Rint::na();
-    a += Rint::from(10);  assert!(a.is_na());
-    a -= Rint::from(20);  assert!(a.is_na());
-    a *= Rint::from(20);  assert!(a.is_na());
-    a /= Rint::from(100); assert!(a.is_na());
+    a += Rint::from(10);
+    assert!(a.is_na());
+    a -= Rint::from(20);
+    assert!(a.is_na());
+    a *= Rint::from(20);
+    assert!(a.is_na());
+    a /= Rint::from(100);
+    assert!(a.is_na());
 
     // RHS NA
-    let mut a = Rint::from(20); a += Rint::na(); assert!(a.is_na());
-    let mut a = Rint::from(20); a -= Rint::na(); assert!(a.is_na());
-    let mut a = Rint::from(20); a *= Rint::na(); assert!(a.is_na());
-    let mut a = Rint::from(20); a /= Rint::na(); assert!(a.is_na());
+    let mut a = Rint::from(20);
+    a += Rint::na();
+    assert!(a.is_na());
+    let mut a = Rint::from(20);
+    a -= Rint::na();
+    assert!(a.is_na());
+    let mut a = Rint::from(20);
+    a *= Rint::na();
+    assert!(a.is_na());
+    let mut a = Rint::from(20);
+    a /= Rint::na();
+    assert!(a.is_na());
 
     // Overflow | LHS Rint, RHS Rint
-    let mut a = Rint::from(i32::MAX - 1); a += Rint::from(10); assert!(a.is_na());
-    let mut a = Rint::from(i32::MAX - 1); a *= Rint::from(10); assert!(a.is_na());
+    let mut a = Rint::from(i32::MAX - 1);
+    a += Rint::from(10);
+    assert!(a.is_na());
+    let mut a = Rint::from(i32::MAX - 1);
+    a *= Rint::from(10);
+    assert!(a.is_na());
 
-    let mut a = Rint::from(1);  a /= Rint::from(0); assert!(a.is_na());
-    let mut a = Rint::from(-1); a /= Rint::na();    assert!(a.is_na());
+    let mut a = Rint::from(1);
+    a /= Rint::from(0);
+    assert!(a.is_na());
+    let mut a = Rint::from(-1);
+    a /= Rint::na();
+    assert!(a.is_na());
 
     // Underflow | LHS Rint, RHS Rint
-    let mut a = Rint::from(i32::MIN + 1); a += Rint::from(-10); assert!(a.is_na());
+    let mut a = Rint::from(i32::MIN + 1);
+    a += Rint::from(-10);
+    assert!(a.is_na());
 }
 
 #[test]
@@ -186,4 +228,130 @@ fn test_rfloat() {
     // Some more, testing mixed binary operators
     assert!((Rfloat::from(f64::INFINITY) + 1.).is_infinite());
     assert!((42. - Rfloat::from(f64::INFINITY)).is_sign_negative());
+}
+
+#[test]
+fn test_rfloat_opassign() {
+    // LHS Rfloat, RHS Rfloat
+    let mut a = Rfloat::from(20.);
+    a += Rfloat::from(10.);
+    assert_eq!(a, Rfloat::from(30.));
+    a -= Rfloat::from(20.);
+    assert_eq!(a, Rfloat::from(10.));
+    a *= Rfloat::from(20.);
+    assert_eq!(a, Rfloat::from(200.));
+    a /= Rfloat::from(100.);
+    assert_eq!(a, Rfloat::from(2.));
+
+    // LHS &mut Rfloat, RHS Rfloat
+    let mut a = Rfloat::from(20.);
+    let mut b = &mut a;
+    b += Rfloat::from(10.);
+    assert_eq!(b, &Rfloat::from(30.));
+    b -= Rfloat::from(20.);
+    assert_eq!(b, &Rfloat::from(10.));
+    b *= Rfloat::from(20.);
+    assert_eq!(b, &Rfloat::from(200.));
+    b /= Rfloat::from(100.);
+    assert_eq!(b, &Rfloat::from(2.));
+
+    // LHS Rfloat, RHS f64
+    let mut a = Rfloat::from(20.);
+    a += 10.;
+    assert_eq!(a, Rfloat::from(30.));
+    a -= 20.;
+    assert_eq!(a, Rfloat::from(10.));
+    a *= 20.;
+    assert_eq!(a, Rfloat::from(200.));
+    a /= 100.;
+    assert_eq!(a, Rfloat::from(2.));
+
+    // LHS &mut Rfloat, RHS f64
+    let mut a = Rfloat::from(20.);
+    let mut b = &mut a;
+    b += 10.;
+    assert_eq!(b, &Rfloat::from(30.));
+    b -= 20.;
+    assert_eq!(b, &Rfloat::from(10.));
+    b *= 20.;
+    assert_eq!(b, &Rfloat::from(200.));
+    b /= 100.;
+    assert_eq!(b, &Rfloat::from(2.));
+
+    // LHS Option<f64>, RHS Rfloat
+    let mut a = Some(20.);
+    a += Rfloat::from(10.);
+    assert_eq!(a, Some(30.));
+    a -= Rfloat::from(20.);
+    assert_eq!(a, Some(10.));
+    a *= Rfloat::from(20.);
+    assert_eq!(a, Some(200.));
+    a /= Rfloat::from(100.);
+    assert_eq!(a, Some(2.));
+
+    // LHS NA
+    let mut a = Rfloat::na();
+    a += Rfloat::from(10.);
+    assert!(a.is_na());
+    a -= Rfloat::from(20.);
+    assert!(a.is_na());
+    a *= Rfloat::from(20.);
+    assert!(a.is_na());
+    a /= Rfloat::from(100.);
+    assert!(a.is_na());
+
+    // RHS NA
+    let mut a = Rfloat::from(20.);
+    a += Rfloat::na();
+    assert!(a.is_na());
+    let mut a = Rfloat::from(20.);
+    a -= Rfloat::na();
+    assert!(a.is_na());
+    let mut a = Rfloat::from(20.);
+    a *= Rfloat::na();
+    assert!(a.is_na());
+    let mut a = Rfloat::from(20.);
+    a /= Rfloat::na();
+    assert!(a.is_na());
+
+    // Inf is a single value, so can be tested for equality
+    let mut a = Rfloat::from(f64::INFINITY);
+    let mut b = Rfloat::from(42.);
+    a += b;
+    assert_eq!(a, f64::INFINITY);
+    a -= b;
+    assert_eq!(a, f64::INFINITY);
+    a *= b;
+    assert_eq!(a, f64::INFINITY);
+    a /= b;
+    assert_eq!(a, f64::INFINITY);
+    b -= a;
+    assert_eq!(b, f64::NEG_INFINITY);
+
+    let mut a = Rfloat::from(f64::NEG_INFINITY);
+    let mut b = Rfloat::from(42.);
+    a += b;
+    assert_eq!(a, f64::NEG_INFINITY);
+    a -= b;
+    assert_eq!(a, f64::NEG_INFINITY);
+    a *= b;
+    assert_eq!(a, f64::NEG_INFINITY);
+    a /= b;
+    assert_eq!(a, f64::NEG_INFINITY);
+    b -= a;
+    assert_eq!(b, f64::INFINITY);
+
+    // Operations with NaN produce NaN
+    let mut a = Rfloat::from(f64::NAN);
+    let mut b = Rfloat::from(42.);
+    a += b;
+    assert!(a.is_nan());
+    a -= b;
+    assert!(a.is_nan());
+    a *= b;
+    assert!(a.is_nan());
+    a /= b;
+    assert!(a.is_nan());
+    b -= a;
+    assert!(b.is_nan());
 }


### PR DESCRIPTION
This PR addresses Issue #285. As this is my first PR in this community, I wanted to check my approach with the maintainers before making the full PR. At present, this branch adds support for the AddAssign, SubAssign, MulAssign, and DivAssign operators for 
- `Rint op= Rint`
- `&mut Rint op= Rint`
- `Rint op= i32`
- `&mut Rint op= i32`
- `Option<i32> op= Rint`.

I wasn't 100% whether you all wanted that last one or not. I'd appreciate feedback or constructive criticism to let me know if I'm on the right track before implementing the same set of operations for `Rfloat`. Thanks!