### PR TITLE
Move to r-actions v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,12 +75,12 @@ jobs:
           components: rustfmt, clippy
       
       - name: Set up R
-        uses: r-lib/actions/setup-r@v1
+        uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
       
       - name: Set up Pandoc
-        uses: r-lib/actions/setup-pandoc@v1
+        uses: r-lib/actions/setup-pandoc@v2
       
       # All configurations for Windows go here
       # If 'rust-version' has no architecture id, both if conditions are executed
@@ -340,7 +340,7 @@ jobs:
           RUST_TOOLCHAIN: ${{ matrix.config.rust-version }}
 
       - name: Set up R
-        uses: r-lib/actions/setup-r@v1
+        uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           windows-path-include-mingw: false


### PR DESCRIPTION
r-actions got v2 tag a month ago, and all the future improvement will be included there (hopefully #354 will be improved eventually). So we should migrate to v2.

https://twitter.com/GaborCsardi/status/1470706718707523585