### PR TITLE
Register `[[.rust_class` just as `$.rust_class`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## extendr devel
 
+- Register S3 method `[[.rust_class` just as `$.rust_class`.
+
 - Extra Serialize support.
 
 - Direct Debug support for wrappers.

--- a/extendr-api/src/metadata.rs
+++ b/extendr-api/src/metadata.rs
@@ -318,7 +318,7 @@ fn write_impl_wrapper(
     writeln!(w, "`$.{}` <- function (self, name) {{ func <- {}[[name]]; environment(func) <- environment(); func }}\n", imp.name, imp_name_fixed)?;
 
     writeln!(w, "#' @export")?;
-    writeln!(w, "`[[.{}` <- `$.{}` \n", imp.name, imp_name_fixed)?;
+    writeln!(w, "`[[.{}` <- `$.{}` \n", imp.name, imp.name)?;
 
     Ok(())
 }

--- a/extendr-api/src/metadata.rs
+++ b/extendr-api/src/metadata.rs
@@ -318,7 +318,7 @@ fn write_impl_wrapper(
     writeln!(w, "`$.{}` <- function (self, name) {{ func <- {}[[name]]; environment(func) <- environment(); func }}\n", imp.name, imp_name_fixed)?;
 
     writeln!(w, "#' @export")?;
-    writeln!(w, "`[[.{}` <- `$.{}` \n", imp.name, imp.name)?;
+    writeln!(w, "`[[.{}` <- `$.{}`\n", imp.name, imp.name)?;
 
     Ok(())
 }

--- a/extendr-api/src/metadata.rs
+++ b/extendr-api/src/metadata.rs
@@ -317,6 +317,9 @@ fn write_impl_wrapper(
     // so we pass preprocessed value
     writeln!(w, "`$.{}` <- function (self, name) {{ func <- {}[[name]]; environment(func) <- environment(); func }}\n", imp.name, imp_name_fixed)?;
 
+    writeln!(w, "#' @export")?;
+    writeln!(w, "`[[.{}` <- `$.{}` \n", imp.name, imp_name_fixed)?;
+
     Ok(())
 }
 

--- a/tests/extendrtests/R/extendr-wrappers.R
+++ b/tests/extendrtests/R/extendr-wrappers.R
@@ -90,6 +90,9 @@ MyClass$me <- function() .Call(wrap__MyClass__me, self)
 #' @export
 `$.MyClass` <- function (self, name) { func <- MyClass[[name]]; environment(func) <- environment(); func }
 
+#' @export
+`[[.MyClass` <- `$.MyClass`
+
 `__MyClass` <- new.env(parent = emptyenv())
 
 `__MyClass`$new <- function() .Call(wrap____MyClass__new)
@@ -98,6 +101,9 @@ MyClass$me <- function() .Call(wrap__MyClass__me, self)
 
 #' @export
 `$.__MyClass` <- function (self, name) { func <- `__MyClass`[[name]]; environment(func) <- environment(); func }
+
+#' @export
+`[[.__MyClass` <- `$.__MyClass`
 
 #' Class for testing (unexported)
 MyClassUnexported <- new.env(parent = emptyenv())
@@ -108,6 +114,9 @@ MyClassUnexported$a <- function() .Call(wrap__MyClassUnexported__a, self)
 
 #' @export
 `$.MyClassUnexported` <- function (self, name) { func <- MyClassUnexported[[name]]; environment(func) <- environment(); func }
+
+#' @export
+`[[.MyClassUnexported` <- `$.MyClassUnexported`
 
 #' Class for testing (exported)
 #' @examples
@@ -130,4 +139,7 @@ MySubmoduleClass$me <- function() .Call(wrap__MySubmoduleClass__me, self)
 #' @usage NULL
 #' @export
 `$.MySubmoduleClass` <- function (self, name) { func <- MySubmoduleClass[[name]]; environment(func) <- environment(); func }
+
+#' @export
+`[[.MySubmoduleClass` <- `$.MySubmoduleClass`
 

--- a/tests/extendrtests/tests/testthat/test-classes.R
+++ b/tests/extendrtests/tests/testthat/test-classes.R
@@ -1,10 +1,13 @@
 test_that("Exported class works", {
   x <- MyClass$new()
   expect_equal(x$a(), 0L)
+  expect_equal(x[["a"]](), 0L)
   x$set_a(10L)
   expect_equal(x$a(), 10L)
+  expect_equal(x[["a"]](), 10L)
   expect_equal(x$me(), x)
-  
+  expect_equal(x[["me"]](), x)
+
   expect_visible(x$a())
   expect_invisible(x$set_a(5L))
 })
@@ -13,4 +16,5 @@ test_that("Unexported class works", {
   # unexported code works in testthat tests
   x <- MyClassUnexported$new()
   expect_equal(x$a(), 22L)
+  expect_equal(x[["a"]](), 22L)
 })


### PR DESCRIPTION
Hi,

I believe it's necessary to register `[[` S3 method for exported Rust Class as well. 

The reason is that, only so, we can call the method dynamically, e.g., `method <- "method_abc"; RustClass[[method]]()`. 

This is not possible for `$`.

Thanks.