### PR TITLE
Add defaults to r arguments

### DIFF
--- a/extendr-api/src/metadata.rs
+++ b/extendr-api/src/metadata.rs
@@ -138,10 +138,17 @@ fn write_function_wrapper(
 
     write_doc(w, func.doc)?;
 
-    let args = func
+    let formal_args = func
         .args
         .iter()
         .map(|arg| gen_formal_arg(arg))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let actual_args = func
+        .args
+        .iter()
+        .map(|arg| sanitize_identifier(arg.name))
         .collect::<Vec<_>>()
         .join(", ");
 
@@ -150,14 +157,14 @@ fn write_function_wrapper(
             w,
             "{} <- function({}) invisible(.Call(",
             sanitize_identifier(func.name),
-            args
+            formal_args
         )?;
     } else {
         write!(
             w,
             "{} <- function({}) .Call(",
             sanitize_identifier(func.name),
-            args
+            formal_args
         )?;
     }
 
@@ -168,7 +175,7 @@ fn write_function_wrapper(
     }
 
     if !func.args.is_empty() {
-        write!(w, ", {}", args)?;
+        write!(w, ", {}", actual_args)?;
     }
 
     if !use_symbols {

--- a/extendr-api/src/metadata.rs
+++ b/extendr-api/src/metadata.rs
@@ -11,6 +11,7 @@ use std::io::Write;
 pub struct Arg {
     pub name: &'static str,
     pub arg_type: &'static str,
+    pub default: Option<&'static str>,
 }
 
 /// Metadata function.
@@ -114,6 +115,16 @@ fn sanitize_identifier(name: &str) -> String {
     }
 }
 
+// Generate an R function argument with optional default.
+fn gen_formal_arg(arg: &Arg) -> String {
+    let id = sanitize_identifier(arg.name);
+    if let Some(default) = arg.default {
+        format!("{} = {}", id, default)
+    } else {
+        id
+    }
+}
+
 /// Generate a wrapper for a non-method function.
 fn write_function_wrapper(
     w: &mut Vec<u8>,
@@ -130,7 +141,7 @@ fn write_function_wrapper(
     let args = func
         .args
         .iter()
-        .map(|arg| sanitize_identifier(arg.name))
+        .map(|arg| gen_formal_arg(arg))
         .collect::<Vec<_>>()
         .join(", ");
 

--- a/extendr-api/tests/extendr_macro.rs
+++ b/extendr-api/tests/extendr_macro.rs
@@ -160,3 +160,38 @@ fn test_call_macro() {
         assert_eq!(three, r!(3));
     }
 }
+
+#[extendr(use_try_from = true)]
+fn test_metadata_1(#[default = "NULL"] val: Robj) -> i32 {
+    if val.is_null() {
+        1
+    } else {
+        0
+    }
+}
+
+#[test]
+fn test_metadata() {
+    use extendr_api::metadata::Arg;
+    use extendr_api::metadata::Func;
+    let mut funcs: Vec<Func> = Vec::new();
+    meta__test_metadata_1(&mut funcs);
+
+    let args = vec![Arg {
+        name: "val",
+        arg_type: "Robj",
+        default: Some("NULL"),
+    }];
+
+    assert_eq!(
+        funcs[0],
+        Func {
+            doc: "",
+            name: "test_metadata_1",
+            args: args,
+            return_type: "i32",
+            func_ptr: wrap__test_metadata_1 as *const u8,
+            hidden: false,
+        }
+    );
+}

--- a/extendr-macros/src/extendr_function.rs
+++ b/extendr-macros/src/extendr_function.rs
@@ -4,7 +4,7 @@ use quote::quote;
 use syn::ItemFn;
 
 /// Generate bindings for a single function.
-pub fn extendr_function(args: Vec<syn::NestedMeta>, func: ItemFn) -> TokenStream {
+pub fn extendr_function(args: Vec<syn::NestedMeta>, mut func: ItemFn) -> TokenStream {
     let mut opts = wrappers::ExtendrOptions::default();
 
     for arg in &args {
@@ -12,7 +12,7 @@ pub fn extendr_function(args: Vec<syn::NestedMeta>, func: ItemFn) -> TokenStream
     }
 
     let mut wrappers: Vec<ItemFn> = Vec::new();
-    wrappers::make_function_wrappers(&opts, &mut wrappers, "", &func.attrs, &func.sig, None);
+    wrappers::make_function_wrappers(&opts, &mut wrappers, "", &func.attrs, &mut func.sig, None);
 
     TokenStream::from(quote! {
         #func

--- a/extendr-macros/src/extendr_impl.rs
+++ b/extendr-macros/src/extendr_impl.rs
@@ -95,7 +95,7 @@ pub fn extendr_impl(mut item_impl: ItemImpl) -> TokenStream {
                 &mut wrappers,
                 prefix.as_str(),
                 &method.attrs,
-                &method.sig,
+                &mut method.sig,
                 Some(self_ty),
             );
         }

--- a/extendr-macros/src/extendr_module.rs
+++ b/extendr-macros/src/extendr_module.rs
@@ -66,8 +66,8 @@ pub fn extendr_module(item: TokenStream) -> TokenStream {
                 doc: "Wrapper generator.",
                 name: #make_module_wrappers_name_string,
                 args: vec![
-                    extendr_api::metadata::Arg { name: "use_symbols", arg_type: "bool" },
-                    extendr_api::metadata::Arg { name: "package_name", arg_type: "&str" },
+                    extendr_api::metadata::Arg { name: "use_symbols", arg_type: "bool", default: None },
+                    extendr_api::metadata::Arg { name: "package_name", arg_type: "&str", default: None },
                     ],
                 return_type: "String",
                 func_ptr: #wrap_make_module_wrappers as * const u8,

--- a/extendr-macros/src/wrappers.rs
+++ b/extendr-macros/src/wrappers.rs
@@ -281,7 +281,10 @@ fn translate_actual(opts: &ExtendrOptions, input: &FnArg) -> Option<Expr> {
             if let syn::Pat::Ident(ref ident) = pat {
                 let varname = format_ident!("_{}_robj", ident.ident);
                 if opts.use_try_from {
-                    Some(parse_quote! { extendr_api::unwrap_or_throw_error(#varname.try_into()) })
+                    Some(parse_quote! { extendr_api::unwrap_or_throw_error(
+                        #varname.try_into()
+                        .map_err(|e| extendr_api::Error::from(e)))
+                    })
                 } else {
                     Some(parse_quote! { extendr_api::unwrap_or_throw(<#ty>::from_robj(&#varname)) })
                 }

--- a/tests/extendrtests/R/extendr-wrappers.R
+++ b/tests/extendrtests/R/extendr-wrappers.R
@@ -34,6 +34,8 @@ doubles_square <- function(input) .Call(wrap__doubles_square, input)
 
 integers_square <- function(input) .Call(wrap__integers_square, input)
 
+check_default <- function(x = NULL) .Call(wrap__check_default, x)
+
 try_rfloat_na <- function() .Call(wrap__try_rfloat_na)
 
 try_rint_na <- function() .Call(wrap__try_rint_na)

--- a/tests/extendrtests/src/rust/src/lib.rs
+++ b/tests/extendrtests/src/rust/src/lib.rs
@@ -129,6 +129,11 @@ fn integers_square(input: Integers) -> Integers {
     result
 }
 
+#[extendr(use_try_from = true)]
+fn check_default(#[default="NULL"] x: Robj) -> bool {
+    x.is_null()
+}
+
 // Parsing
 
 // Weird behavior of parameter descriptions:
@@ -244,6 +249,8 @@ extendr_module! {
 
     fn doubles_square;
     fn integers_square;
+
+    fn check_default;
 
     fn try_rfloat_na;
     fn try_rint_na;

--- a/tests/extendrtests/tests/testthat/test-wrappers.R
+++ b/tests/extendrtests/tests/testthat/test-wrappers.R
@@ -56,4 +56,6 @@ test_that("Call to Rust via wrapper functions works", {
   
   expect_equal(do_nothing(), NULL)
   expect_invisible(do_nothing())
+  expect_equal(check_default(), TRUE)
+  expect_equal(check_default("xyz"), FALSE)
 })


### PR DESCRIPTION
This PR adds the ability to set defaults to R arguments.

Example:

```rust
#[extendr] 
fn fred(#[default="NULL"] x: Option><i32>) {
}
```
Should generate R code:

```R
fred <- function(x = NULL) ...
```
