### PR TITLE
Add comments to macros in scalar/macros.rs

### DIFF
--- a/extendr-api/src/scalar/macros.rs
+++ b/extendr-api/src/scalar/macros.rs
@@ -459,8 +459,7 @@ macro_rules! gen_binopassign {
                 fn [< $opname:snake >](&mut self, other: $type) {
                     match (*self, other.into()) {
                         (Some(lhs), Some(rhs)) => {
-                            let f = $expr;
-                            *self = f(lhs, rhs);
+                            *self = $expr(lhs, rhs);
                         },
                         _ => *self = None,
                     }


### PR DESCRIPTION
Since the comments I included in the macro from my last PR went over so well, I thought that adding similar comments to the other macros in `scalar/macros.rs` might be useful.