### PR TITLE
Serde Deserialize and Deserializer conversion from Robjs.

### DIFF
--- a/extendr-api/src/deserializer.rs
+++ b/extendr-api/src/deserializer.rs
@@ -192,7 +192,7 @@ impl<'de> EnumAccess<'de> for &'de Robj {
         V: DeserializeSeed<'de>,
     {
         match self.as_any() {
-            Rany::String(s) if s.len() == 1 => {
+            Rany::Strings(s) if s.len() == 1 => {
                 let variant = seed.deserialize(self)?;
                 Ok((variant, self))
             }
@@ -275,21 +275,21 @@ impl<'de> Deserializer<'de> for &'de Robj {
         let len = self.len();
         match self.as_any() {
             Rany::Null(_) => self.deserialize_unit(visitor),
-            Rany::Integer(_v) => {
+            Rany::Integers(_v) => {
                 if len == 1 {
                     self.deserialize_i32(visitor)
                 } else {
                     self.deserialize_seq(visitor)
                 }
             }
-            Rany::Real(_v) => {
+            Rany::Doubles(_v) => {
                 if len == 1 {
                     self.deserialize_f64(visitor)
                 } else {
                     self.deserialize_seq(visitor)
                 }
             }
-            Rany::Logical(_v) => {
+            Rany::Logicals(_v) => {
                 if len == 1 {
                     self.deserialize_bool(visitor)
                 } else {
@@ -297,7 +297,7 @@ impl<'de> Deserializer<'de> for &'de Robj {
                 }
             }
             Rany::List(_v) => self.deserialize_seq(visitor),
-            Rany::String(_v) => {
+            Rany::Strings(_v) => {
                 if len == 1 {
                     self.deserialize_str(visitor)
                 } else {
@@ -521,19 +521,19 @@ impl<'de> Deserializer<'de> for &'de Robj {
                 };
                 Ok(visitor.visit_seq(lg)?)
             }
-            Rany::Integer(val) => {
+            Rany::Integers(val) => {
                 let lg = SliceGetter { list: &*val };
                 Ok(visitor.visit_seq(lg)?)
             }
-            Rany::Real(val) => {
+            Rany::Doubles(val) => {
                 let lg = SliceGetter { list: &*val };
                 Ok(visitor.visit_seq(lg)?)
             }
-            Rany::Logical(val) => {
+            Rany::Logicals(val) => {
                 let lg = SliceGetter { list: &*val };
                 Ok(visitor.visit_seq(lg)?)
             }
-            Rany::String(_val) => {
+            Rany::Strings(_val) => {
                 // Grubby hack that will go away once PRs are merged.
                 // use std::convert::TryInto;
                 // let val : Strings = val.clone().try_into().unwrap();

--- a/extendr-api/src/deserializer.rs
+++ b/extendr-api/src/deserializer.rs
@@ -1,90 +1,265 @@
-
-
-use crate::robj::{Robj, Types, Length};
-use crate::{Rany, List};
+//! Convert R objects to a wide variety of types.
+//!
 use crate::error::{Error, Result};
-use serde::de::{Visitor, Deserializer, Deserialize, SeqAccess, DeserializeSeed};
+use crate::robj::{Attributes, Length, Robj, Types};
+use crate::scalar::Rint;
+use crate::wrapper::{Rstr, Strings};
+use crate::Rany;
+use serde::de::{
+    Deserialize, DeserializeSeed, Deserializer, EnumAccess, MapAccess, SeqAccess, VariantAccess,
+    Visitor,
+};
 use serde::forward_to_deserialize_any;
 use std::convert::TryFrom;
 
-struct RobjDeserializer(Robj);
-
 /// Convert any R object to a Deserialize object.
-pub fn from_robj<'a, T>(robj: Robj) -> Result<T>
+pub fn from_robj<'de, T>(robj: &'de Robj) -> Result<T>
 where
-    T: Deserialize<'a>,
+    T: Deserialize<'de>,
 {
-    let deserializer = RobjDeserializer(robj);
-    let t = T::deserialize(deserializer)?;
+    // let deserializer = RobjDeserializer(robj);
+    let t = T::deserialize(robj)?;
     Ok(t)
 }
 
+// Allow errors to popagate to extendr errors.
 impl serde::de::Error for Error {
     fn custom<T>(msg: T) -> Self
     where
-        T: std::fmt::Display
+        T: std::fmt::Display,
     {
         Error::Other(msg.to_string())
     }
 }
 
-struct ListGetter {
-    list: List,
-    elem: usize,
+// Convert unnamed lists to sequences.
+struct ListGetter<'a> {
+    list: &'a [Robj],
 }
 
-impl<'de> SeqAccess<'de> for ListGetter {
+impl<'de> SeqAccess<'de> for ListGetter<'de> {
     type Error = Error;
 
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>>
     where
         T: DeserializeSeed<'de>,
     {
-        if self.elem >= self.list.len() {
+        if self.list.is_empty() {
             Ok(None)
         } else {
-            let elem = self.elem;
-            self.elem += 1;
-            let de = RobjDeserializer(self.list.elt(elem)?);
-            seed.deserialize(de).map(Some)
+            let e = &self.list[0];
+            self.list = &self.list[1..];
+            seed.deserialize(e).map(Some)
         }
     }
 }
 
-impl<'de> Deserializer<'de> for RobjDeserializer {
+// Convert named lists to maps.
+struct NamedListGetter<'a> {
+    keys: &'a [Rstr],
+    values: &'a [Robj],
+}
+
+impl<'de> MapAccess<'de> for NamedListGetter<'de> {
+    type Error = Error;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>>
+    where
+        K: DeserializeSeed<'de>,
+    {
+        if self.keys.is_empty() {
+            Ok(None)
+        } else {
+            let e = &self.keys[0];
+            self.keys = &self.keys[1..];
+            seed.deserialize(e).map(Some)
+        }
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        let e = &self.values[0];
+        self.values = &self.values[1..];
+        seed.deserialize(e)
+    }
+}
+
+// Allow us to use Integers, Doubles and Logicals.
+struct SliceGetter<'a, E> {
+    list: &'a [E],
+}
+
+// Allow us to use Integers and Rint.
+impl<'de> Deserializer<'de> for Rint {
     type Error = Error;
 
     fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        // println!("deserialize_any robj={:?}", self.0);
-        // match self.0.as_any() {
-        //     Rany::Null(_) => visitor.visit_unit(),
-        //     Rany::Integer(val) => {
-        //         visitor.visit_i32(val.as_integer())
-        //     }
-        //     _ => Err(Error::Other(format!("unexpected {:?}", self.0.rtype()))),
-        //     // 'n' => self.deserialize_unit(visitor),
-        //     // 't' | 'f' => self.deserialize_bool(visitor),
-        //     // '"' => self.deserialize_str(visitor),
-        //     // '0'..='9' => self.deserialize_u64(visitor),
-        //     // '-' => self.deserialize_i64(visitor),
-        //     // '[' => self.deserialize_seq(visitor),
-        //     // '{' => self.deserialize_map(visitor),
-        //     // _ => Err(Error::Syntax),
-        // }
-        Err(Error::Other(format!("unexpected {:?}", self.0.rtype())))
+        unimplemented!()
+    }
+
+    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        if let Some(val) = self.into() {
+            visitor.visit_i32(val)
+        } else {
+            Err(Error::MustNotBeNA(Robj::from(())))
+        }
+    }
+
+    fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        if let Some(val) = self.into() {
+            visitor.visit_i32(val)
+        } else {
+            Err(Error::MustNotBeNA(Robj::from(())))
+        }
+    }
+
+    forward_to_deserialize_any! {
+        bool i8 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        tuple_struct map struct enum identifier ignored_any
+    }
+}
+
+// Decode identifiers from the "names" attribute of lists.
+impl<'de> Deserializer<'de> for &'de Rstr {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        unimplemented!()
+    }
+
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        return visitor.visit_borrowed_str(self.as_str());
+    }
+
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_str(visitor)
+    }
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char string
+        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        tuple_struct map struct enum ignored_any
+    }
+}
+
+// Get the variant name and content of an enum.
+impl<'de> EnumAccess<'de> for &'de Robj {
+    type Error = Error;
+    type Variant = Self;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant)>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        match self.as_any() {
+            Rany::String(s) if s.len() == 1 => {
+                let variant = seed.deserialize(self)?;
+                Ok((variant, self))
+            }
+            Rany::List(list) if list.len() == 1 => {
+                if let Some(keys) = self.get_attrib(crate::wrapper::symbol::names_symbol()) {
+                    if let Ok(keys) = Strings::try_from(keys) {
+                        let keys = keys.as_slice();
+                        let values = &list.as_slice()[0];
+                        let variant = seed.deserialize(&keys[0])?;
+                        return Ok((variant, values));
+                    }
+                }
+                Err(Error::Other("Expected named List for enum".into()))
+            }
+            _ => Err(Error::Other("Expected String or List for enum".into())),
+        }
+    }
+}
+
+// Decode enum variants of various kinds.
+impl<'de> VariantAccess<'de> for &'de Robj {
+    type Error = Error;
+
+    fn unit_variant(self) -> Result<()> {
+        Ok(())
+    }
+
+    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        seed.deserialize(self)
+    }
+
+    fn tuple_variant<V>(self, _len: usize, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        serde::de::Deserializer::deserialize_seq(self, visitor)
+    }
+
+    fn struct_variant<V>(self, _fields: &'static [&'static str], visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        serde::de::Deserializer::deserialize_map(self, visitor)
+    }
+}
+
+// Enable sequences from Integers, Doubles etc.
+impl<'de> SeqAccess<'de> for SliceGetter<'de, Rint> {
+    type Error = Error;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        if self.list.is_empty() {
+            Ok(None)
+        } else {
+            let res = seed.deserialize(self.list[0]).map(Some);
+            self.list = &self.list[1..];
+            res
+        }
+    }
+}
+
+// Given an Robj, generate a value of many kinds.
+impl<'de> Deserializer<'de> for &'de Robj {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::Other(format!("unexpected {:?}", self.rtype())))
     }
 
     fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        if let Rany::Null(_) = self.0.as_any() {
+        if let Rany::Null(_) = self.as_any() {
             visitor.visit_unit()
         } else {
-            Err(Error::ExpectedNull(self.0))
+            Err(Error::ExpectedNull(self.clone()))
         }
     }
 
@@ -92,136 +267,129 @@ impl<'de> Deserializer<'de> for RobjDeserializer {
     where
         V: Visitor<'de>,
     {
-        visitor.visit_bool(bool::try_from(self.0)?)
+        visitor.visit_bool(bool::try_from(self.clone())?)
     }
 
     fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_i8(i8::try_from(self.0)?)
+        visitor.visit_i8(i8::try_from(self.clone())?)
     }
 
     fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_i16(i16::try_from(self.0)?)
+        visitor.visit_i16(i16::try_from(self.clone())?)
     }
 
     fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_i32(i32::try_from(self.0)?)
+        visitor.visit_i32(i32::try_from(self.clone())?)
     }
 
     fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_i64(i64::try_from(self.0)?)
+        visitor.visit_i64(i64::try_from(self.clone())?)
     }
 
     fn deserialize_i128<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_i128(i64::try_from(self.0)? as i128)
+        visitor.visit_i128(i64::try_from(self.clone())? as i128)
     }
 
     fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_u8(u8::try_from(self.0)?)
+        visitor.visit_u8(u8::try_from(self.clone())?)
     }
 
     fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_u16(u16::try_from(self.0)?)
+        visitor.visit_u16(u16::try_from(self.clone())?)
     }
 
     fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_u32(u32::try_from(self.0)?)
+        visitor.visit_u32(u32::try_from(self.clone())?)
     }
 
     fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_u64(u64::try_from(self.0)?)
+        visitor.visit_u64(u64::try_from(self.clone())?)
     }
 
     fn deserialize_u128<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_u128(u64::try_from(self.0)? as u128)
+        visitor.visit_u128(u64::try_from(self.clone())? as u128)
     }
 
     fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_f32(f32::try_from(self.0)?)
+        visitor.visit_f32(f32::try_from(self.clone())?)
     }
 
     fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_f64(f64::try_from(self.0)?)
+        visitor.visit_f64(f64::try_from(self.clone())?)
     }
 
     fn deserialize_char<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        if let Some(s) = self.0.as_str() {
-            let mut c= s.chars();
-            if let Some(ch) = c.next() {
-                if c.next() == None {
-                    return visitor.visit_char(ch)
-                }
+        let s = <&str>::try_from(self.clone())?;
+        let mut c = s.chars();
+        if let Some(ch) = c.next() {
+            if c.next() == None {
+                return visitor.visit_char(ch);
             }
         }
-        Err(Error::ExpectedString(self.0))
+        Err(Error::ExpectedString(self.clone()))
     }
 
     fn deserialize_str<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        if let Some(s) = self.0.as_str() {
-            return visitor.visit_borrowed_str(s)
-        }
-        Err(Error::ExpectedString(self.0))
+        visitor.visit_borrowed_str(<&str>::try_from(self.clone())?)
     }
 
     fn deserialize_string<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        if let Some(s) = self.0.as_str() {
-            return visitor.visit_string(s.into())
-        }
-        Err(Error::ExpectedString(self.0))
+        visitor.visit_string(<&str>::try_from(self.clone())?.into())
     }
-    
+
     fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        if let Rany::Raw(val) = self.0.as_any() {
+        if let Rany::Raw(val) = self.as_any() {
             visitor.visit_bytes(val.as_slice())
         } else {
-            Err(Error::ExpectedRaw(self.0))
+            Err(Error::ExpectedRaw(self.clone()))
         }
     }
 
@@ -229,10 +397,10 @@ impl<'de> Deserializer<'de> for RobjDeserializer {
     where
         V: Visitor<'de>,
     {
-        if let Rany::Raw(val) = self.0.as_any() {
+        if let Rany::Raw(val) = self.as_any() {
             visitor.visit_byte_buf(val.as_slice().to_owned())
         } else {
-            Err(Error::ExpectedRaw(self.0))
+            Err(Error::ExpectedRaw(self.clone()))
         }
     }
 
@@ -240,9 +408,10 @@ impl<'de> Deserializer<'de> for RobjDeserializer {
     where
         V: Visitor<'de>,
     {
-        if let Rany::Null(_) = self.0.as_any() {
+        #![allow(clippy::if_same_then_else)]
+        if let Rany::Null(_) = self.as_any() {
             visitor.visit_none()
-        } else if self.0.is_na() {
+        } else if self.is_na() {
             visitor.visit_none()
         } else {
             visitor.visit_some(self)
@@ -270,21 +439,94 @@ impl<'de> Deserializer<'de> for RobjDeserializer {
         self.deserialize_seq(visitor)
     }
 
+    fn deserialize_tuple_struct<V>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_seq(visitor)
+    }
+
     fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        match self.0.as_any() {
+        match self.as_any() {
             Rany::List(val) => {
-                let lg = ListGetter { list: val.clone(), elem: 0 };
+                let lg = ListGetter {
+                    list: val.as_slice(),
+                };
                 Ok(visitor.visit_seq(lg)?)
             }
-            _ => Err(Error::ExpectedList(self.0))
+            Rany::Integer(val) => {
+                let lg = SliceGetter { list: &*val };
+                Ok(visitor.visit_seq(lg)?)
+            }
+            _ => Err(Error::ExpectedList(self.clone())),
         }
     }
 
-    forward_to_deserialize_any! {
-        tuple_struct map struct enum identifier ignored_any
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        match self.as_any() {
+            Rany::List(val) => {
+                if let Some(keys) = self.get_attrib(crate::wrapper::symbol::names_symbol()) {
+                    if let Ok(keys) = Strings::try_from(keys) {
+                        let keys = keys.as_slice();
+                        let lg = NamedListGetter {
+                            keys,
+                            values: val.as_slice(),
+                        };
+                        return visitor.visit_map(lg);
+                    }
+                }
+                Err(Error::ExpectedList(self.clone()))
+            }
+            _ => Err(Error::ExpectedList(self.clone())),
+        }
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_map(visitor)
+    }
+
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_str(visitor)
+    }
+
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_any(visitor)
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_enum(self)
     }
 }
-

--- a/extendr-api/src/deserializer.rs
+++ b/extendr-api/src/deserializer.rs
@@ -1,0 +1,290 @@
+
+
+use crate::robj::{Robj, Types, Length};
+use crate::{Rany, List};
+use crate::error::{Error, Result};
+use serde::de::{Visitor, Deserializer, Deserialize, SeqAccess, DeserializeSeed};
+use serde::forward_to_deserialize_any;
+use std::convert::TryFrom;
+
+struct RobjDeserializer(Robj);
+
+/// Convert any R object to a Deserialize object.
+pub fn from_robj<'a, T>(robj: Robj) -> Result<T>
+where
+    T: Deserialize<'a>,
+{
+    let deserializer = RobjDeserializer(robj);
+    let t = T::deserialize(deserializer)?;
+    Ok(t)
+}
+
+impl serde::de::Error for Error {
+    fn custom<T>(msg: T) -> Self
+    where
+        T: std::fmt::Display
+    {
+        Error::Other(msg.to_string())
+    }
+}
+
+struct ListGetter {
+    list: List,
+    elem: usize,
+}
+
+impl<'de> SeqAccess<'de> for ListGetter {
+    type Error = Error;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        if self.elem >= self.list.len() {
+            Ok(None)
+        } else {
+            let elem = self.elem;
+            self.elem += 1;
+            let de = RobjDeserializer(self.list.elt(elem)?);
+            seed.deserialize(de).map(Some)
+        }
+    }
+}
+
+impl<'de> Deserializer<'de> for RobjDeserializer {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        // println!("deserialize_any robj={:?}", self.0);
+        // match self.0.as_any() {
+        //     Rany::Null(_) => visitor.visit_unit(),
+        //     Rany::Integer(val) => {
+        //         visitor.visit_i32(val.as_integer())
+        //     }
+        //     _ => Err(Error::Other(format!("unexpected {:?}", self.0.rtype()))),
+        //     // 'n' => self.deserialize_unit(visitor),
+        //     // 't' | 'f' => self.deserialize_bool(visitor),
+        //     // '"' => self.deserialize_str(visitor),
+        //     // '0'..='9' => self.deserialize_u64(visitor),
+        //     // '-' => self.deserialize_i64(visitor),
+        //     // '[' => self.deserialize_seq(visitor),
+        //     // '{' => self.deserialize_map(visitor),
+        //     // _ => Err(Error::Syntax),
+        // }
+        Err(Error::Other(format!("unexpected {:?}", self.0.rtype())))
+    }
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        if let Rany::Null(_) = self.0.as_any() {
+            visitor.visit_unit()
+        } else {
+            Err(Error::ExpectedNull(self.0))
+        }
+    }
+
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_bool(bool::try_from(self.0)?)
+    }
+
+    fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_i8(i8::try_from(self.0)?)
+    }
+
+    fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_i16(i16::try_from(self.0)?)
+    }
+
+    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_i32(i32::try_from(self.0)?)
+    }
+
+    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_i64(i64::try_from(self.0)?)
+    }
+
+    fn deserialize_i128<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_i128(i64::try_from(self.0)? as i128)
+    }
+
+    fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_u8(u8::try_from(self.0)?)
+    }
+
+    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_u16(u16::try_from(self.0)?)
+    }
+
+    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_u32(u32::try_from(self.0)?)
+    }
+
+    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_u64(u64::try_from(self.0)?)
+    }
+
+    fn deserialize_u128<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_u128(u64::try_from(self.0)? as u128)
+    }
+
+    fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_f32(f32::try_from(self.0)?)
+    }
+
+    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_f64(f64::try_from(self.0)?)
+    }
+
+    fn deserialize_char<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        if let Some(s) = self.0.as_str() {
+            let mut c= s.chars();
+            if let Some(ch) = c.next() {
+                if c.next() == None {
+                    return visitor.visit_char(ch)
+                }
+            }
+        }
+        Err(Error::ExpectedString(self.0))
+    }
+
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        if let Some(s) = self.0.as_str() {
+            return visitor.visit_borrowed_str(s)
+        }
+        Err(Error::ExpectedString(self.0))
+    }
+
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        if let Some(s) = self.0.as_str() {
+            return visitor.visit_string(s.into())
+        }
+        Err(Error::ExpectedString(self.0))
+    }
+    
+    fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        if let Rany::Raw(val) = self.0.as_any() {
+            visitor.visit_bytes(val.as_slice())
+        } else {
+            Err(Error::ExpectedRaw(self.0))
+        }
+    }
+
+    fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        if let Rany::Raw(val) = self.0.as_any() {
+            visitor.visit_byte_buf(val.as_slice().to_owned())
+        } else {
+            Err(Error::ExpectedRaw(self.0))
+        }
+    }
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        if let Rany::Null(_) = self.0.as_any() {
+            visitor.visit_none()
+        } else if self.0.is_na() {
+            visitor.visit_none()
+        } else {
+            visitor.visit_some(self)
+        }
+    }
+
+    fn deserialize_unit_struct<V>(self, _name: &str, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_unit(visitor)
+    }
+
+    fn deserialize_newtype_struct<V>(self, _name: &str, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        match self.0.as_any() {
+            Rany::List(val) => {
+                let lg = ListGetter { list: val.clone(), elem: 0 };
+                Ok(visitor.visit_seq(lg)?)
+            }
+            _ => Err(Error::ExpectedList(self.0))
+        }
+    }
+
+    forward_to_deserialize_any! {
+        tuple_struct map struct enum identifier ignored_any
+    }
+}
+

--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -235,6 +235,9 @@ pub mod rmacros;
 #[cfg(feature = "serde")]
 pub mod serializer;
 
+#[cfg(feature = "serde")]
+pub mod deserializer;
+
 pub mod graphics;
 pub mod robj;
 pub mod scalar;

--- a/extendr-api/src/serializer.rs
+++ b/extendr-api/src/serializer.rs
@@ -1,10 +1,11 @@
 //! See https://serde.rs/impl-serializer.html
 
 use crate::error::{Error, Result};
-use crate::robj::{AsStrIter, GetSexp, Length, Rinternals, Types};
+use crate::na::CanBeNA;
+use crate::robj::{Attributes, GetSexp, Length, Rinternals, Types};
 use crate::scalar::{Rbool, Rfloat, Rint};
-use crate::{
-    Doubles, Environment, Expression, Function, Integers, Language, Logicals, Pairlist, Primitive,
+use crate::wrapper::{
+    Doubles, Environment, Expressions, Function, Integers, Language, Logicals, Pairlist, Primitive,
     Promise, Raw, Rstr, Symbol, S4,
 };
 use crate::{List, Rany, Robj};
@@ -679,45 +680,6 @@ impl ser::Serialize for Rstr {
             serializer.serialize_unit()
         } else {
             serializer.serialize_str(self.as_str())
-        }
-    }
-}
-
-impl ser::Serialize for Rint {
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        if self.is_na() {
-            serializer.serialize_unit()
-        } else {
-            serializer.serialize_i32(self.inner())
-        }
-    }
-}
-
-impl ser::Serialize for Rfloat {
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        if self.is_na() {
-            serializer.serialize_unit()
-        } else {
-            serializer.serialize_f64(self.inner())
-        }
-    }
-}
-
-impl ser::Serialize for Rbool {
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        if self.is_na() {
-            serializer.serialize_unit()
-        } else {
-            serializer.serialize_bool(self.is_true())
         }
     }
 }

--- a/extendr-api/src/wrapper/strings.rs
+++ b/extendr-api/src/wrapper/strings.rs
@@ -60,7 +60,7 @@ impl Strings {
     }
 
     /// This is a relatively expensive operation, so use a variable if using this in a loop.
-    pub fn as_slice(&self) -> &[Rstr] {
+    pub fn as_slice<'a>(&self) -> &'a [Rstr] {
         unsafe {
             let data = STRING_PTR_RO(self.robj.get()) as *const Rstr;
             let len = self.robj.len();

--- a/extendr-api/tests/deserializer_tests.rs
+++ b/extendr-api/tests/deserializer_tests.rs
@@ -126,6 +126,19 @@ mod test {
             let j = r!(list!(Struct=list!(a=1)));
             let expected = Enum::Struct { a: 1 };
             assert_eq!(expected, from_robj(&j).unwrap());
+
+            // Many things will generate a Robj.
+            // But note that the original Robj will not be copied verbatim.
+            // The Deserialize trait for Robj can also be used to generate
+            // JSON and other formats for Robj.
+            #[derive(Deserialize, PartialEq, Debug)]
+            struct ROBJ(Robj);
+            assert_eq!(from_robj::<ROBJ>(&r!(TRUE)), Ok(ROBJ(r!(TRUE))));
+            assert_eq!(from_robj::<ROBJ>(&r!(1)), Ok(ROBJ(r!(1))));
+            assert_eq!(from_robj::<ROBJ>(&r!(1.0)), Ok(ROBJ(r!(1.0))));
+            assert_eq!(from_robj::<ROBJ>(&r!("xyz")), Ok(ROBJ(r!("xyz"))));
+
+            // assert_eq!(from_robj::<ROBJ>(&r!([TRUE, FALSE])), Ok(ROBJ(r!([TRUE, FALSE]))));
         }
     }
 }

--- a/extendr-api/tests/deserializer_tests.rs
+++ b/extendr-api/tests/deserializer_tests.rs
@@ -5,10 +5,19 @@ mod test {
     use serde::Deserialize;
 
     ////////////////////////////////////////////////////////////////////////////////
-
+    ///
+    /// Deserialize from a Robj.
+    /// 
+    /// Like JSON, we can use a Robj as a storage format.
+    /// 
+    /// For example if creating vectors from a RDS file or returning a structure.
+    /// 
     #[test]
     fn test_deserialize_robj() {
         test! {
+            // In these tests, the wrapper is transparent and just tests the contents.
+            // So Int(i32) is actually testing i32.
+
             #[derive(Deserialize, PartialEq, Debug)]
             struct Null;
             assert_eq!(from_robj::<Null>(r!(NULL)), Ok(Null));
@@ -23,6 +32,14 @@ mod test {
             #[derive(Deserialize, PartialEq, Debug)]
             struct VInt(Vec<i32>);
             assert_eq!(from_robj::<VInt>(r!(list!(1, 2))), Ok(VInt(vec![1, 2])));
+
+            #[derive(Deserialize, PartialEq, Debug)]
+            struct Str(String);
+            assert_eq!(from_robj::<Str>(r!("xyz")), Ok(Str("xyz".into())));
+
+            #[derive(Deserialize, PartialEq, Debug)]
+            struct StrSlice<'a>(&'a str);
+            assert_eq!(from_robj::<StrSlice>(r!("xyz")), Ok(StrSlice("xyz")));
         }
     }
 }

--- a/extendr-api/tests/deserializer_tests.rs
+++ b/extendr-api/tests/deserializer_tests.rs
@@ -1,0 +1,28 @@
+#[cfg(feature = "serde")]
+mod test {
+    use extendr_api::prelude::*;
+    use extendr_api::deserializer::from_robj;
+    use serde::Deserialize;
+
+    ////////////////////////////////////////////////////////////////////////////////
+
+    #[test]
+    fn test_deserialize_robj() {
+        test! {
+            #[derive(Deserialize, PartialEq, Debug)]
+            struct Null;
+            assert_eq!(from_robj::<Null>(r!(NULL)), Ok(Null));
+            assert_eq!(from_robj::<Null>(r!(1)), Err(Error::ExpectedNull(r!(1))));
+
+            #[derive(Deserialize, PartialEq, Debug)]
+            struct Int(i32);
+            assert_eq!(from_robj::<Int>(r!(1)), Ok(Int(1)));
+            assert_eq!(from_robj::<Int>(r!(1.0)), Ok(Int(1)));
+            assert_eq!(from_robj::<Int>(r!(NULL)), Err(Error::ExpectedNonZeroLength(r!(NULL))));
+
+            #[derive(Deserialize, PartialEq, Debug)]
+            struct VInt(Vec<i32>);
+            assert_eq!(from_robj::<VInt>(r!(list!(1, 2))), Ok(VInt(vec![1, 2])));
+        }
+    }
+}

--- a/extendr-api/tests/deserializer_tests.rs
+++ b/extendr-api/tests/deserializer_tests.rs
@@ -1,17 +1,17 @@
 #[cfg(feature = "serde")]
 mod test {
-    use extendr_api::prelude::*;
     use extendr_api::deserializer::from_robj;
+    use extendr_api::prelude::*;
     use serde::Deserialize;
 
     ////////////////////////////////////////////////////////////////////////////////
     ///
     /// Deserialize from a Robj.
-    /// 
+    ///
     /// Like JSON, we can use a Robj as a storage format.
-    /// 
+    ///
     /// For example if creating vectors from a RDS file or returning a structure.
-    /// 
+    ///
     #[test]
     fn test_deserialize_robj() {
         test! {
@@ -20,26 +20,68 @@ mod test {
 
             #[derive(Deserialize, PartialEq, Debug)]
             struct Null;
-            assert_eq!(from_robj::<Null>(r!(NULL)), Ok(Null));
-            assert_eq!(from_robj::<Null>(r!(1)), Err(Error::ExpectedNull(r!(1))));
+            assert_eq!(from_robj::<Null>(&r!(NULL)), Ok(Null));
+            assert_eq!(from_robj::<Null>(&r!(1)), Err(Error::ExpectedNull(r!(1))));
 
             #[derive(Deserialize, PartialEq, Debug)]
             struct Int(i32);
-            assert_eq!(from_robj::<Int>(r!(1)), Ok(Int(1)));
-            assert_eq!(from_robj::<Int>(r!(1.0)), Ok(Int(1)));
-            assert_eq!(from_robj::<Int>(r!(NULL)), Err(Error::ExpectedNonZeroLength(r!(NULL))));
+            assert_eq!(from_robj::<Int>(&r!(1)), Ok(Int(1)));
+            assert_eq!(from_robj::<Int>(&r!(1.0)), Ok(Int(1)));
+            assert_eq!(from_robj::<Int>(&r!(NULL)), Err(Error::ExpectedNonZeroLength(r!(NULL))));
+
+            #[derive(Deserialize, PartialEq, Debug)]
+            struct Float(f64);
+            assert_eq!(from_robj::<Float>(&r!(1)), Ok(Float(1.0)));
+            assert_eq!(from_robj::<Float>(&r!(1.0)), Ok(Float(1.0)));
+            assert_eq!(from_robj::<Float>(&r!(NULL)), Err(Error::ExpectedNonZeroLength(r!(NULL))));
 
             #[derive(Deserialize, PartialEq, Debug)]
             struct VInt(Vec<i32>);
-            assert_eq!(from_robj::<VInt>(r!(list!(1, 2))), Ok(VInt(vec![1, 2])));
+            assert_eq!(from_robj::<VInt>(&r!(list!(1, 2))), Ok(VInt(vec![1, 2])));
+            assert_eq!(from_robj::<VInt>(&r!([1, 2])), Ok(VInt(vec![1, 2])));
+
+            #[derive(Deserialize, PartialEq, Debug)]
+            struct VInt16(Vec<i16>);
+            assert_eq!(from_robj::<VInt16>(&r!(list!(1, 2))), Ok(VInt16(vec![1, 2])));
+            assert_eq!(from_robj::<VInt16>(&r!([1, 2])), Ok(VInt16(vec![1, 2])));
 
             #[derive(Deserialize, PartialEq, Debug)]
             struct Str(String);
-            assert_eq!(from_robj::<Str>(r!("xyz")), Ok(Str("xyz".into())));
+            assert_eq!(from_robj::<Str>(&r!("xyz")), Ok(Str("xyz".into())));
 
             #[derive(Deserialize, PartialEq, Debug)]
             struct StrSlice<'a>(&'a str);
-            assert_eq!(from_robj::<StrSlice>(r!("xyz")), Ok(StrSlice("xyz")));
+            assert_eq!(from_robj::<StrSlice>(&r!("xyz")), Ok(StrSlice("xyz")));
+
+            // Structs are mapped to named lists.
+            #[derive(Deserialize, PartialEq, Debug)]
+            struct Struct { a: i32, b: f64 }
+            assert_eq!(from_robj::<Struct>(&r!(list!(a=1, b=2))), Ok(Struct{ a: 1, b: 2.0 }));
+
+            // Enums are mapped to named lists of lists.
+            #[derive(Deserialize, PartialEq, Debug)]
+            enum Enum {
+                Unit,
+                Newtype(u32),
+                Tuple(u32, u32),
+                Struct { a: u32 },
+            }
+
+            let j = r!("Unit");
+            let expected = Enum::Unit;
+            assert_eq!(expected, from_robj(&j).unwrap());
+
+            let j = r!(list!(Newtype=1));
+            let expected = Enum::Newtype(1);
+            assert_eq!(expected, from_robj(&j).unwrap());
+
+            let j = r!(list!(Tuple=list!(1,2)));
+            let expected = Enum::Tuple(1, 2);
+            assert_eq!(expected, from_robj(&j).unwrap());
+
+            let j = r!(list!(Struct=list!(a=1)));
+            let expected = Enum::Struct { a: 1 };
+            assert_eq!(expected, from_robj(&j).unwrap());
         }
     }
 }

--- a/extendr-api/tests/deserializer_tests.rs
+++ b/extendr-api/tests/deserializer_tests.rs
@@ -27,23 +27,62 @@ mod test {
             struct Int(i32);
             assert_eq!(from_robj::<Int>(&r!(1)), Ok(Int(1)));
             assert_eq!(from_robj::<Int>(&r!(1.0)), Ok(Int(1)));
-            assert_eq!(from_robj::<Int>(&r!(NULL)), Err(Error::ExpectedNonZeroLength(r!(NULL))));
+            assert_eq!(from_robj::<Int>(&r!(NULL)).is_err(), true);
+
+            #[derive(Deserialize, PartialEq, Debug)]
+            struct RInt(Rint);
+            assert_eq!(from_robj::<RInt>(&r!(1)), Ok(RInt(1.into())));
+            assert_eq!(from_robj::<RInt>(&r!(1.0)), Ok(RInt(1.into())));
+            assert_eq!(from_robj::<RInt>(&r!(Rint::na())).is_err(), true);
+            assert_eq!(from_robj::<RInt>(&r!(NULL)).is_err(), true);
 
             #[derive(Deserialize, PartialEq, Debug)]
             struct Float(f64);
             assert_eq!(from_robj::<Float>(&r!(1)), Ok(Float(1.0)));
             assert_eq!(from_robj::<Float>(&r!(1.0)), Ok(Float(1.0)));
-            assert_eq!(from_robj::<Float>(&r!(NULL)), Err(Error::ExpectedNonZeroLength(r!(NULL))));
+            assert_eq!(from_robj::<Float>(&r!(NULL)).is_err(), true);
+
+            #[derive(Deserialize, PartialEq, Debug)]
+            struct RFloat(Rfloat);
+            assert_eq!(from_robj::<RFloat>(&r!(1)), Ok(RFloat(1.0.into())));
+            assert_eq!(from_robj::<RFloat>(&r!(1.0)), Ok(RFloat(1.0.into())));
+            assert_eq!(from_robj::<RFloat>(&r!(Rfloat::na())).is_err(), true);
+            assert_eq!(from_robj::<RFloat>(&r!(NULL)).is_err(), true);
+
+            #[derive(Deserialize, PartialEq, Debug)]
+            struct Bool(bool);
+            assert_eq!(from_robj::<Bool>(&r!(TRUE)), Ok(Bool(true)));
+            assert_eq!(from_robj::<Bool>(&r!(FALSE)), Ok(Bool(false)));
+            assert_eq!(from_robj::<Bool>(&r!(NULL)).is_err(), true);
+
+            #[derive(Deserialize, PartialEq, Debug)]
+            struct RBool(Rbool);
+            assert_eq!(from_robj::<RBool>(&r!(TRUE)), Ok(RBool(TRUE)));
+            assert_eq!(from_robj::<RBool>(&r!(FALSE)), Ok(RBool(FALSE)));
+            assert_eq!(from_robj::<RBool>(&r!(Rbool::na())).is_err(), true);
+            assert_eq!(from_robj::<RBool>(&r!(NULL)).is_err(), true);
 
             #[derive(Deserialize, PartialEq, Debug)]
             struct VInt(Vec<i32>);
             assert_eq!(from_robj::<VInt>(&r!(list!(1, 2))), Ok(VInt(vec![1, 2])));
             assert_eq!(from_robj::<VInt>(&r!([1, 2])), Ok(VInt(vec![1, 2])));
+            assert_eq!(from_robj::<VInt>(&r!([1, 2, i32::na()])).is_err(), true);
 
+            // Any integer type will do.
             #[derive(Deserialize, PartialEq, Debug)]
             struct VInt16(Vec<i16>);
             assert_eq!(from_robj::<VInt16>(&r!(list!(1, 2))), Ok(VInt16(vec![1, 2])));
             assert_eq!(from_robj::<VInt16>(&r!([1, 2])), Ok(VInt16(vec![1, 2])));
+
+            #[derive(Deserialize, PartialEq, Debug)]
+            struct VFloat64(Vec<f64>);
+            assert_eq!(from_robj::<VFloat64>(&r!(list!(1, 2))), Ok(VFloat64(vec![1., 2.])));
+            assert_eq!(from_robj::<VFloat64>(&r!([1, 2])), Ok(VFloat64(vec![1., 2.])));
+
+            #[derive(Deserialize, PartialEq, Debug)]
+            struct VBool(Vec<bool>);
+            assert_eq!(from_robj::<VBool>(&r!(list!(TRUE, FALSE))), Ok(VBool(vec![true, false])));
+            assert_eq!(from_robj::<VBool>(&r!([TRUE, FALSE])), Ok(VBool(vec![true, false])));
 
             #[derive(Deserialize, PartialEq, Debug)]
             struct Str(String);
@@ -75,7 +114,7 @@ mod test {
             let expected = Enum::Newtype(1);
             assert_eq!(expected, from_robj(&j).unwrap());
 
-            let j = r!(list!(Tuple=list!(1,2)));
+            let j = r!(list!(Tuple=list!(1, 2)));
             let expected = Enum::Tuple(1, 2);
             assert_eq!(expected, from_robj(&j).unwrap());
 

--- a/extendr-api/tests/deserializer_tests.rs
+++ b/extendr-api/tests/deserializer_tests.rs
@@ -10,7 +10,8 @@ mod test {
     ///
     /// Like JSON, we can use a Robj as a storage format.
     ///
-    /// For example if creating vectors from a RDS file or returning a structure.
+    /// For example if creating vectors from a RDS file or returning a structure
+    /// or just doing a conversion.
     ///
     #[test]
     fn test_deserialize_robj() {
@@ -109,6 +110,10 @@ mod test {
             let j = r!("Unit");
             let expected = Enum::Unit;
             assert_eq!(expected, from_robj(&j).unwrap());
+
+            // If the name is wrong:
+            let j = r!("UnitX");
+            assert_eq!(from_robj::<Enum>(&j).is_err(), true);
 
             let j = r!(list!(Newtype=1));
             let expected = Enum::Newtype(1);

--- a/extendr-api/tests/deserializer_tests.rs
+++ b/extendr-api/tests/deserializer_tests.rs
@@ -138,7 +138,37 @@ mod test {
             assert_eq!(from_robj::<ROBJ>(&r!(1.0)), Ok(ROBJ(r!(1.0))));
             assert_eq!(from_robj::<ROBJ>(&r!("xyz")), Ok(ROBJ(r!("xyz"))));
 
-            // assert_eq!(from_robj::<ROBJ>(&r!([TRUE, FALSE])), Ok(ROBJ(r!([TRUE, FALSE]))));
+            // Sequences are always converted to lists.
+            assert_eq!(from_robj::<ROBJ>(&r!([TRUE, FALSE])), Ok(ROBJ(r!(list!(TRUE, FALSE)))));
+            assert_eq!(from_robj::<ROBJ>(&r!([1, 2])), Ok(ROBJ(r!(list!(1, 2)))));
+
+            // If you use a wrapper type, conversions are more specific.
+            #[derive(Deserialize, PartialEq, Debug)]
+            struct RIntegers(Integers);
+            assert_eq!(from_robj::<RIntegers>(&r!(1)), Ok(RIntegers(Integers::from_values([1]))));
+            assert_eq!(from_robj::<RIntegers>(&r!([1, 2])), Ok(RIntegers(Integers::from_values([1, 2]))));
+            assert_eq!(from_robj::<RIntegers>(&r!(1.0)).is_err(), true);
+            assert_eq!(from_robj::<RIntegers>(&r!("xyz")).is_err(), true);
+
+            #[derive(Deserialize, PartialEq, Debug)]
+            struct RDoubles(Doubles);
+            assert_eq!(from_robj::<RDoubles>(&r!(1)), Ok(RDoubles(Doubles::from_values([1.0]))));
+            // assert_eq!(from_robj::<RDoubles>(&r!([1, 2])), Ok(RDoubles(Doubles::from_values([1.0, 2.0]))));
+            assert_eq!(from_robj::<RDoubles>(&r!([1.0, 2.0])), Ok(RDoubles(Doubles::from_values([1.0, 2.0]))));
+            assert_eq!(from_robj::<RDoubles>(&r!("xyz")).is_err(), true);
+
+            #[derive(Deserialize, PartialEq, Debug)]
+            struct RLogicals(Logicals);
+            assert_eq!(from_robj::<RLogicals>(&r!(TRUE)), Ok(RLogicals(Logicals::from_values([TRUE]))));
+            assert_eq!(from_robj::<RLogicals>(&r!([TRUE, FALSE, NA_LOGICAL])), Ok(RLogicals(Logicals::from_values([TRUE, FALSE, NA_LOGICAL]))));
+            assert_eq!(from_robj::<RLogicals>(&r!("xyz")).is_err(), true);
+
+            // This requires a PR that is not yet merged.
+            // #[derive(Deserialize, PartialEq, Debug)]
+            // struct RStrings(Strings);
+            // assert_eq!(from_robj::<RStrings>(&r!("xyz")), Ok(RStrings(Strings::from_values(["xyz"]))));
+            // assert_eq!(from_robj::<RStrings>(&r!(["a", "b"])), Ok(RStrings(Strings::from_values(["a", "b"]))));
+            // assert_eq!(from_robj::<RStrings>(&r!(0)).is_err(), true);
         }
     }
 }

--- a/extendr-api/tests/serializer_tests.rs
+++ b/extendr-api/tests/serializer_tests.rs
@@ -99,6 +99,8 @@ mod test {
             let expected = r!(list![1.0, 2.0]);
             assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
 
+            // BUG! Will probably be fixed by "better-debug"
+            //
             // #[derive(Serialize)]
             // struct List1(List);
             // let s = List1(list!(a=1, b=2));

--- a/extendr-api/tests/serializer_tests.rs
+++ b/extendr-api/tests/serializer_tests.rs
@@ -10,9 +10,9 @@ mod test {
     fn test_serialize_struct() {
         test! {
             #[derive(Serialize)]
-            struct Test {
+            struct Test<'a> {
                 int: i32,
-                seq: Vec<&'static str>,
+                seq: Vec<&'a str>,
             }
 
             let test = Test {
@@ -37,7 +37,7 @@ mod test {
             }
 
             let u = E::Unit;
-            let expected = list!(Unit=NULL);
+            let expected = r!("Unit");
             assert_eq!(to_robj(&u).unwrap(), r!(expected));
 
             let n = E::Newtype(1);
@@ -57,50 +57,101 @@ mod test {
     #[test]
     fn test_serialize_robj() {
         test! {
-            let s = r!(());
-            assert_eq!(to_robj(&s).unwrap(), r!(()));
-            let s = r!(sym!(xyz));
-            assert_eq!(to_robj(&s).unwrap(), r!("xyz"));
-            let s = r!(pairlist!(x=1, y=2));
-            assert_eq!(to_robj(&s).unwrap(), r!(list!(x=1, y=2)));
-            let s = R!("function (x) 1").unwrap();
-            assert_eq!(to_robj(&s).unwrap(), r!(()));
-            let s = r!(Environment::new_with_parent(global_env()));
-            assert_eq!(to_robj(&s).unwrap(), r!(()));
-            let s = r!(Promise::from_parts(r!(()), global_env()));
-            assert_eq!(to_robj(&s).unwrap(), r!(()));
-            let s = r!(Language::from_values([r!(())]));
-            assert_eq!(to_robj(&s).unwrap(), r!(()));
-            let s = r!(Primitive::from_string("+"));
-            assert_eq!(to_robj(&s).unwrap(), r!(".Primitive(\"+\")"));
-            let s = r!(Primitive::from_string("if"));
-            assert_eq!(to_robj(&s).unwrap(), r!(".Primitive(\"if\")"));
-            let s = r!(Rstr::from_string("xyz"));
-            assert_eq!(to_robj(&s).unwrap(), r!("xyz"));
-            let s = r!([TRUE, FALSE, NA_LOGICAL]);
-            assert_eq!(to_robj(&s).unwrap(), r!(list!(TRUE, FALSE, ())));
-            let s = r!([1, 2, 3]);
-            assert_eq!(to_robj(&s).unwrap(), r!(list![1, 2, 3]));
-            let s = r!([1., 2., 3.]);
-            assert_eq!(to_robj(&s).unwrap(), r!(list![1., 2., 3.]));
-            // Rany::Complexes(_complex) => serializer.serialize_unit(),
-            let s = r!(["1", "2", "3"]);
-            assert_eq!(to_robj(&s).unwrap(), r!(list!["1", "2", "3"]));
-            // Rany::Dot(_dot) => serializer.serialize_unit(),
-            // Rany::Any(_any) => serializer.serialize_unit(),
-            let s = r!(list![1, 2., "3"]);
-            assert_eq!(to_robj(&s).unwrap(), r!(list![1, 2., "3"]));
-            let s = r!(list![a=1, b=2., c="3"]);
-            assert_eq!(to_robj(&s).unwrap(), r!(list![a=1, b=2., c="3"]));
-            let s = r!(parse("1 + 2"));
-            assert_eq!(to_robj(&s).unwrap(), r!("expression(1 + 2)"));
-            // Rany::Bytecode(_bytecode) => serializer.serialize_unit(),
-            // Rany::ExternalPtr(_externalptr) => serializer.serialize_unit(),
-            // Rany::WeakRef(_weakref) => serializer.serialize_unit(),
-            let s = r!(Raw::from_bytes(&[1, 2, 3]));
-            assert_eq!(to_robj(&s).unwrap(), r!(Raw::from_bytes(&[1, 2, 3])));
-            // Rany::S4(value) => value.serialize(serializer),
-            // Rany::Unknown(_unknown) => serializer.serialize_unit(),
+            #[derive(Serialize)]
+            struct Null(Robj);
+            let s = Null(r!(NULL));
+            let expected = r!(NULL);
+            assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+
+            #[derive(Serialize)]
+            struct Sym(Symbol);
+            let s = Sym(sym!(xyz).try_into()?);
+            let expected = r!("xyz");
+            assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+
+            #[derive(Serialize)]
+            struct Plist(Pairlist);
+            let s = Plist(pairlist!(a=1, b=2));
+            let expected = list!(a=1, b=2);
+            assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+
+            #[derive(Serialize)]
+            struct Rstr1(Rstr);
+            let s = Rstr1(Rstr::from("xyz"));
+            let expected = r!("xyz");
+            assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+
+            #[derive(Serialize)]
+            struct Int(Integers);
+            let s = Int(Integers::from_values([1]));
+            let expected = r!(1);
+            assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+
+            #[derive(Serialize)]
+            struct Int2(Integers);
+            let s = Int2(Integers::from_values([1, 2]));
+            let expected = r!(list![1, 2]);
+            assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+
+            #[derive(Serialize)]
+            struct Dbl2(Doubles);
+            let s = Dbl2(Doubles::from_values([1.0, 2.0]));
+            let expected = r!(list![1.0, 2.0]);
+            assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+
+            // #[derive(Serialize)]
+            // struct List1(List);
+            // let s = List1(list!(a=1, b=2));
+            // let expected = r!(list!(a=1, b=2));
+            // assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+
+            // #[derive(Serialize)]
+            // struct List2(List);
+            // let s = List2(list!(1, 2));
+            // let expected = r!(list!(1, 2));
+            // assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+
+            #[derive(Serialize)]
+            struct Raw1(Raw);
+            let s = Raw1(Raw::from_bytes(&[1, 2, 3]));
+            let expected = r!(Raw::from_bytes(&[1, 2, 3]));
+            assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+
+            #[derive(Serialize)]
+            struct Rint1(Rint);
+            let s = Rint1(Rint::from(1));
+            let expected = r!(1);
+            assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+
+            #[derive(Serialize)]
+            struct Rint2(Rint);
+            let s = Rint2(Rint::na());
+            let expected = r!(());
+            assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+
+            #[derive(Serialize)]
+            struct Rfloat1(Rfloat);
+            let s = Rfloat1(Rfloat::from(1.0));
+            let expected = r!(1.0);
+            assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+
+            #[derive(Serialize)]
+            struct Rfloat2(Rfloat);
+            let s = Rfloat2(Rfloat::na());
+            let expected = r!(());
+            assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+
+            #[derive(Serialize)]
+            struct Rbool1(Rbool);
+            let s = Rbool1(Rbool::from(true));
+            let expected = r!(true);
+            assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+
+            #[derive(Serialize)]
+            struct Rbool2(Rbool);
+            let s = Rbool2(Rbool::na());
+            let expected = r!(());
+            assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
         }
     }
 }


### PR DESCRIPTION
This PR adds Deserialize and Deserializer for Robjs.

This enables any objects declared with `#[derive(Deserialize)]` to be converted
from a Robj.

We can also make an Robj from JSON and other formats.

This is the counterpoint for Serialize and Serializer.

Example:

```
            #[derive(Deserialize, PartialEq, Debug)]
            struct Struct {
               a: i32,
               b: f64
            }
            assert_eq!(from_robj::<Struct>(&r!(list!(a=1, b=2))), Ok(Struct{ a: 1, b: 2.0 }));
```

Note that this is somewhat similar to #347