### PR TITLE
Create multiple traits for Robj and wrapper methods.

### DIFF
--- a/extendr-api/src/error.rs
+++ b/extendr-api/src/error.rs
@@ -1,5 +1,6 @@
 //! Error handling in Rust called from R.
 
+use crate::robj::Types;
 use crate::{throw_r_error, Robj};
 
 use std::convert::Infallible;

--- a/extendr-api/src/iter.rs
+++ b/extendr-api/src/iter.rs
@@ -135,7 +135,7 @@ impl_iter_debug!(PairlistIter);
 impl_iter_debug!(StrIter);
 impl_iter_debug!(EnvIter);
 
-impl Robj {
+pub trait AsStrIter: GetSexp + Types + Length + Attributes + Rinternals {
     /// Get an iterator over a string vector.
     /// Returns None if the object is not a string vector
     /// but works for factors.
@@ -163,13 +163,13 @@ impl Robj {
     ///     assert_eq!(obj.as_str_iter().unwrap().map(|s| s.is_na()).collect::<Vec<_>>(), vec![false, false, false]);
     /// }
     /// ```
-    pub fn as_str_iter(&self) -> Option<StrIter> {
+    fn as_str_iter(&self) -> Option<StrIter> {
         let i = 0;
         let len = self.len();
         match self.sexptype() {
             STRSXP => unsafe {
                 Some(StrIter {
-                    vector: self.into(),
+                    vector: self.as_robj().clone(),
                     i,
                     len,
                     levels: R_NilValue,
@@ -179,7 +179,7 @@ impl Robj {
                 if let Some(levels) = self.get_attrib(levels_symbol()) {
                     if self.is_factor() && levels.sexptype() == STRSXP {
                         Some(StrIter {
-                            vector: self.into(),
+                            vector: self.as_robj().clone(),
                             i,
                             len,
                             levels: levels.get(),
@@ -195,3 +195,5 @@ impl Robj {
         }
     }
 }
+
+impl AsStrIter for Robj {}

--- a/extendr-api/src/lang_macros.rs
+++ b/extendr-api/src/lang_macros.rs
@@ -3,6 +3,7 @@
 
 use libR_sys::*;
 //use crate::robj::*;
+use crate::robj::GetSexp;
 use crate::robj::Robj;
 use crate::single_threaded;
 
@@ -115,6 +116,7 @@ macro_rules! lang {
     };
     ($sym : expr, $($rest: tt)*) => {
         unsafe {
+            use extendr_api::robj::GetSexp;
             let res = make_lang($sym);
             let mut tail = res.get();
             append_lang!(tail, $($rest)*);

--- a/extendr-api/src/prelude.rs
+++ b/extendr-api/src/prelude.rs
@@ -46,7 +46,12 @@ pub use super::wrapper::{
 
 pub use super::wrapper::s4::S4;
 
-pub use super::robj::{IntoRobj, Robj, RobjItertools};
+pub use super::wrapper::{Conversions, MatrixConversions};
+
+pub use super::robj::{
+    AsStrIter, Attributes, Eval, GetSexp, IntoRobj, Length, Operators, Rinternals, Robj,
+    RobjItertools, Slices, Types,
+};
 
 pub use super::thread_safety::{
     catch_r_error, handle_panic, single_threaded, this_thread_id, throw_r_error,

--- a/extendr-api/src/robj/from_robj.rs
+++ b/extendr-api/src/robj/from_robj.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::wrapper::matrix::MatrixConversions;
 
 /// Trait used for incomming parameter conversion.
 pub trait FromRobj<'a>: Sized {

--- a/extendr-api/src/robj/rinternals.rs
+++ b/extendr-api/src/robj/rinternals.rs
@@ -4,112 +4,112 @@ use std::os::raw;
 ///////////////////////////////////////////////////////////////
 /// The following impls wrap specific Rinternals.h functions.
 ///
-impl Robj {
+pub trait Rinternals: Types + Conversions {
     /// Return true if this is the null object.
-    pub fn is_null(&self) -> bool {
+    fn is_null(&self) -> bool {
         unsafe { Rf_isNull(self.get()) != 0 }
     }
 
     /// Return true if this is a symbol.
-    pub fn is_symbol(&self) -> bool {
+    fn is_symbol(&self) -> bool {
         unsafe { Rf_isSymbol(self.get()) != 0 }
     }
 
     /// Return true if this is a boolean (logical) vector
-    pub fn is_logical(&self) -> bool {
+    fn is_logical(&self) -> bool {
         unsafe { Rf_isLogical(self.get()) != 0 }
     }
 
     /// Return true if this is a real (f64) vector.
-    pub fn is_real(&self) -> bool {
+    fn is_real(&self) -> bool {
         unsafe { Rf_isReal(self.get()) != 0 }
     }
 
     /// Return true if this is a complex vector.
-    pub fn is_complex(&self) -> bool {
+    fn is_complex(&self) -> bool {
         unsafe { Rf_isComplex(self.get()) != 0 }
     }
 
     /// Return true if this is an expression.
-    pub fn is_expression(&self) -> bool {
+    fn is_expression(&self) -> bool {
         unsafe { Rf_isExpression(self.get()) != 0 }
     }
 
     /// Return true if this is an environment.
-    pub fn is_environment(&self) -> bool {
+    fn is_environment(&self) -> bool {
         unsafe { Rf_isEnvironment(self.get()) != 0 }
     }
 
     /// Return true if this is an environment.
-    pub fn is_promise(&self) -> bool {
+    fn is_promise(&self) -> bool {
         self.sexptype() == PROMSXP
     }
 
     /// Return true if this is a string.
-    pub fn is_string(&self) -> bool {
+    fn is_string(&self) -> bool {
         unsafe { Rf_isString(self.get()) != 0 }
     }
 
     /// Return true if this is an object (ie. has a class attribute).
-    pub fn is_object(&self) -> bool {
+    fn is_object(&self) -> bool {
         unsafe { Rf_isObject(self.get()) != 0 }
     }
 
     /// Return true if this is a S4 object.
-    pub fn is_s4(&self) -> bool {
+    fn is_s4(&self) -> bool {
         unsafe { Rf_isS4(self.get()) != 0 }
     }
 
     /// Return true if this is an expression.
-    pub fn is_external_pointer(&self) -> bool {
+    fn is_external_pointer(&self) -> bool {
         self.rtype() == RType::ExternalPtr
     }
 
     /// Get the source ref.
-    pub fn get_current_srcref(val: i32) -> Robj {
+    fn get_current_srcref(val: i32) -> Robj {
         unsafe { Robj::from_sexp(R_GetCurrentSrcref(val as raw::c_int)) }
     }
 
     /// Get the source filename.
-    pub fn get_src_filename(&self) -> Robj {
+    fn get_src_filename(&self) -> Robj {
         unsafe { Robj::from_sexp(R_GetSrcFilename(self.get())) }
     }
 
     /// Convert to a string vector.
-    pub fn as_character_vector(&self) -> Robj {
+    fn as_character_vector(&self) -> Robj {
         unsafe { Robj::from_sexp(Rf_asChar(self.get())) }
     }
 
     /// Convert to vectors of many kinds.
-    pub fn coerce_vector(&self, sexptype: u32) -> Robj {
+    fn coerce_vector(&self, sexptype: u32) -> Robj {
         single_threaded(|| unsafe {
             Robj::from_sexp(Rf_coerceVector(self.get(), sexptype as SEXPTYPE))
         })
     }
 
     /// Convert a pairlist (LISTSXP) to a vector list (VECSXP).
-    pub fn pair_to_vector_list(&self) -> Robj {
+    fn pair_to_vector_list(&self) -> Robj {
         single_threaded(|| unsafe { Robj::from_sexp(Rf_PairToVectorList(self.get())) })
     }
 
     /// Convert a vector list (VECSXP) to a pair list (LISTSXP)
-    pub fn vector_to_pair_list(&self) -> Robj {
+    fn vector_to_pair_list(&self) -> Robj {
         single_threaded(|| unsafe { Robj::from_sexp(Rf_VectorToPairList(self.get())) })
     }
 
     /// Convert a factor to a string vector.
-    pub fn as_character_factor(&self) -> Robj {
+    fn as_character_factor(&self) -> Robj {
         single_threaded(|| unsafe { Robj::from_sexp(Rf_asCharacterFactor(self.get())) })
     }
 
     /// Allocate a matrix object.
-    pub fn alloc_matrix(sexptype: SEXPTYPE, rows: i32, cols: i32) -> Robj {
+    fn alloc_matrix(sexptype: SEXPTYPE, rows: i32, cols: i32) -> Robj {
         single_threaded(|| unsafe { Robj::from_sexp(Rf_allocMatrix(sexptype, rows, cols)) })
     }
 
     /// Do a deep copy of this object.
     /// Note that clone() only adds a reference.
-    pub fn duplicate(&self) -> Self {
+    fn duplicate(&self) -> Robj {
         single_threaded(|| unsafe { Robj::from_sexp(Rf_duplicate(self.get())) })
     }
 
@@ -128,7 +128,7 @@ impl Robj {
     ///    // assert!(base_env().find_function(sym!(qwertyuiop)).is_none());
     /// }
     /// ```
-    pub fn find_function<K: TryInto<Symbol, Error = Error>>(&self, key: K) -> Result<Robj> {
+    fn find_function<K: TryInto<Symbol, Error = Error>>(&self, key: K) -> Result<Robj> {
         let key: Symbol = key.try_into()?;
         if !self.is_environment() {
             return Err(Error::NotFound(key.into()));
@@ -150,7 +150,8 @@ impl Robj {
         //     }
         // }
         unsafe {
-            if let Ok(var) = catch_r_error(|| Rf_findFun(key.get(), self.get())) {
+            let sexp = self.get();
+            if let Ok(var) = catch_r_error(|| Rf_findFun(key.get(), sexp)) {
                 Ok(Robj::from_sexp(var))
             } else {
                 Err(Error::NotFound(key.into()))
@@ -176,7 +177,7 @@ impl Robj {
     ///    //assert_eq!(global_env().find_var(sym!(imnotasymbol)), None);
     /// }
     /// ```
-    pub fn find_var<K: TryInto<Symbol, Error = Error>>(&self, key: K) -> Result<Robj> {
+    fn find_var<K: TryInto<Symbol, Error = Error>>(&self, key: K) -> Result<Robj> {
         let key: Symbol = key.try_into()?;
         if !self.is_environment() {
             return Err(Error::NotFound(key.into()));
@@ -198,7 +199,8 @@ impl Robj {
         //     }
         // }
         unsafe {
-            if let Ok(var) = catch_r_error(|| Rf_findVar(key.get(), self.get())) {
+            let sexp = self.get();
+            if let Ok(var) = catch_r_error(|| Rf_findVar(key.get(), sexp)) {
                 if var != R_UnboundValue {
                     Ok(Robj::from_sexp(var))
                 } else {
@@ -219,27 +221,27 @@ impl Robj {
     ///    assert_eq!(iris_dataframe.is_frame(), true);
     /// }
     /// ```
-    pub fn eval_promise(&self) -> Result<Robj> {
+    fn eval_promise(&self) -> Result<Robj> {
         if self.is_promise() {
             self.as_promise().unwrap().eval()
         } else {
-            Ok(self.into())
+            Ok(self.as_robj().clone())
         }
     }
 
     /// Number of columns of a matrix
-    pub fn ncols(&self) -> usize {
+    fn ncols(&self) -> usize {
         unsafe { Rf_ncols(self.get()) as usize }
     }
 
     /// Number of rows of a matrix
-    pub fn nrows(&self) -> usize {
+    fn nrows(&self) -> usize {
         unsafe { Rf_nrows(self.get()) as usize }
     }
 
     /// Internal function used to implement `#[extendr]` impl
     #[doc(hidden)]
-    pub unsafe fn make_external_ptr<T>(p: *mut T, tag: Robj, prot: Robj) -> Self {
+    unsafe fn make_external_ptr<T>(p: *mut T, tag: Robj, prot: Robj) -> Robj {
         Robj::from_sexp(single_threaded(|| {
             R_MakeExternalPtr(p as *mut ::std::os::raw::c_void, tag.get(), prot.get())
         }))
@@ -247,160 +249,160 @@ impl Robj {
 
     /// Internal function used to implement `#[extendr]` impl
     #[doc(hidden)]
-    pub unsafe fn external_ptr_addr<T>(&self) -> *mut T {
+    unsafe fn external_ptr_addr<T>(&self) -> *mut T {
         R_ExternalPtrAddr(self.get()) as *mut T
     }
 
     /// Internal function used to implement `#[extendr]` impl
     #[doc(hidden)]
-    pub unsafe fn external_ptr_tag(&self) -> Self {
+    unsafe fn external_ptr_tag(&self) -> Robj {
         Robj::from_sexp(R_ExternalPtrTag(self.get()))
     }
 
     /// Internal function used to implement `#[extendr]` impl
     #[doc(hidden)]
-    pub unsafe fn external_ptr_protected(&self) -> Self {
+    unsafe fn external_ptr_protected(&self) -> Robj {
         Robj::from_sexp(R_ExternalPtrProtected(self.get()))
     }
 
     #[doc(hidden)]
-    pub unsafe fn register_c_finalizer(&self, func: R_CFinalizer_t) {
+    unsafe fn register_c_finalizer(&self, func: R_CFinalizer_t) {
         single_threaded(|| R_RegisterCFinalizer(self.get(), func));
     }
 
     /// Copy a vector and resize it.
     /// See. <https://github.com/hadley/r-internals/blob/master/vectors.md>
-    pub fn xlengthgets(&self, new_len: usize) -> Result<Robj> {
+    fn xlengthgets(&self, new_len: usize) -> Result<Robj> {
         unsafe {
             if self.is_vector() {
                 Ok(single_threaded(|| {
                     Robj::from_sexp(Rf_xlengthgets(self.get(), new_len as R_xlen_t))
                 }))
             } else {
-                Err(Error::ExpectedVector(self.clone()))
+                Err(Error::ExpectedVector(self.as_robj().clone()))
             }
         }
     }
 
     /// Allocated an owned object of a certain type.
-    pub fn alloc_vector(sexptype: u32, len: usize) -> Robj {
+    fn alloc_vector(sexptype: u32, len: usize) -> Robj {
         single_threaded(|| unsafe { Robj::from_sexp(Rf_allocVector(sexptype, len as R_xlen_t)) })
     }
 
     /// Return true if two arrays have identical dims.
-    pub fn conformable(a: &Robj, b: &Robj) -> bool {
+    fn conformable(a: &Robj, b: &Robj) -> bool {
         single_threaded(|| unsafe { Rf_conformable(a.get(), b.get()) != 0 })
     }
 
     /// Return true if this is an array.
-    pub fn is_array(&self) -> bool {
+    fn is_array(&self) -> bool {
         unsafe { Rf_isArray(self.get()) != 0 }
     }
 
     /// Return true if this is factor.
-    pub fn is_factor(&self) -> bool {
+    fn is_factor(&self) -> bool {
         unsafe { Rf_isFactor(self.get()) != 0 }
     }
 
     /// Return true if this is a data frame.
-    pub fn is_frame(&self) -> bool {
+    fn is_frame(&self) -> bool {
         unsafe { Rf_isFrame(self.get()) != 0 }
     }
 
     /// Return true if this is a function or a primitive (CLOSXP, BUILTINSXP or SPECIALSXP)
-    pub fn is_function(&self) -> bool {
+    fn is_function(&self) -> bool {
         unsafe { Rf_isFunction(self.get()) != 0 }
     }
 
     /// Return true if this is an integer vector (INTSXP) but not a factor.
-    pub fn is_integer(&self) -> bool {
+    fn is_integer(&self) -> bool {
         unsafe { Rf_isInteger(self.get()) != 0 }
     }
 
     /// Return true if this is a language object (LANGSXP).
-    pub fn is_language(&self) -> bool {
+    fn is_language(&self) -> bool {
         unsafe { Rf_isLanguage(self.get()) != 0 }
     }
 
     /// Return true if this is NILSXP or LISTSXP.
-    pub fn is_pairlist(&self) -> bool {
+    fn is_pairlist(&self) -> bool {
         unsafe { Rf_isList(self.get()) != 0 }
     }
 
     /// Return true if this is a matrix.
-    pub fn is_matrix(&self) -> bool {
+    fn is_matrix(&self) -> bool {
         unsafe { Rf_isMatrix(self.get()) != 0 }
     }
 
     /// Return true if this is NILSXP or VECSXP.
-    pub fn is_list(&self) -> bool {
+    fn is_list(&self) -> bool {
         unsafe { Rf_isNewList(self.get()) != 0 }
     }
 
     /// Return true if this is INTSXP, LGLSXP or REALSXP but not a factor.
-    pub fn is_number(&self) -> bool {
+    fn is_number(&self) -> bool {
         unsafe { Rf_isNumber(self.get()) != 0 }
     }
 
     /// Return true if this is a primitive function BUILTINSXP, SPECIALSXP.
-    pub fn is_primitive(&self) -> bool {
+    fn is_primitive(&self) -> bool {
         unsafe { Rf_isPrimitive(self.get()) != 0 }
     }
 
     /// Return true if this is a time series vector (see tsp).
-    pub fn is_ts(&self) -> bool {
+    fn is_ts(&self) -> bool {
         unsafe { Rf_isTs(self.get()) != 0 }
     }
 
     /// Return true if this is a user defined binop.
-    pub fn is_user_binop(&self) -> bool {
+    fn is_user_binop(&self) -> bool {
         unsafe { Rf_isUserBinop(self.get()) != 0 }
     }
 
     /// Return true if this is a valid string.
-    pub fn is_valid_string(&self) -> bool {
+    fn is_valid_string(&self) -> bool {
         unsafe { Rf_isValidString(self.get()) != 0 }
     }
 
     /// Return true if this is a valid string.
-    pub fn is_valid_string_f(&self) -> bool {
+    fn is_valid_string_f(&self) -> bool {
         unsafe { Rf_isValidStringF(self.get()) != 0 }
     }
 
     /// Return true if this is a vector.
-    pub fn is_vector(&self) -> bool {
+    fn is_vector(&self) -> bool {
         unsafe { Rf_isVector(self.get()) != 0 }
     }
 
     /// Return true if this is an atomic vector.
-    pub fn is_vector_atomic(&self) -> bool {
+    fn is_vector_atomic(&self) -> bool {
         unsafe { Rf_isVectorAtomic(self.get()) != 0 }
     }
 
     /// Return true if this is a vector list.
-    pub fn is_vector_list(&self) -> bool {
+    fn is_vector_list(&self) -> bool {
         unsafe { Rf_isVectorList(self.get()) != 0 }
     }
 
     /// Return true if this is can be made into a vector.
-    pub fn is_vectorizable(&self) -> bool {
+    fn is_vectorizable(&self) -> bool {
         unsafe { Rf_isVectorizable(self.get()) != 0 }
     }
 
     /// Return true if this is RAWSXP.
-    pub fn is_raw(&self) -> bool {
+    fn is_raw(&self) -> bool {
         self.rtype() == RType::Raw
     }
 
     /// Return true if this is CHARSXP.
-    pub fn is_char(&self) -> bool {
+    fn is_char(&self) -> bool {
         self.rtype() == RType::Rstr
     }
 
     /// Check an external pointer tag.
     /// This is used to wrap R objects.
     #[doc(hidden)]
-    pub fn check_external_ptr(&self, expected_tag: &str) -> bool {
+    fn check_external_ptr(&self, expected_tag: &str) -> bool {
         if self.sexptype() == libR_sys::EXTPTRSXP {
             let tag = unsafe { self.external_ptr_tag() };
             if tag.as_str() == Some(expected_tag) {
@@ -410,63 +412,65 @@ impl Robj {
         false
     }
 
-    pub fn is_missing_arg(&self) -> bool {
+    fn is_missing_arg(&self) -> bool {
         unsafe { self.get() == R_MissingArg }
     }
 
-    pub fn is_unbound_value(&self) -> bool {
+    fn is_unbound_value(&self) -> bool {
         unsafe { self.get() == R_UnboundValue }
     }
 
-    pub fn is_package_env(&self) -> bool {
+    fn is_package_env(&self) -> bool {
         unsafe { R_IsPackageEnv(self.get()) != 0 }
     }
 
-    pub fn package_env_name(&self) -> Robj {
+    fn package_env_name(&self) -> Robj {
         unsafe { Robj::from_sexp(R_PackageEnvName(self.get())) }
     }
 
-    pub fn is_namespace_env(&self) -> bool {
+    fn is_namespace_env(&self) -> bool {
         unsafe { R_IsNamespaceEnv(self.get()) != 0 }
     }
 
-    pub fn namespace_env_spec(&self) -> Robj {
+    fn namespace_env_spec(&self) -> Robj {
         unsafe { Robj::from_sexp(R_NamespaceEnvSpec(self.get())) }
     }
 
     /// Returns `true` if this is an ALTREP object.
-    pub fn is_altrep(&self) -> bool {
+    fn is_altrep(&self) -> bool {
         unsafe { ALTREP(self.get()) != 0 }
     }
 
     /// Returns `true` if this is an integer ALTREP object.
-    pub fn is_altinteger(&self) -> bool {
+    fn is_altinteger(&self) -> bool {
         unsafe { ALTREP(self.get()) != 0 && TYPEOF(self.get()) == INTSXP as i32 }
     }
 
     /// Returns `true` if this is an real ALTREP object.
-    pub fn is_altreal(&self) -> bool {
+    fn is_altreal(&self) -> bool {
         unsafe { ALTREP(self.get()) != 0 && TYPEOF(self.get()) == REALSXP as i32 }
     }
 
     /// Returns `true` if this is an logical ALTREP object.
-    pub fn is_altlogical(&self) -> bool {
+    fn is_altlogical(&self) -> bool {
         unsafe { ALTREP(self.get()) != 0 && TYPEOF(self.get()) == LGLSXP as i32 }
     }
 
     /// Returns `true` if this is a raw ALTREP object.
-    pub fn is_altraw(&self) -> bool {
+    fn is_altraw(&self) -> bool {
         unsafe { ALTREP(self.get()) != 0 && TYPEOF(self.get()) == RAWSXP as i32 }
     }
 
     /// Returns `true` if this is an integer ALTREP object.
-    pub fn is_altstring(&self) -> bool {
+    fn is_altstring(&self) -> bool {
         unsafe { ALTREP(self.get()) != 0 && TYPEOF(self.get()) == STRSXP as i32 }
     }
 
     /// Generate a text representation of this object.
-    pub fn deparse(&self) -> Result<Robj> {
+    fn deparse(&self) -> Result<Robj> {
         use crate as extendr_api;
-        call!("deparse", self)
+        call!("deparse", self.as_robj())
     }
 }
+
+impl Rinternals for Robj {}

--- a/extendr-api/src/wrapper/list.rs
+++ b/extendr-api/src/wrapper/list.rs
@@ -1,4 +1,5 @@
 use std::iter::FromIterator;
+use crate::robj::Attributes;
 
 use super::*;
 
@@ -62,7 +63,11 @@ impl List {
             values.push(pair.value());
         }
         let mut res = List::from_values(values);
-        res.set_names(names).unwrap().as_list().unwrap()
+        res.as_robj_mut()
+            .set_names(names)
+            .unwrap()
+            .as_list()
+            .unwrap()
     }
 
     /// Wrapper for creating a list (VECSXP) object from an existing `HashMap`.
@@ -388,3 +393,5 @@ impl<T: Into<Robj>> FromIterator<T> for List {
         })
     }
 }
+
+impl Attributes for List {}

--- a/extendr-api/src/wrapper/macros.rs
+++ b/extendr-api/src/wrapper/macros.rs
@@ -119,7 +119,7 @@ macro_rules! gen_vector_wrapper_impl {
                 #[doc = "Return an iterator for a " $doc_name " object."]
                 #[doc = "Forces ALTREP objects to manifest."]
                 pub fn iter(&self) -> impl Iterator<Item = $type_elem> {
-                    self.as_typed_slice().unwrap().iter().cloned()
+                    self.as_robj().as_typed_slice().unwrap().iter().cloned()
                 }
             }
 
@@ -127,7 +127,7 @@ macro_rules! gen_vector_wrapper_impl {
                 #[doc = "Return a writable iterator for a " $doc_name " object."]
                 #[doc = "Forces ALTREP objects to manifest."]
                 pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut $type_elem> {
-                    self.as_typed_slice_mut().unwrap().iter_mut()
+                    self.as_robj_mut().as_typed_slice_mut().unwrap().iter_mut()
                 }
             }
         }

--- a/extendr-api/src/wrapper/matrix.rs
+++ b/extendr-api/src/wrapper/matrix.rs
@@ -1,6 +1,7 @@
 //! Wrappers for matrices with deferred arithmetic.
 
 use super::*;
+use crate::robj::GetSexp;
 use std::ops::{Index, IndexMut};
 
 /// Wrapper for creating and using matrices and arrays.
@@ -279,28 +280,30 @@ impl<T, D> From<RArray<T, D>> for Robj {
     }
 }
 
-impl Robj {
-    pub fn as_column<'a, E: 'a>(&self) -> Option<RColumn<E>>
+pub trait MatrixConversions: GetSexp {
+    fn as_column<'a, E: 'a>(&self) -> Option<RColumn<E>>
     where
-        Self: AsTypedSlice<'a, E>,
+        Robj: AsTypedSlice<'a, E>,
     {
-        <RColumn<E>>::try_from(self.clone()).ok()
+        <RColumn<E>>::try_from(self.as_robj().clone()).ok()
     }
 
-    pub fn as_matrix<'a, E: 'a>(&self) -> Option<RMatrix<E>>
+    fn as_matrix<'a, E: 'a>(&self) -> Option<RMatrix<E>>
     where
-        Self: AsTypedSlice<'a, E>,
+        Robj: AsTypedSlice<'a, E>,
     {
-        <RMatrix<E>>::try_from(self.clone()).ok()
+        <RMatrix<E>>::try_from(self.as_robj().clone()).ok()
     }
 
-    pub fn as_matrix3d<'a, E: 'a>(&self) -> Option<RMatrix3D<E>>
+    fn as_matrix3d<'a, E: 'a>(&self) -> Option<RMatrix3D<E>>
     where
-        Self: AsTypedSlice<'a, E>,
+        Robj: AsTypedSlice<'a, E>,
     {
-        <RMatrix3D<E>>::try_from(self.clone()).ok()
+        <RMatrix3D<E>>::try_from(self.as_robj().clone()).ok()
     }
 }
+
+impl MatrixConversions for Robj {}
 
 impl<T> Index<[usize; 2]> for RArray<T, [usize; 2]> {
     type Output = T;

--- a/extendr-api/tests/altrep_tests.rs
+++ b/extendr-api/tests/altrep_tests.rs
@@ -35,7 +35,7 @@ fn test_altinteger() {
 
         assert_eq!(obj.len(), 10);
         // assert_eq!(obj.sum(true), r!(45.0));
-        assert_eq!(obj.as_integer_slice().unwrap(), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        assert_eq!(obj.as_robj().as_integer_slice().unwrap(), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
         // index 5 is missing
         let mystate_w_missing = MyCompactIntRange { start: 0, len: 10, step: 1, missing_index: 5 };
@@ -89,7 +89,7 @@ fn test_altreal() {
 
         assert_eq!(obj.len(), 10);
         // assert_eq!(obj.sum(true), r!(45.0));
-        assert_eq!(obj.as_real_slice().unwrap(), [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]);
+        assert_eq!(obj.as_robj().as_real_slice().unwrap(), [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]);
 
         // index 5 is missing
         let mystate_w_missing = MyCompactRealRange { start: 0.0, len: 10, step: 1.0, missing_index: 5 };
@@ -138,7 +138,7 @@ fn test_altlogical() {
 
         assert_eq!(obj.len(), 10);
         // assert_eq!(obj.sum(true), r!(5.0));
-        assert_eq!(obj.as_logical_slice().unwrap(), [FALSE, TRUE, FALSE, TRUE, FALSE, TRUE, FALSE, TRUE, FALSE, TRUE]);
+        assert_eq!(obj.as_robj().as_logical_slice().unwrap(), [FALSE, TRUE, FALSE, TRUE, FALSE, TRUE, FALSE, TRUE, FALSE, TRUE]);
     }
 }
 
@@ -170,7 +170,7 @@ fn test_altraw() {
         let obj = Altrep::from_state_and_class(mystate, class, false);
 
         assert_eq!(obj.len(), 10);
-        assert_eq!(obj.as_raw_slice().unwrap(), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        assert_eq!(obj.as_robj().as_raw_slice().unwrap(), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
     }
 }
 

--- a/extendr-api/tests/serializer_tests.rs
+++ b/extendr-api/tests/serializer_tests.rs
@@ -85,7 +85,7 @@ mod test {
                 // s4: S4,
             }
 
-            let test = Test {
+            let _test = Test {
                 null: r!(()),
                 symbol: sym!("xyz").try_into()?,
                 pairlist: pairlist!(x=1),
@@ -112,7 +112,7 @@ mod test {
                 // s4: S4,
             };
 
-            let expected = list!(int=1, seq=list!(null = (), symbol = (), pairlist = (), function = (), rstr = (), integer = (), real = (), list = (), raw = ()));
+            let _expected = list!(int=1, seq=list!(null = (), symbol = (), pairlist = (), function = (), rstr = (), integer = (), real = (), list = (), raw = ()));
             // assert_eq!(to_robj(&test).unwrap(), Robj::from(expected));
         }
     }


### PR DESCRIPTION
This is a major refactor of the implementation of the wrappers and Robj.

Currently, many of the wrappers implement `Deref<Target=Robj>` which makes making alternative
behaviour quite challenging.

For example, we would like to be able to index Integers with [i] and environments with ["str"]
ExternalPtr<T> should behave like a Box<T> enabling the contained element to be referenced
without calling a function.

This also starts to build a consistent interface for the wrappers which is expressed in traits.

We now only have two `impl Robj` blocks and one will be phased out.

Conversions between wrappers and Robj should be unified.

This PR should have very little effect on the visible interface, but should help us to start
cleaning up a bit.

There are a number of new traits that encapsulate existing functionality.

### GetSexp

controls access to the underlying SEXP pointer.

### Types 

Generates the new Rtype and Rany enums

### Length

Implements len()

### Conversions

Likely to be phased out has a large number of as_xxx() conversions.

### Rinternals

Has a number of internal R functions such as find_var()

### Slices

Gives unsafe access to DATAPTR in vectors.

### Operators

Implements R operators such as dollar()

 