### PR TITLE
Implement Device::close()

### DIFF
--- a/extendr-api/src/graphics/mod.rs
+++ b/extendr-api/src/graphics/mod.rs
@@ -374,6 +374,18 @@ impl Device {
         }
     }
 
+    /// Close the current device (equivalent to `dev.off()` on R).
+    pub fn close(&self) -> Result<()> {
+        unsafe {
+            if Rf_NoDevices() != 0 {
+                Err(Error::NoGraphicsDevices(r!(())))
+            } else {
+                GEkillDevice(self.inner());
+                Ok(())
+            }
+        }
+    }
+
     /// Get the device number for this device.
     pub fn device_number(&self) -> i32 {
         unsafe { GEdeviceNumber(self.inner()) }

--- a/extendr-api/tests/graphics_tests.rs
+++ b/extendr-api/tests/graphics_tests.rs
@@ -71,7 +71,7 @@ fn graphics_test() {
 
         if use_postscript {
             // Flush the file and kill the device.
-            R!("dev.off()")?;
+            dev.close()?;
             let ps = std::fs::read_to_string(path).expect("PS file not written.");
             if let Some(split) = ps.split_once("%%EndProlog") {
                 let epilogue = split.1;


### PR DESCRIPTION
Close #299 

I chose `close()` because `off()` might be confusing with `mode_off()`, but I'm open to any suggestions.