### PR TITLE
Add Deref implementations for wrappers.

### DIFF
--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -406,8 +406,8 @@ pub enum RType {
 }
 
 /// Enum use to unpack R objects into their specialist wrappers.
-/// Todo: convert all Robj types to wrappers.
-/// Note: this only works if the wrappers are all just SEXPs.
+// Todo: convert all Robj types to wrappers.
+// Note: this only works if the wrappers are all just SEXPs.
 #[derive(Debug, PartialEq)]
 pub enum Rany<'a> {
     Null(&'a Robj),               // NILSXP

--- a/extendr-api/src/wrapper/doubles.rs
+++ b/extendr-api/src/wrapper/doubles.rs
@@ -123,4 +123,3 @@ impl DerefMut for Doubles {
         }
     }
 }
-

--- a/extendr-api/src/wrapper/doubles.rs
+++ b/extendr-api/src/wrapper/doubles.rs
@@ -92,3 +92,35 @@ mod tests {
         }
     }
 }
+
+// TODO: this should be a trait.
+impl Doubles {
+    pub fn set_elt(&mut self, index: usize, val: Rfloat) {
+        unsafe {
+            SET_REAL_ELT(self.get(), index as R_xlen_t, val.inner());
+        }
+    }
+}
+
+impl Deref for Doubles {
+    type Target = [Rfloat];
+
+    /// Treat Doubles as if it is a slice, like Vec<Rfloat>
+    fn deref(&self) -> &Self::Target {
+        unsafe {
+            let ptr = DATAPTR_RO(self.get()) as *const Rfloat;
+            std::slice::from_raw_parts(ptr, self.len())
+        }
+    }
+}
+
+impl DerefMut for Doubles {
+    /// Treat Doubles as if it is a mutable slice, like Vec<Rfloat>
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe {
+            let ptr = DATAPTR(self.get()) as *mut Rfloat;
+            std::slice::from_raw_parts_mut(ptr, self.len())
+        }
+    }
+}
+

--- a/extendr-api/src/wrapper/externalptr.rs
+++ b/extendr-api/src/wrapper/externalptr.rs
@@ -6,7 +6,7 @@ use std::any::Any;
 /// ```
 /// use extendr_api::prelude::*;
 /// test! {
-///     let extptr = ExternalPtr::from_val(1);
+///     let extptr = ExternalPtr::new(1);
 ///     assert_eq!(*extptr, 1);
 ///     let robj : Robj = extptr.into();
 ///     let extptr2 : ExternalPtr<i32> = robj.try_into().unwrap();
@@ -37,7 +37,9 @@ impl<T: Any> ExternalPtr<T> {
     /// In this case, the R object owns the data and will drop the Rust object
     /// when the last reference is removed via register_c_finalizer.
     ///
-    pub fn from_val(val: T) -> Self {
+    /// An ExternalPtr behaves like a Box except that the information is
+    /// tracked by a R object.
+    pub fn new(val: T) -> Self {
         unsafe {
             // This gets the type name of T as a string. eg. "i32".
             let type_name = std::any::type_name::<T>();

--- a/extendr-api/src/wrapper/integers.rs
+++ b/extendr-api/src/wrapper/integers.rs
@@ -94,3 +94,34 @@ mod tests {
         }
     }
 }
+
+// TODO: this should be a trait.
+impl Integers {
+    pub fn set_elt(&mut self, index: usize, val: Rint) {
+        unsafe {
+            SET_INTEGER_ELT(self.get(), index as R_xlen_t, val.inner());
+        }
+    }
+}
+
+impl Deref for Integers {
+    type Target = [Rint];
+
+    /// Treat Integers as if it is a slice, like Vec<Rint>
+    fn deref(&self) -> &Self::Target {
+        unsafe {
+            let ptr = DATAPTR_RO(self.get()) as *const Rint;
+            std::slice::from_raw_parts(ptr, self.len())
+        }
+    }
+}
+
+impl DerefMut for Integers {
+    /// Treat Integers as if it is a mutable slice, like Vec<Rint>
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe {
+            let ptr = DATAPTR(self.get()) as *mut Rint;
+            std::slice::from_raw_parts_mut(ptr, self.len())
+        }
+    }
+}

--- a/extendr-api/src/wrapper/list.rs
+++ b/extendr-api/src/wrapper/list.rs
@@ -395,3 +395,12 @@ impl<T: Into<Robj>> FromIterator<T> for List {
 }
 
 impl Attributes for List {}
+
+impl Deref for List {
+    type Target = [Robj];
+
+    /// Lists behave like slices of Robj.
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}

--- a/extendr-api/src/wrapper/rstr.rs
+++ b/extendr-api/src/wrapper/rstr.rs
@@ -12,7 +12,7 @@ use super::*;
 /// }
 /// ```
 ///
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Clone)]
 pub struct Rstr {
     pub(crate) robj: Robj,
 }
@@ -58,5 +58,31 @@ impl From<&str> for Rstr {
     /// Convert a string slice to a Rstr.
     fn from(s: &str) -> Self {
         Rstr::from_string(s)
+    }
+}
+
+impl Deref for Rstr {
+    type Target = str;
+
+    /// Treat Rstr like &str.
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+impl<T> PartialEq<T> for Rstr
+where
+    T: AsRef<str>,
+{
+    /// Compare a `Rstr` with a `Rstr`.
+    fn eq(&self, other: &T) -> bool {
+        self.as_str() == other.as_ref()
+    }
+}
+
+impl PartialEq<str> for Rstr {
+    /// Compare a `Rstr` with a string slice.
+    fn eq(&self, other: &str) -> bool {
+        self.as_str() == other
     }
 }

--- a/extendr-api/src/wrapper/strings.rs
+++ b/extendr-api/src/wrapper/strings.rs
@@ -133,3 +133,11 @@ where
         Strings::from_values([value.as_ref()])
     }
 }
+
+impl Deref for Strings {
+    type Target = [Rstr];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}

--- a/extendr-api/tests/externalptr_test.rs
+++ b/extendr-api/tests/externalptr_test.rs
@@ -4,7 +4,7 @@ use lazy_static::lazy_static;
 #[test]
 fn test_externalptr() {
     test! {
-        let extptr = ExternalPtr::from_val(1);
+        let extptr = ExternalPtr::new(1);
         assert_eq!(*extptr, 1);
         let robj : Robj = extptr.into();
         let extptr2 : ExternalPtr<i32> = robj.try_into().unwrap();
@@ -34,7 +34,7 @@ fn test_externalptr_drop() {
         }
 
         // Create an external pointer to test the drop.
-        let extptr = ExternalPtr::from_val(X {});
+        let extptr = ExternalPtr::new(X {});
 
         // The object should be protected here - drop not called yet.
         R!("gc()").unwrap();
@@ -44,5 +44,19 @@ fn test_externalptr_drop() {
         drop(extptr);
         R!("gc()").unwrap();
         assert_eq!(*Z.lock().unwrap(), true);
+    }
+}
+
+#[test]
+fn test_externalptr_deref() {
+    test! {
+        struct X {
+            x: i32,
+            y: i32,
+        }
+
+        let extptr = ExternalPtr::new(X { x: 1, y: 2});
+        assert_eq!(extptr.x, 1);
+        assert_eq!(extptr.y, 2);
     }
 }

--- a/extendr-api/tests/vector_tests.rs
+++ b/extendr-api/tests/vector_tests.rs
@@ -66,3 +66,102 @@ fn test_list() {
         assert_eq!(s.elt(1)?.is_na(), true);
     }
 }
+
+#[test]
+fn test_doubles() {
+    test! {
+        let s = Doubles::new(10);
+        assert_eq!(s.len(), 10);
+        assert_eq!(s.rtype(), RType::Real);
+
+        let mut s = Doubles::from_values([1, 2, 3]);
+        assert_eq!(s.len(), 3);
+        assert_eq!(s.rtype(), RType::Real);
+        assert_eq!(s.elt(0), 1.0);
+        assert_eq!(s.elt(1), 2.0);
+        assert_eq!(s.elt(2), 3.0);
+        assert!(s.elt(3).is_na());
+
+        let v = s.iter().collect::<Vec<Rfloat>>();
+        assert_eq!(v, [1.0, 2.0, 3.0]);
+
+        s.set_elt(1, 5.0.into());
+        assert_eq!(s.elt(1), 5.0);
+
+        let s : Doubles = [1.0, 2.0, 3.0].iter().map(|i| Rfloat::from(*i)).collect();
+        let v = s.iter().collect::<Doubles>();
+        assert_eq!(v, Doubles::from_values([1.0, 2.0, 3.0]));
+
+        // Bug: from_values should be Into<Rfloat>
+        //let s = Doubles::from_values([Rint::from(1), Rint::na(), Rint::from(3)]);
+        //assert_eq!(s.elt(1).is_na(), true);
+
+        let robj = r!([1.0, 2.0, 3.0]);
+        let s = Doubles::try_from(robj)?;
+        assert_eq!(s.len(), 3);
+        assert_eq!(s.elt(0), 1.0);
+
+        // Test Deref and DerefMut.
+        let mut s = Doubles::from_values([1.0, 2.0, 3.0]);
+        assert_eq!(s[0], 1.0);
+        assert_eq!(s[1], 2.0);
+        assert_eq!(s[2], 3.0);
+
+        s[0] = 4.0.into();
+        s[1] = 5.0.into();
+        s[2] = 6.0.into();
+        assert_eq!(s[0], 4.0);
+        assert_eq!(s[1], 5.0);
+        assert_eq!(s[2], 6.0);
+    }
+}
+
+#[test]
+fn test_integers() {
+    test! {
+        let s = Integers::new(10);
+        assert_eq!(s.len(), 10);
+        assert_eq!(s.rtype(), RType::Integer);
+
+        let mut s = Integers::from_values([1, 2, 3]);
+        assert_eq!(s.len(), 3);
+        assert_eq!(s.rtype(), RType::Integer);
+        assert_eq!(s.elt(0), 1);
+        assert_eq!(s.elt(1), 2);
+        assert_eq!(s.elt(2), 3);
+        assert!(s.elt(3).is_na());
+
+        let v = s.iter().collect::<Vec<Rint>>();
+        assert_eq!(v, [1, 2, 3]);
+
+        s.set_elt(1, 5.into());
+        assert_eq!(s.elt(1), 5);
+
+        let s : Integers = [1, 2, 3].iter().map(|i| Rint::from(*i)).collect();
+        let v = s.iter().collect::<Integers>();
+        assert_eq!(v, Integers::from_values([1, 2, 3]));
+
+        // Bug: from_values should be Into<Rint>
+        //let s = Integers::from_values([Rint::from(1), Rint::na(), Rint::from(3)]);
+        //assert_eq!(s.elt(1).is_na(), true);
+
+        let robj = r!([1, 2, 3]);
+        let s = Integers::try_from(robj)?;
+        assert_eq!(s.len(), 3);
+        assert_eq!(s.elt(0), 1);
+
+        // Test Deref and DerefMut.
+        let mut s = Integers::from_values([1, 2, 3]);
+        assert_eq!(s[0], 1);
+        assert_eq!(s[1], 2);
+        assert_eq!(s[2], 3);
+
+        s[0] = 4.into();
+        s[1] = 5.into();
+        s[2] = 6.into();
+        assert_eq!(s[0], 4);
+        assert_eq!(s[1], 5);
+        assert_eq!(s[2], 6);
+    }
+}
+

--- a/extendr-api/tests/vector_tests.rs
+++ b/extendr-api/tests/vector_tests.rs
@@ -24,6 +24,10 @@ fn test_strings() {
         let s : Strings = ["x", "y", "z"].iter().collect();
         let v = s.iter().map(|c| c.as_str()).collect::<String>();
         assert_eq!(v, "xyz");
+        assert_eq!(&*s, &["x", "y", "z"]);
+
+        // Strings supports methods of &[Rstr] via Deref.
+        assert_eq!(s.contains(&"x".into()), true);
 
         let s = Strings::from_values(["x", <&str>::na(), "z"]);
         assert_eq!(s.elt(1).is_na(), true);
@@ -64,6 +68,15 @@ fn test_list() {
 
         let s = List::from_values(["x", <&str>::na(), "z"]);
         assert_eq!(s.elt(1)?.is_na(), true);
+        assert_eq!(s.as_slice().iter().any(|s| s.is_na()), true);
+
+        // Deref allows all the immutable methods from slice.
+        let v = s.as_slice().iter().map(|c| c).collect::<Vec<_>>();
+        assert_eq!(v, vec![&r!("x"), &r!(<&str>::na()), &r!("z")]);
+        assert_eq!(v[0], "x");
+        assert_eq!(v[1].is_na(), true);
+        assert_eq!(v.contains(&&r!("x")), true);
+        assert_eq!(s.as_slice().iter().any(Robj::is_na), true);
     }
 }
 
@@ -162,5 +175,19 @@ fn test_integers() {
         assert_eq!(s[0], 4);
         assert_eq!(s[1], 5);
         assert_eq!(s[2], 6);
+    }
+}
+
+#[test]
+fn test_rstr() {
+    test! {
+        let x = Rstr::from_string("xyz");
+        // All methods of &str are usable on Rstr.
+        assert_eq!(x.contains('y'), true);
+        assert_eq!(x.starts_with("xy"), true);
+        assert_eq!(x.len(), 3);
+
+        let x : Rstr = "xyz".into();
+        assert_eq!(x, "xyz");
     }
 }

--- a/extendr-api/tests/vector_tests.rs
+++ b/extendr-api/tests/vector_tests.rs
@@ -164,4 +164,3 @@ fn test_integers() {
         assert_eq!(s[2], 6);
     }
 }
-


### PR DESCRIPTION
This PR adds derefs for wrapper types.

Vectors deref to slices of their value (`Rint /Rfloat/Rbool/Rstr/Robj`).

Some Vectors deref to mutable slices (`Rint/Rfloat/Rbool`) but not `Rstr` and `Robj` which need set_elt to work.

ExternalPtr<T> derefs to &T so we can use it like Box.

Rstr derefs to &str

We could deref Robj to &Rany - answers on a postcard.

