### PR TITLE
Better list macro

### DIFF
--- a/extendr-api/src/error.rs
+++ b/extendr-api/src/error.rs
@@ -2,6 +2,8 @@
 
 use crate::{throw_r_error, Robj};
 
+use std::convert::Infallible;
+
 /// Throw an R error if a result is an error.
 #[doc(hidden)]
 pub fn unwrap_or_throw<T>(r: std::result::Result<T, &'static str>) -> T {
@@ -193,3 +195,9 @@ impl From<String> for Error {
 //         Error::None
 //     }
 // }
+
+impl From<Infallible> for Error {
+    fn from(_: Infallible) -> Self {
+        Error::Other("".to_string())
+    }
+}

--- a/extendr-api/src/rmacros.rs
+++ b/extendr-api/src/rmacros.rs
@@ -91,28 +91,6 @@ macro_rules! sym {
     };
 }
 
-/// Create a list.
-///
-/// Example:
-/// ```
-/// use extendr_api::prelude::*;
-/// test! {
-///     let mylist = list!(x=1, y=2);
-///     assert_eq!(mylist, r!(List::from_pairs(vec![("x", r!(1)), ("y", r!(2))])));
-/// }
-/// ```
-///
-/// Panics on error.
-#[macro_export]
-macro_rules! list {
-    () => {
-        call!("list").unwrap()
-    };
-    ($($rest: tt)*) => {
-        call!("list", $($rest)*).unwrap()
-    };
-}
-
 /// Create a dataframe.
 ///
 /// Example:

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -808,10 +808,12 @@ impl Robj {
     {
         let iter = names.into_iter();
         let robj = iter.collect_robj();
-        if robj.len() == self.len() {
-            self.set_attrib(wrapper::symbol::names_symbol(), robj)
-        } else {
+        if !robj.is_vector() && !robj.is_pairlist() {
+            Err(Error::ExpectedVector(robj))
+        } else if robj.len() != self.len() {
             Err(Error::NamesLengthMismatch(robj))
+        } else {
+            self.set_attrib(wrapper::symbol::names_symbol(), robj)
         }
     }
 

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -710,6 +710,8 @@ make_typed_slice!(Rint, INTEGER, INTSXP);
 make_typed_slice!(f64, REAL, REALSXP);
 make_typed_slice!(Rfloat, REAL, REALSXP);
 make_typed_slice!(u8, RAW, RAWSXP);
+make_typed_slice!(Robj, VECTOR_PTR, VECSXP);
+make_typed_slice!(Rstr, STRING_PTR, STRSXP);
 
 /// These are helper functions which give access to common properties of R objects.
 #[allow(non_snake_case)]

--- a/extendr-api/src/scalar/macros.rs
+++ b/extendr-api/src/scalar/macros.rs
@@ -459,7 +459,9 @@ macro_rules! gen_binopassign {
                 fn [< $opname:snake >](&mut self, other: $type) {
                     match (*self, other.into()) {
                         (Some(lhs), Some(rhs)) => {
-                            *self = $expr(lhs, rhs);
+                            let f = $expr;
+                            let _ = (); // confuse clippy.
+                            *self = f(lhs, rhs);
                         },
                         _ => *self = None,
                     }

--- a/extendr-api/src/wrapper/list.rs
+++ b/extendr-api/src/wrapper/list.rs
@@ -12,13 +12,13 @@ impl Default for List {
 }
 
 impl List {
-    /// Create a new, empty list.
+    /// Create a new list.
     /// ```
     /// use extendr_api::prelude::*;
     /// test! {
-    ///     let list = List::new();
+    ///     let list = List::new(10);
     ///     assert_eq!(list.is_list(), true);
-    ///     assert_eq!(list.len(), 0);
+    ///     assert_eq!(list.len(), 10);
     /// }
     /// ```
     pub fn new(size: usize) -> Self {
@@ -248,7 +248,7 @@ impl ExactSizeIterator for ListIter {
 /// ```
 /// use extendr_api::prelude::*;
 /// test! {
-///     let list = list!(1, 2);
+///     let list = Robj::from(list!(1, 2));
 ///     let vec : FromList<Vec<i32>> = list.try_into()?;
 ///     assert_eq!(vec.0, vec![1, 2]);
 /// }
@@ -266,7 +266,7 @@ where
     /// ```
     /// use extendr_api::prelude::*;
     /// test! {
-    ///     let list = list!(1, 2);
+    ///     let list = Robj::from(list!(1, 2));
     ///     let vec : FromList<Vec<i32>> = list.try_into()?;
     ///     assert_eq!(vec.0, vec![1, 2]);
     /// }
@@ -287,7 +287,7 @@ impl TryFrom<Robj> for ListIter {
     /// ```
     /// use extendr_api::prelude::*;
     /// test! {
-    ///     let list = list!(1, 2);
+    ///     let list = Robj::from(list!(1, 2));
     ///     let vec : ListIter = list.try_into()?;
     ///     assert_eq!(vec.collect::<Vec<_>>(), vec![r!(1), r!(2)]);
     /// }
@@ -303,8 +303,8 @@ impl From<ListIter> for Robj {
     /// ```
     /// use extendr_api::prelude::*;
     /// test! {
-    ///     let listiter = list!(1, 2).as_list().unwrap().values();
-    ///     assert_eq!(Robj::from(listiter), list!(1, 2));
+    ///     let listiter = list!(1, 2).values();
+    ///     assert_eq!(Robj::from(listiter), Robj::from(list!(1, 2)));
     /// }
     /// ```
     fn from(iter: ListIter) -> Self {

--- a/extendr-api/src/wrapper/list.rs
+++ b/extendr-api/src/wrapper/list.rs
@@ -92,8 +92,7 @@ impl List {
 
     /// Build a list using separate names and values iterators.
     /// Used internally by the list! macro.
-    /// Will panic if the length of names and values does not match.
-    pub fn from_names_and_values<N, V>(names: N, values: V) -> Self
+    pub fn from_names_and_values<N, V>(names: N, values: V) -> Result<Self>
     where
         N: IntoIterator,
         N::IntoIter: ExactSizeIterator,
@@ -103,8 +102,8 @@ impl List {
         V::Item: Into<Robj>,
     {
         let mut list = List::from_values(values);
-        list.set_names(names).unwrap();
-        list
+        list.set_names(names)?;
+        Ok(list)
     }
 
     /// Return an iterator over the values of this list.

--- a/extendr-api/tests/extendr_macro_tests.rs
+++ b/extendr-api/tests/extendr_macro_tests.rs
@@ -9,8 +9,10 @@ fn test_list() {
         let l : List = list!(1);
         assert_eq!(l, List::from_values([1]));
         let l : List = list!(a=1);
-        assert_eq!(l, List::from_names_and_values(["a"], [1]));
+        assert_eq!(l, List::from_names_and_values(["a"], [1]).unwrap());
         let l : List = list!(a=1, b=2);
-        assert_eq!(l, List::from_names_and_values(["a", "b"], [1, 2]));
+        assert_eq!(l, List::from_names_and_values(["a", "b"], [1, 2]).unwrap());
+
+        assert!(List::from_names_and_values(["a", "b"], [1, 2, 3]).is_err());
     }
 }

--- a/extendr-api/tests/extendr_maro_tests.rs
+++ b/extendr-api/tests/extendr_maro_tests.rs
@@ -1,6 +1,5 @@
-
 // use extendr_api::prelude::*;
-use extendr_api::{List, test, Result, list};
+use extendr_api::{list, test, List, Result};
 
 #[test]
 fn test_list() {

--- a/extendr-api/tests/extendr_maro_tests.rs
+++ b/extendr-api/tests/extendr_maro_tests.rs
@@ -1,0 +1,17 @@
+
+// use extendr_api::prelude::*;
+use extendr_api::{List, test, Result, list};
+
+#[test]
+fn test_list() {
+    test! {
+        let l : List = list!();
+        assert_eq!(l, List::default());
+        let l : List = list!(1);
+        assert_eq!(l, List::from_values([1]));
+        let l : List = list!(a=1);
+        assert_eq!(l, List::from_names_and_values(["a"], [1]));
+        let l : List = list!(a=1, b=2);
+        assert_eq!(l, List::from_names_and_values(["a", "b"], [1, 2]));
+    }
+}

--- a/extendr-api/tests/serializer_tests.rs
+++ b/extendr-api/tests/serializer_tests.rs
@@ -38,19 +38,19 @@ mod test {
 
             let u = E::Unit;
             let expected = list!(Unit=NULL);
-            assert_eq!(to_robj(&u).unwrap(), expected);
+            assert_eq!(to_robj(&u).unwrap(), r!(expected));
 
             let n = E::Newtype(1);
             let expected = list!(Newtype=1);
-            assert_eq!(to_robj(&n).unwrap(), expected);
+            assert_eq!(to_robj(&n).unwrap(), r!(expected));
 
             let t = E::Tuple(1, 2);
             let expected = list!(Tuple=list!(1, 2));
-            assert_eq!(to_robj(&t).unwrap(), expected);
+            assert_eq!(to_robj(&t).unwrap(), r!(expected));
 
             let s = E::Struct { a: 1 };
             let expected = list!(Struct=list!(a=1));
-            assert_eq!(to_robj(&s).unwrap(), expected);
+            assert_eq!(to_robj(&s).unwrap(), r!(expected));
         }
     }
 

--- a/extendr-api/tests/vector_tests.rs
+++ b/extendr-api/tests/vector_tests.rs
@@ -34,3 +34,35 @@ fn test_strings() {
         assert_eq!(s.elt(0), "xyz");
     }
 }
+
+#[test]
+fn test_list() {
+    test! {
+        let s = List::new(10);
+        assert_eq!(s.len(), 10);
+        assert_eq!(s.rtype(), RType::List);
+
+        let mut s = List::from_values(["x", "y", "z"]);
+        assert_eq!(s.len(), 3);
+        assert_eq!(s.rtype(), RType::List);
+        assert_eq!(s.elt(0)?, r!("x"));
+        assert_eq!(s.elt(1)?, r!("y"));
+        assert_eq!(s.elt(2)?, r!("z"));
+        assert_eq!(s.elt(3).is_err(), true);
+
+        let v = s.as_slice().iter().map(|c| c).collect::<Vec<_>>();
+        assert_eq!(v, vec![&r!("x"), &r!("y"), &r!("z")]);
+
+        s.set_elt(1, r!("q"))?;
+        assert_eq!(s.elt(1)?, r!("q"));
+
+        let s : List = ["x", "y", "z"].iter().collect();
+        assert_eq!(s, list!("x", "y", "z"));
+
+        let v = list!(a="x", b="y", c="z").iter().collect::<Vec<_>>();
+        assert_eq!(v, vec![("a", r!("x")), ("b", r!("y")), ("c", r!("z"))]);
+
+        let s = List::from_values(["x", <&str>::na(), "z"]);
+        assert_eq!(s.elt(1)?.is_na(), true);
+    }
+}

--- a/extendr-macros/src/lib.rs
+++ b/extendr-macros/src/lib.rs
@@ -60,8 +60,8 @@ mod call;
 mod extendr_function;
 mod extendr_impl;
 mod extendr_module;
-mod pairlist;
 mod list;
+mod pairlist;
 mod pairs;
 mod wrappers;
 

--- a/extendr-macros/src/lib.rs
+++ b/extendr-macros/src/lib.rs
@@ -61,6 +61,7 @@ mod extendr_function;
 mod extendr_impl;
 mod extendr_module;
 mod pairlist;
+mod list;
 mod pairs;
 mod wrappers;
 
@@ -111,6 +112,15 @@ pub fn extendr_module(item: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn pairlist(item: TokenStream) -> TokenStream {
     pairlist::pairlist(item)
+}
+
+/// Create a List R object from a list of name-value pairs.
+/// ```ignore
+///     assert_eq!(list!(a=1, 2, 3), List::from_pairs(&[("a", 1), ("", 2), ("", 3)]));
+/// ```
+#[proc_macro]
+pub fn list(item: TokenStream) -> TokenStream {
+    list::list(item)
 }
 
 /// Call a function or primitive defined by a text expression with arbitrary parameters.

--- a/extendr-macros/src/list.rs
+++ b/extendr-macros/src/list.rs
@@ -16,7 +16,7 @@ pub fn list(item: TokenStream) -> TokenStream {
             .iter()
             .map(|(_n, v)| quote!( extendr_api::Robj::from(#v) ))
             .collect();
-        if nv.iter().any(|(n, _v)| n != "") {
+        if nv.iter().any(|(n, _v)| !n.is_empty()) {
             let names: Vec<proc_macro2::TokenStream> =
                 nv.iter().map(|(n, _v)| quote!( #n )).collect();
             TokenStream::from(quote!(

--- a/extendr-macros/src/list.rs
+++ b/extendr-macros/src/list.rs
@@ -20,11 +20,11 @@ pub fn list(item: TokenStream) -> TokenStream {
             let names: Vec<proc_macro2::TokenStream> =
                 nv.iter().map(|(n, _v)| quote!( #n )).collect();
             TokenStream::from(quote!(
-                List::from_names_and_values(&[# ( #names ),*], &[# ( #values ),*])
+                extendr_api::List::from_names_and_values(&[# ( #names ),*], &[# ( #values ),*])
             ))
         } else {
             TokenStream::from(quote!(
-                List::from_values(&[# ( #values ),*])
+                extendr_api::List::from_values(&[# ( #values ),*])
             ))
         }
     }

--- a/extendr-macros/src/list.rs
+++ b/extendr-macros/src/list.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input};
+use syn::parse_macro_input;
 
 use crate::pairs::Pairs;
 
@@ -12,13 +12,13 @@ pub fn list(item: TokenStream) -> TokenStream {
     if nv.is_empty() {
         TokenStream::from(quote!(List::default()))
     } else {
-        let values : Vec<proc_macro2::TokenStream> = nv.iter().map(|(_n, v)| {
-            quote!( extendr_api::Robj::from(#v) )
-        }).collect();
+        let values: Vec<proc_macro2::TokenStream> = nv
+            .iter()
+            .map(|(_n, v)| quote!( extendr_api::Robj::from(#v) ))
+            .collect();
         if nv.iter().any(|(n, _v)| n != "") {
-            let names : Vec<proc_macro2::TokenStream> = nv.iter().map(|(n, _v)| {
-                quote!( #n )
-            }).collect();
+            let names: Vec<proc_macro2::TokenStream> =
+                nv.iter().map(|(n, _v)| quote!( #n )).collect();
             TokenStream::from(quote!(
                 List::from_names_and_values(&[# ( #names ),*], &[# ( #values ),*])
             ))

--- a/extendr-macros/src/list.rs
+++ b/extendr-macros/src/list.rs
@@ -20,7 +20,7 @@ pub fn list(item: TokenStream) -> TokenStream {
             let names: Vec<proc_macro2::TokenStream> =
                 nv.iter().map(|(n, _v)| quote!( #n )).collect();
             TokenStream::from(quote!(
-                extendr_api::List::from_names_and_values(&[# ( #names ),*], &[# ( #values ),*])
+                extendr_api::List::from_names_and_values(&[# ( #names ),*], &[# ( #values ),*]).unwrap()
             ))
         } else {
             TokenStream::from(quote!(

--- a/extendr-macros/src/list.rs
+++ b/extendr-macros/src/list.rs
@@ -19,6 +19,7 @@ pub fn list(item: TokenStream) -> TokenStream {
         if nv.iter().any(|(n, _v)| !n.is_empty()) {
             let names: Vec<proc_macro2::TokenStream> =
                 nv.iter().map(|(n, _v)| quote!( #n )).collect();
+            // Note that this unwrap should not fail.
             TokenStream::from(quote!(
                 extendr_api::List::from_names_and_values(&[# ( #names ),*], &[# ( #values ),*]).unwrap()
             ))

--- a/extendr-macros/src/pairs.rs
+++ b/extendr-macros/src/pairs.rs
@@ -1,4 +1,4 @@
-use syn::{parse::ParseStream, punctuated::Punctuated, Expr, Token};
+use syn::{parse::ParseStream, punctuated::Punctuated, Expr, Token, ExprAssign, ExprPath};
 
 #[derive(Debug)]
 pub struct Pairs {
@@ -19,5 +19,23 @@ impl syn::parse::Parse for Pairs {
             input.parse::<Token![,]>()?;
         }
         Ok(res)
+    }
+}
+
+impl Pairs {
+    pub (crate) fn names_and_values(&self) -> Vec<(String, &Expr)> {
+        self
+        .pairs
+        .iter()
+        .map(|e| -> (String, &Expr) {
+            if let Expr::Assign(ExprAssign { left, right, .. }) = e {
+                if let Expr::Path(ExprPath { path, .. }) = &**left {
+                    let s = path.get_ident().unwrap().to_string();
+                    return (s, right.as_ref());
+                }
+            }
+            ("".to_owned(), e)
+        })
+        .collect()
     }
 }

--- a/extendr-macros/src/pairs.rs
+++ b/extendr-macros/src/pairs.rs
@@ -1,4 +1,4 @@
-use syn::{parse::ParseStream, punctuated::Punctuated, Expr, Token, ExprAssign, ExprPath};
+use syn::{parse::ParseStream, punctuated::Punctuated, Expr, ExprAssign, ExprPath, Token};
 
 #[derive(Debug)]
 pub struct Pairs {
@@ -23,19 +23,18 @@ impl syn::parse::Parse for Pairs {
 }
 
 impl Pairs {
-    pub (crate) fn names_and_values(&self) -> Vec<(String, &Expr)> {
-        self
-        .pairs
-        .iter()
-        .map(|e| -> (String, &Expr) {
-            if let Expr::Assign(ExprAssign { left, right, .. }) = e {
-                if let Expr::Path(ExprPath { path, .. }) = &**left {
-                    let s = path.get_ident().unwrap().to_string();
-                    return (s, right.as_ref());
+    pub(crate) fn names_and_values(&self) -> Vec<(String, &Expr)> {
+        self.pairs
+            .iter()
+            .map(|e| -> (String, &Expr) {
+                if let Expr::Assign(ExprAssign { left, right, .. }) = e {
+                    if let Expr::Path(ExprPath { path, .. }) = &**left {
+                        let s = path.get_ident().unwrap().to_string();
+                        return (s, right.as_ref());
+                    }
                 }
-            }
-            ("".to_owned(), e)
-        })
-        .collect()
+                ("".to_owned(), e)
+            })
+            .collect()
     }
 }

--- a/extendr-macros/src/pairs.rs
+++ b/extendr-macros/src/pairs.rs
@@ -1,7 +1,9 @@
+//! Internal module for parsing R-like variadic arguments.
+
 use syn::{parse::ParseStream, punctuated::Punctuated, Expr, ExprAssign, ExprPath, Token};
 
 #[derive(Debug)]
-pub struct Pairs {
+pub (crate) struct Pairs {
     pub pairs: Punctuated<Expr, Token![,]>,
 }
 

--- a/extendr-macros/src/pairs.rs
+++ b/extendr-macros/src/pairs.rs
@@ -3,7 +3,7 @@
 use syn::{parse::ParseStream, punctuated::Punctuated, Expr, ExprAssign, ExprPath, Token};
 
 #[derive(Debug)]
-pub (crate) struct Pairs {
+pub(crate) struct Pairs {
     pub pairs: Punctuated<Expr, Token![,]>,
 }
 

--- a/extendr-macros/src/pairs.rs
+++ b/extendr-macros/src/pairs.rs
@@ -23,6 +23,7 @@ impl syn::parse::Parse for Pairs {
 }
 
 impl Pairs {
+    // Having parsed a variadic expression, extract the names and values.
     pub(crate) fn names_and_values(&self) -> Vec<(String, &Expr)> {
         self.pairs
             .iter()


### PR DESCRIPTION
This PR makes a procedural version of the list! macro which now returns the List type.

There are also a few structural changes to List.

As `Robj` is now a wrapper for `SEXP` we can express lists as an array of `Robj` types.

I have also added a more efficient method to create named lists.

