### PR TITLE
Use Rtools42, stop cross-compiling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Configure Windows (R-devel)
         if: startsWith(runner.os, 'Windows') && matrix.config.r == 'devel'
         run: |
-          $rtools42_home = "C:/rtools42"
+          $rtools42_home = "C:\rtools42"
 
           # c.f. https://github.com/wch/r-source/blob/f1501504df8df1668a57d3a1b6f80167f24441d3/src/library/profile/Rprofile.windows#L70-L71
           echo "${rtools42_home}\x86_64-w64-mingw32.static.posix\bin"      | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
@@ -144,6 +144,8 @@ jobs:
               "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc.a" `
               "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc_s.a"
           }
+
+          echo "BUILD_TARGETS=x86_64-pc-windows-gnu" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append ;
         env: 
           RUST_TOOLCHAIN: ${{ matrix.config.rust-version }}
 
@@ -405,7 +407,7 @@ jobs:
       - name: Configure Windows (R-devel)
         if: startsWith(runner.os, 'Windows') && matrix.config.r == 'devel'
         run: |
-          $rtools42_home = "C:/rtools42"
+          $rtools42_home = "C:\rtools42"
 
           echo "::group::Setting up x86_64"
           echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,7 +144,9 @@ jobs:
               "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc.a" `
               "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc_s.a"
           }
-
+          
+          # Add target
+          rustup target add x86_64-pc-windows-gnu
           echo "BUILD_TARGETS=x86_64-pc-windows-gnu" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append ;
         env: 
           RUST_TOOLCHAIN: ${{ matrix.config.rust-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,24 +123,24 @@ jobs:
           echo "${rtools42_home}\usr\bin"                                  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
           echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\x64"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
 
-          # The default linker of rustc is "x86_64-w64-mingw32-gcc", however, there's no such name of executable in Rtools42
+          # rustc adds -lgcc_eh and -lgcc_s flag to the compiler, but there's no libgcc_eh or libgcc_a in Rtools42.
+          # So, we need to create an empty lib to please the compiler.
+          # For more details, please refer to https://github.com/r-windows/rtools-packages/blob/2407b23f1e0925bbb20a4162c963600105236318/mingw-w64-gcc/PKGBUILD#L313-L316
+          New-Item -Path libgcc_mock -Type Directory
+          New-Item -Path libgcc_mock\gcc.c -Type File
+          x86_64-w64-mingw32.static.posix-gcc.exe -c libgcc_mock\gcc.c -o libgcc_mock\gcc.o
+          x86_64-w64-mingw32.static.posix-ar.exe -r libgcc_mock\libgcc_eh.a libgcc_mock\gcc.o
+          x86_64-w64-mingw32.static.posix-ar.exe -r libgcc_mock\libgcc_s.a libgcc_mock\gcc.o
+
           New-Item -Path .cargo -ItemType Directory -Force
-          @'
+          @"
+          # The default linker of rustc is "x86_64-w64-mingw32-gcc", however, there's no such name of executable in Rtools42
           [target.x86_64-pc-windows-gnu]
           linker = "x86_64-w64-mingw32.static.posix-gcc.exe"
-          '@ | Out-File -FilePath .cargo/config.toml -Encoding utf8 -Append ;
 
-          # rustc adds -lgcc_eh and -lgcc_s flag to the compiler, but there's no libgcc_eh or libgcc_a in Rtools42.
-          # For more details, please refer to https://github.com/r-windows/rtools-packages/blob/2407b23f1e0925bbb20a4162c963600105236318/mingw-w64-gcc/PKGBUILD#L313-L316
-          cp `
-            "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc.a" `
-            "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc_eh.a"
-          
-          if ('${{ matrix.config.rust-version }}' -eq 'stable-gnu') {
-            cp `
-              "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc.a" `
-              "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc_s.a"
-          }
+          [env]
+          LIBRARY_PATH = "${PWD}\libgcc_mock"
+          "@ | Out-File -FilePath .cargo/config.toml -Encoding utf8 -Append ;
           
           # Add target
           rustup target add x86_64-pc-windows-gnu
@@ -419,24 +419,24 @@ jobs:
           echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\x64"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           echo "::endgroup::"
           
-          # The default linker of rustc is "x86_64-w64-mingw32-gcc", however, there's no such name of executable in Rtools42
+          # rustc adds -lgcc_eh and -lgcc_s flag to the compiler, but there's no libgcc_eh or libgcc_a in Rtools42.
+          # So, we need to create an empty lib to please the compiler.
+          # For more details, please refer to https://github.com/r-windows/rtools-packages/blob/2407b23f1e0925bbb20a4162c963600105236318/mingw-w64-gcc/PKGBUILD#L313-L316
+          New-Item -Path libgcc_mock -Type Directory
+          New-Item -Path libgcc_mock\gcc.c -Type File
+          x86_64-w64-mingw32.static.posix-gcc.exe -c libgcc_mock\gcc.c -o libgcc_mock\gcc.o
+          x86_64-w64-mingw32.static.posix-ar.exe -r libgcc_mock\libgcc_eh.a libgcc_mock\gcc.o
+          x86_64-w64-mingw32.static.posix-ar.exe -r libgcc_mock\libgcc_s.a libgcc_mock\gcc.o
+
           New-Item -Path .cargo -ItemType Directory -Force
-          @'
+          @"
+          # The default linker of rustc is "x86_64-w64-mingw32-gcc", however, there's no such name of executable in Rtools42
           [target.x86_64-pc-windows-gnu]
           linker = "x86_64-w64-mingw32.static.posix-gcc.exe"
-          '@ | Out-File -FilePath .cargo/config.toml -Encoding utf8 -Append ;
 
-          # rustc adds -lgcc_eh flag to the compiler, but there's no libgcc_eh in Rtools42 (this might be a bug in MSYS2 itself?, but Rtools40
-          # has a workaround for this).
-          cp `
-            "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc.a" `
-            "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc_eh.a"
-          
-          if ('${{ matrix.config.rust-version }}' -eq 'stable-gnu') {
-            cp `
-              "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc.a" `
-              "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc_s.a"
-          }
+          [env]
+          LIBRARY_PATH = "${PWD}\libgcc_mock"
+          "@ | Out-File -FilePath .cargo/config.toml -Encoding utf8 -Append ;
         env:
           RUST_TARGETS: ${{ join(matrix.config.rust-targets, ',') }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,19 +118,24 @@ jobs:
       - name: Configure Windows (R-devel)
         if: startsWith(runner.os, 'Windows') && matrix.config.r == 'devel'
         run: |
+          $rtools42_home = "$(Rscript.exe -e "cat(Sys.getenv('RTOOLS42_HOME'))")"
+          echo ${rtools42_home}
+
           # c.f. https://github.com/wch/r-source/blob/f1501504df8df1668a57d3a1b6f80167f24441d3/src/library/profile/Rprofile.windows#L70-L71
-          echo "D:\rtools42\x86_64-w64-mingw32.static.posix\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
-          echo "D:\rtools42\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+          echo "${rtools42_home}\x86_64-w64-mingw32.static.posix\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+          echo "${rtools42_home}\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
           echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\x64"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
 
           # The default linker of rustc is "x86_64-w64-mingw32-gcc", however, there's no such name of executable in Rtools42
           New-Item -Path .cargo -ItemType Directory -Force
-          "[target.x86_64-pc-windows-gnu]
-          linker = `"x86_64-w64-mingw32.static.posix-gcc.exe`"" | Out-File -FilePath .cargo/config.toml -Encoding utf8 -Append ;
+          @'
+          [target.x86_64-pc-windows-gnu]
+          linker = "x86_64-w64-mingw32.static.posix-gcc.exe"
+          '@ | Out-File -FilePath .cargo/config.toml -Encoding utf8 -Append ;
 
           # rustc adds -lgcc_eh flag to the compiler, but there's no libgcc_eh in Rtools42 (this might be a bug in MSYS2 itself?, but Rtools40
           # has a workaround for this).
-          cd "D:\rtools42\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\"
+          cd "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\"
           cp libgcc.a libgcc_eh.a
         env: 
           RUST_TOOLCHAIN: ${{ matrix.config.rust-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -206,7 +206,7 @@ jobs:
 
       # TODO: remove this when we decide which to use stable-gnu or stable-msvc for R >= 4.2
       - name: Tweak Makevars.ucrt
-        if: startsWith(runner.os, 'Windows') && matrix.config.r == 'devel' && matrix.config.rust-version == 'stable-gnu'
+        if: startsWith(runner.os, 'Windows') && matrix.config.r == 'devel' && matrix.config.rust-version == 'stable-msvc'
         run: |
           sed -i 's/stable-gnu/stable-msvc/g' tests/extendrtests/src/Makevars.ucrt
           sed -i 's/stable-gnu/stable-msvc/g' tests/rextendr/inst/templates/Makevars.ucrt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,8 @@ jobs:
         if: startsWith(runner.os, 'Windows') && matrix.config.r == 'devel'
         run: |
           # c.f. https://github.com/wch/r-source/blob/f1501504df8df1668a57d3a1b6f80167f24441d3/src/library/profile/Rprofile.windows#L70-L71
-          echo "${env:RTOOLS42_HOME}\x86_64-w64-mingw32.static.posix\bin;${env:RTOOLS42_HOME}\usr\bin;" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+          echo "${env:RTOOLS42_HOME}\x86_64-w64-mingw32.static.posix\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+          echo "${env:RTOOLS42_HOME}\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
           echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\x64"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
         env: 
           RUST_TOOLCHAIN: ${{ matrix.config.rust-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Configure Windows (R-devel)
         if: startsWith(runner.os, 'Windows') && matrix.config.r == 'devel'
         run: |
-          $rtools42_home = "$(Rscript.exe -e "cat(Sys.getenv('RTOOLS42_HOME'))")"
+          $rtools42_home = "C:/rtools42"
 
           # c.f. https://github.com/wch/r-source/blob/f1501504df8df1668a57d3a1b6f80167f24441d3/src/library/profile/Rprofile.windows#L70-L71
           echo "${rtools42_home}\x86_64-w64-mingw32.static.posix\bin"      | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
@@ -398,7 +398,7 @@ jobs:
       - name: Configure Windows (R-devel)
         if: startsWith(runner.os, 'Windows') && matrix.config.r == 'devel'
         run: |
-          $rtools42_home = "$(Rscript.exe -e "cat(Sys.getenv('RTOOLS42_HOME'))")"
+          $rtools42_home = "C:/rtools42"
 
           echo "::group::Setting up x86_64"
           echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,6 +124,7 @@ jobs:
           echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\x64"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
 
           # The default linker of rustc is "x86_64-w64-mingw32-gcc", however, there's no such name of executable in Rtools42
+          New-Item -Path .cargo -ItemType Directory -Force
           "[target.x86_64-pc-windows-gnu]
           linker = `"x86_64-w64-mingw32.static.posix-gcc.exe`"" | Out-File -FilePath .cargo/config.toml -Encoding utf8 -Append ;
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,10 +29,7 @@ jobs:
           # Windows jobs with unspecific Rust architecture build for both i686 and x86_64 
           # R integration tests are also executed for both architectures
           - {os: windows-latest, r: 'release', rust-version: 'stable-msvc'}
-          # TODO: remove this when we drop suppoort for R 4.1. Since R 4.2 uses
-          # a different toolchain than R 4.1, we need to test both.
           - {os: windows-latest, r: 'devel',   rust-version: 'stable-gnu',  rtools-version: '42'}
-          - {os: windows-latest, r: 'devel',   rust-version: 'stable-msvc', rtools-version: '42'}
           # - {os: windows-latest, r: 'release', rust-version: 'nightly-msvc'}
           # - {os: windows-latest, r: 'devel', rust-version: 'stable-msvc'}
           # - {os: windows-latest, r: 'oldrel', rust-version: 'stable-msvc'}
@@ -320,7 +317,6 @@ jobs:
           # This will be changed back to `R-devel` as soon as R drops 32-bit support and we no longer need cross-compilation
           - {os: windows-latest, r: 'release', rust-version: 'nightly-msvc', rust-targets: ['x86_64-pc-windows-gnu'], extra-args: ['-Zdoctest-xcompile']}
           - {os: windows-latest, r: 'release', rust-version: 'nightly-msvc', rust-targets: ['i686-pc-windows-gnu'],   extra-args: ['-Zdoctest-xcompile']}
-          - {os: windows-latest, r: 'devel',   rust-version: 'nightly-msvc', rust-targets: ['x86_64-pc-windows-gnu'], extra-args: ['-Zdoctest-xcompile'], rtools-version: '42'}
           # If we use stable-gnu, we don't need doctest-xcompile feature
           - {os: windows-latest, r: 'devel',   rust-version: 'stable-gnu',   rust-targets: ['x86_64-pc-windows-gnu'], rtools-version: '42'}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -207,6 +207,7 @@ jobs:
         run: |
           sed -i 's/stable-msvc/stable-gnu/g' tests/extendrtests/src/Makevars.win
           sed -i 's/stable-msvc/stable-gnu/g' tests/rextendr/inst/templates/Makevars.win
+          sed -i 's/stable-msvc/stable-gnu/g' tests/rextendr/tests/testthat/_snaps/use_extendr.md
         shell: bash
 
       # Regex is used to inject absolute path into Cargo.toml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -188,8 +188,10 @@ jobs:
       - name: Obtain 'rextendr'
         uses: actions/checkout@v2
         with:
-          repository: extendr/rextendr
+          # TODO: revert this when https://github.com/extendr/rextendr/pull/187 gets merged
+          repository: yutannihilation/rextendr
           path: ./tests/rextendr
+          ref: use-rtools42
 
       - name: Install dependencies for extendrtests and rcmdcheck
         uses: r-lib/actions/setup-r-dependencies@v2
@@ -202,12 +204,13 @@ jobs:
         with:
           working-directory: tests/rextendr
 
-      - name: Tweak Makevars.win
+      # TODO: remove this when we decide which to use stable-gnu or stable-msvc for R >= 4.2
+      - name: Tweak Makevars.ucrt
         if: startsWith(runner.os, 'Windows') && matrix.config.r == 'devel' && matrix.config.rust-version == 'stable-gnu'
         run: |
-          sed -i 's/stable-msvc/stable-gnu/g' tests/extendrtests/src/Makevars.win
-          sed -i 's/stable-msvc/stable-gnu/g' tests/rextendr/inst/templates/Makevars.win
-          sed -i 's/stable-msvc/stable-gnu/g' tests/rextendr/tests/testthat/_snaps/use_extendr.md
+          sed -i 's/stable-gnu/stable-msvc/g' tests/extendrtests/src/Makevars.ucrt
+          sed -i 's/stable-gnu/stable-msvc/g' tests/rextendr/inst/templates/Makevars.ucrt
+          sed -i 's/stable-gnu/stable-msvc/g' tests/rextendr/tests/testthat/_snaps/use_extendr.md
         shell: bash
 
       # Regex is used to inject absolute path into Cargo.toml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,8 +135,9 @@ jobs:
 
           # rustc adds -lgcc_eh flag to the compiler, but there's no libgcc_eh in Rtools42 (this might be a bug in MSYS2 itself?, but Rtools40
           # has a workaround for this).
-          cd "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\"
-          cp libgcc.a libgcc_eh.a
+          cp `
+            "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc.a" `
+            "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc_eh.a"
         env: 
           RUST_TOOLCHAIN: ${{ matrix.config.rust-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,9 +123,28 @@ jobs:
           echo "${rtools42_home}\usr\bin"                                  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
           echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\x64"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
 
-          # rustc adds -lgcc_eh and -lgcc_s flag to the compiler, but there's no libgcc_eh or libgcc_a in Rtools42.
-          # So, we need to create an empty lib to please the compiler.
+          # Add target
+          rustup target add x86_64-pc-windows-gnu
+          echo "BUILD_TARGETS=x86_64-pc-windows-gnu" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append ;
+
+          # The following lines add two tweaks:
+          #
+          #  1. Change the linker name to "x86_64-w64-mingw32.static.posix-gcc.exe".
+          #  2. Add empty libgcc_s.a and libgcc_eh.a, and add them to the compiler's
+          #     library search paths via `LIBRARY_PATH` envvar.
+          # 
+          # The first tweak is needed because Rtools42 doesn't contain 
+          # "x86_64-w64-mingw32-gcc," which `rustc` uses as the default linker 
+          # for the `x86_64-pc-windows-gnu` target.
+          #  
+          # If we use the Rtools' toolchain, the second tweak is also required.
+          # `rustc` adds `-lgcc_eh` and `-lgcc_s` flags to the compiler, but
+          # Rtools' GCC doesn't have `libgcc_eh` or `libgcc_a` due to the 
+          # compilation settings. So, in order to please the compiler, we need
+          # to add empty `libgcc_eh` or `libgcc_a` to the library search paths.
+          # 
           # For more details, please refer to https://github.com/r-windows/rtools-packages/blob/2407b23f1e0925bbb20a4162c963600105236318/mingw-w64-gcc/PKGBUILD#L313-L316
+
           New-Item -Path libgcc_mock -Type Directory
           New-Item -Path libgcc_mock\gcc.c -Type File
           x86_64-w64-mingw32.static.posix-gcc.exe -c libgcc_mock\gcc.c -o libgcc_mock\gcc.o
@@ -135,17 +154,12 @@ jobs:
           New-Item -Path .cargo -ItemType Directory -Force
           $pwd_slash = echo "${PWD}" | % {$_ -replace '\\','/'}
           @"
-          # The default linker of rustc is "x86_64-w64-mingw32-gcc", however, there's no such name of executable in Rtools42
           [target.x86_64-pc-windows-gnu]
           linker = "x86_64-w64-mingw32.static.posix-gcc.exe"
 
           [env]
           LIBRARY_PATH = "${pwd_slash}/libgcc_mock"
           "@ | Out-File -FilePath .cargo/config.toml -Encoding utf8 -Append ;
-          
-          # Add target
-          rustup target add x86_64-pc-windows-gnu
-          echo "BUILD_TARGETS=x86_64-pc-windows-gnu" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append ;
         env: 
           RUST_TOOLCHAIN: ${{ matrix.config.rust-version }}
 
@@ -420,9 +434,24 @@ jobs:
           echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\x64"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           echo "::endgroup::"
           
-          # rustc adds -lgcc_eh and -lgcc_s flag to the compiler, but there's no libgcc_eh or libgcc_a in Rtools42.
-          # So, we need to create an empty lib to please the compiler.
+          # The following lines add two tweaks:
+          #
+          #  1. Change the linker name to "x86_64-w64-mingw32.static.posix-gcc.exe".
+          #  2. Add empty libgcc_s.a and libgcc_eh.a, and add them to the compiler's
+          #     library search paths via `LIBRARY_PATH` envvar.
+          # 
+          # The first tweak is needed because Rtools42 doesn't contain 
+          # "x86_64-w64-mingw32-gcc," which `rustc` uses as the default linker 
+          # for the `x86_64-pc-windows-gnu` target.
+          #  
+          # If we use the Rtools' toolchain, the second tweak is also required.
+          # `rustc` adds `-lgcc_eh` and `-lgcc_s` flags to the compiler, but
+          # Rtools' GCC doesn't have `libgcc_eh` or `libgcc_a` due to the 
+          # compilation settings. So, in order to please the compiler, we need
+          # to add empty `libgcc_eh` or `libgcc_a` to the library search paths.
+          # 
           # For more details, please refer to https://github.com/r-windows/rtools-packages/blob/2407b23f1e0925bbb20a4162c963600105236318/mingw-w64-gcc/PKGBUILD#L313-L316
+
           New-Item -Path libgcc_mock -Type Directory
           New-Item -Path libgcc_mock\gcc.c -Type File
           x86_64-w64-mingw32.static.posix-gcc.exe -c libgcc_mock\gcc.c -o libgcc_mock\gcc.o
@@ -432,7 +461,6 @@ jobs:
           New-Item -Path .cargo -ItemType Directory -Force
           $pwd_slash = echo "${PWD}" | % {$_ -replace '\\','/'}
           @"
-          # The default linker of rustc is "x86_64-w64-mingw32-gcc", however, there's no such name of executable in Rtools42
           [target.x86_64-pc-windows-gnu]
           linker = "x86_64-w64-mingw32.static.posix-gcc.exe"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
           - {os: windows-latest, r: 'release', rust-version: 'stable-msvc'}
           # TODO: remove this when we drop suppoort for R 4.1. Since R 4.2 uses
           # a different toolchain than R 4.1, we need to test both.
-          - {os: windows-latest, r: 'devel',   rust-version: 'stable-msvc'}
+          - {os: windows-latest, r: 'devel',   rust-version: 'stable-gnu', rtools-version: '42'}
           # - {os: windows-latest, r: 'release', rust-version: 'nightly-msvc'}
           # - {os: windows-latest, r: 'devel', rust-version: 'stable-msvc'}
           # - {os: windows-latest, r: 'oldrel', rust-version: 'stable-msvc'}
@@ -80,6 +80,7 @@ jobs:
         uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
+          rtools-version: ${{ matrix.config.rtools-version }}
           use-public-rspm: true
       
       - name: Set up Pandoc
@@ -117,11 +118,9 @@ jobs:
       - name: Configure Windows (R-devel)
         if: startsWith(runner.os, 'Windows') && matrix.config.r == 'devel'
         run: |
-          rustup target add x86_64-pc-windows-gnu ;
-          # Use Rtools's UCRT toolchain rather than MSYS2. Note that the setting needs to be modified when Rtools42 becomes official.
-          echo "${env:RTOOLS40_HOME}\ucrt64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+          # c.f. https://github.com/wch/r-source/blob/f1501504df8df1668a57d3a1b6f80167f24441d3/src/library/profile/Rprofile.windows#L70-L71
+          echo "${env:RTOOLS42_HOME}\x86_64-w64-mingw32.static.posix\bin;${env:RTOOLS42_HOME}\usr\bin;" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
           echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\x64"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
-          echo "BUILD_TARGETS=x86_64-pc-windows-gnu" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append ;
         env: 
           RUST_TOOLCHAIN: ${{ matrix.config.rust-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,8 +133,8 @@ jobs:
           linker = "x86_64-w64-mingw32.static.posix-gcc.exe"
           '@ | Out-File -FilePath .cargo/config.toml -Encoding utf8 -Append ;
 
-          # rustc adds -lgcc_eh flag to the compiler, but there's no libgcc_eh in Rtools42 (this might be a bug in MSYS2 itself?, but Rtools40
-          # has a workaround for this).
+          # rustc adds -lgcc_eh and -lgcc_s flag to the compiler, but there's no libgcc_eh or libgcc_a in Rtools42.
+          # For more details, please refer to https://github.com/r-windows/rtools-packages/blob/2407b23f1e0925bbb20a4162c963600105236318/mingw-w64-gcc/PKGBUILD#L313-L316
           cp `
             "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc.a" `
             "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc_eh.a"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,8 @@ jobs:
           - {os: windows-latest, r: 'release', rust-version: 'stable-msvc'}
           # TODO: remove this when we drop suppoort for R 4.1. Since R 4.2 uses
           # a different toolchain than R 4.1, we need to test both.
-          - {os: windows-latest, r: 'devel',   rust-version: 'stable-gnu', rtools-version: '42'}
+          - {os: windows-latest, r: 'devel',   rust-version: 'stable-gnu',  rtools-version: '42'}
+          - {os: windows-latest, r: 'devel',   rust-version: 'stable-msvc', rtools-version: '42'}
           # - {os: windows-latest, r: 'release', rust-version: 'nightly-msvc'}
           # - {os: windows-latest, r: 'devel', rust-version: 'stable-msvc'}
           # - {os: windows-latest, r: 'oldrel', rust-version: 'stable-msvc'}
@@ -118,28 +119,10 @@ jobs:
       - name: Configure Windows (R-devel)
         if: startsWith(runner.os, 'Windows') && matrix.config.r == 'devel'
         run: |
-          $rtools42_home = "C:\rtools42"
-
           # c.f. https://github.com/wch/r-source/blob/f1501504df8df1668a57d3a1b6f80167f24441d3/src/library/profile/Rprofile.windows#L70-L71
-          echo "${rtools42_home}\x86_64-w64-mingw32.static.posix\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
-          echo "${rtools42_home}\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+          echo "C:\rtools42\x86_64-w64-mingw32.static.posix\bin"           | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+          echo "C:\rtools42\usr\bin"                                       | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
           echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\x64"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
-
-          # The default linker of rustc is "x86_64-w64-mingw32-gcc", however, there's no such name of executable in Rtools42
-          New-Item -Path .cargo -ItemType Directory -Force
-          @'
-          [target.x86_64-pc-windows-gnu]
-          linker = "x86_64-w64-mingw32.static.posix-gcc.exe"
-          '@ | Out-File -FilePath .cargo/config.toml -Encoding utf8 -Append ;
-
-          # rustc adds -lgcc_eh flag to the compiler, but there's no libgcc_eh in Rtools42 (this might be a bug in MSYS2 itself?, but Rtools40
-          # has a workaround for this).
-          cp `
-            "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc.a" `
-            "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc_eh.a"
-          cp `
-            "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc.a" `
-            "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc_s.a"
         env: 
           RUST_TOOLCHAIN: ${{ matrix.config.rust-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -283,9 +283,10 @@ jobs:
           - {os: macOS-latest,   r: 'devel', rust-version: 'stable'}
           # This will be changed back to `R-devel` as soon as R drops 32-bit support and we no longer need cross-compilation
           - {os: windows-latest, r: 'release', rust-version: 'nightly-msvc', rust-targets: ['x86_64-pc-windows-gnu'], extra-args: ['-Zdoctest-xcompile']}
-          - {os: windows-latest, r: 'release', rust-version: 'nightly-msvc', rust-targets: ['i686-pc-windows-gnu'], extra-args: ['-Zdoctest-xcompile']}
-
-
+          - {os: windows-latest, r: 'release', rust-version: 'nightly-msvc', rust-targets: ['i686-pc-windows-gnu'],   extra-args: ['-Zdoctest-xcompile']}
+          - {os: windows-latest, r: 'devel',   rust-version: 'nightly-msvc', rust-targets: ['x86_64-pc-windows-gnu'], extra-args: ['-Zdoctest-xcompile'], rtools-version: '42'}
+          # If we use stable-gnu, we don't need doctest-xcompile feature
+          - {os: windows-latest, r: 'devel',   rust-version: 'stable-gnu',   rust-targets: ['x86_64-pc-windows-gnu'], rtools-version: '42'}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
@@ -328,6 +329,7 @@ jobs:
         uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
+          rtools-version: ${{ matrix.config.rtools-version }}
           use-public-rspm: true
           windows-path-include-mingw: false
 
@@ -353,7 +355,7 @@ jobs:
       # 4. Add R/{arch}/bin to path
       # 5. Create array of correct (arch-dependent) paths to 'libclang.dll', export as env variable
       - name: Configure Windows
-        if: startsWith(runner.os, 'Windows')
+        if: startsWith(runner.os, 'Windows') && matrix.config.r != 'devel'
         run: |
 
           # mingw64 is required for both 32 and 64 bit targets
@@ -369,6 +371,16 @@ jobs:
             echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\i386"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
             echo "::endgroup::"
           }
+        env:
+          RUST_TARGETS: ${{ join(matrix.config.rust-targets, ',') }}
+
+      - name: Configure Windows (R-devel)
+        if: startsWith(runner.os, 'Windows') && matrix.config.r == 'devel'
+        run: |
+          echo "::group::Setting up x86_64"
+          echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\x64"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "::endgroup::"
         env:
           RUST_TARGETS: ${{ join(matrix.config.rust-targets, ',') }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,6 +122,15 @@ jobs:
           echo "${env:RTOOLS42_HOME}\x86_64-w64-mingw32.static.posix\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
           echo "${env:RTOOLS42_HOME}\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
           echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\x64"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+
+          # The default linker of rustc is "x86_64-w64-mingw32-gcc", however, there's no such name of executable in Rtools42
+          "[target.x86_64-pc-windows-gnu]
+          linker = `"x86_64-w64-mingw32.static.posix-gcc.exe`"" | Out-File -FilePath .cargo/config.toml -Encoding utf8 -Append ;
+
+          # rustc adds -lgcc_eh flag to the compiler, but there's no libgcc_eh in Rtools42 (this might be a bug in MSYS2 itself?, but Rtools40
+          # has a workaround for this).
+          cd "${env:RTOOLS42_HOME}/x86_64-w64-mingw32.static.posix/lib/gcc/x86_64-w64-mingw32.static.posix/10.3.0/"
+          cp libgcc.a libgcc_eh.a
         env: 
           RUST_TOOLCHAIN: ${{ matrix.config.rust-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,8 +118,7 @@ jobs:
       - name: Configure Windows (R-devel)
         if: startsWith(runner.os, 'Windows') && matrix.config.r == 'devel'
         run: |
-          $rtools42_home = "$(Rscript.exe -e "cat(Sys.getenv('RTOOLS42_HOME'))")"
-          echo ${rtools42_home}
+          $rtools42_home = "C:\rtools42"
 
           # c.f. https://github.com/wch/r-source/blob/f1501504df8df1668a57d3a1b6f80167f24441d3/src/library/profile/Rprofile.windows#L70-L71
           echo "${rtools42_home}\x86_64-w64-mingw32.static.posix\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,7 +153,7 @@ jobs:
         run: |
           . ./ci-cargo.ps1
           foreach($target in ($env:BUILD_TARGETS).Split(',')) {
-            ci-cargo test $(if($target -ne 'default') {"--target=$target"} ) '--' --nocapture -ActionName "Testing for $target target"
+            ci-cargo test $(if($target -ne 'default') {"--target=$target"} ) '--' --nocapture --test-threads=1 -ActionName "Testing for $target target"
           }
 
       # c.f. https://github.com/actions/checkout#checkout-multiple-repos-side-by-side

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,13 +133,14 @@ jobs:
           x86_64-w64-mingw32.static.posix-ar.exe -r libgcc_mock\libgcc_s.a libgcc_mock\gcc.o
 
           New-Item -Path .cargo -ItemType Directory -Force
+          $pwd_slash = echo "${PWD}" | % {$_ -replace '\\','/'}
           @"
           # The default linker of rustc is "x86_64-w64-mingw32-gcc", however, there's no such name of executable in Rtools42
           [target.x86_64-pc-windows-gnu]
           linker = "x86_64-w64-mingw32.static.posix-gcc.exe"
 
           [env]
-          LIBRARY_PATH = "${PWD}\libgcc_mock"
+          LIBRARY_PATH = "${pwd_slash}/libgcc_mock"
           "@ | Out-File -FilePath .cargo/config.toml -Encoding utf8 -Append ;
           
           # Add target
@@ -429,13 +430,14 @@ jobs:
           x86_64-w64-mingw32.static.posix-ar.exe -r libgcc_mock\libgcc_s.a libgcc_mock\gcc.o
 
           New-Item -Path .cargo -ItemType Directory -Force
+          $pwd_slash = echo "${PWD}" | % {$_ -replace '\\','/'}
           @"
           # The default linker of rustc is "x86_64-w64-mingw32-gcc", however, there's no such name of executable in Rtools42
           [target.x86_64-pc-windows-gnu]
           linker = "x86_64-w64-mingw32.static.posix-gcc.exe"
 
           [env]
-          LIBRARY_PATH = "${PWD}\libgcc_mock"
+          LIBRARY_PATH = "${pwd_slash}/libgcc_mock"
           "@ | Out-File -FilePath .cargo/config.toml -Encoding utf8 -Append ;
         env:
           RUST_TARGETS: ${{ join(matrix.config.rust-targets, ',') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -202,7 +202,7 @@ jobs:
         if: startsWith(runner.os, 'Windows') && matrix.config.r == 'devel' && matrix.config.rust-version == 'stable-gnu'
         run: |
           sed -i 's/stable-msvc/stable-gnu/g' tests/extendrtests/src/Makevars.win
-          sed -i 's/stable-msvc/stable-gnu/g' tests/rextendr/src/Makevars.win
+          sed -i 's/stable-msvc/stable-gnu/g' tests/rextendr/inst/templates/Makevars.win
         shell: bash
 
       # Regex is used to inject absolute path into Cargo.toml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,8 +119,8 @@ jobs:
         if: startsWith(runner.os, 'Windows') && matrix.config.r == 'devel'
         run: |
           # c.f. https://github.com/wch/r-source/blob/f1501504df8df1668a57d3a1b6f80167f24441d3/src/library/profile/Rprofile.windows#L70-L71
-          echo "${env:RTOOLS42_HOME}\x86_64-w64-mingw32.static.posix\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
-          echo "${env:RTOOLS42_HOME}\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+          echo "D:\rtools42\x86_64-w64-mingw32.static.posix\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+          echo "D:\rtools42\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
           echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\x64"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
 
           # The default linker of rustc is "x86_64-w64-mingw32-gcc", however, there's no such name of executable in Rtools42
@@ -130,7 +130,7 @@ jobs:
 
           # rustc adds -lgcc_eh flag to the compiler, but there's no libgcc_eh in Rtools42 (this might be a bug in MSYS2 itself?, but Rtools40
           # has a workaround for this).
-          cd "${env:RTOOLS42_HOME}/x86_64-w64-mingw32.static.posix/lib/gcc/x86_64-w64-mingw32.static.posix/10.3.0/"
+          cd "D:\rtools42\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\"
           cp libgcc.a libgcc_eh.a
         env: 
           RUST_TOOLCHAIN: ${{ matrix.config.rust-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -198,6 +198,13 @@ jobs:
         with:
           working-directory: tests/rextendr
 
+      - name: Tweak Makevars.win
+        if: startsWith(runner.os, 'Windows') && matrix.config.r == 'devel' && matrix.config.rust-version == 'stable-gnu'
+        run: |
+          sed -i 's/stable-msvc/stable-gnu/g' tests/extendrtests/src/Makevars.win
+          sed -i 's/stable-msvc/stable-gnu/g' tests/rextendr/src/Makevars.win
+        shell: bash
+
       # Regex is used to inject absolute path into Cargo.toml
       - name: Configure R for integration testing
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,6 +137,9 @@ jobs:
           cp `
             "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc.a" `
             "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc_eh.a"
+          cp `
+            "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc.a" `
+            "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc_s.a"
         env: 
           RUST_TOOLCHAIN: ${{ matrix.config.rust-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -484,7 +484,7 @@ jobs:
             ci-cargo +$toolchain test --manifest-path extendr-api/Cargo.toml --features tests $(if($target -ne 'default') {"--target=$target"} ) $env:EXTRA_ARGS '--' --nocapture -ActionName "Test extendr-api \w tests for $target target"
 
             # graphics tests requires --test-threads=1
-            ci-cargo +$toolchain test graphics_tests:: --manifest-path extendr-api/Cargo.toml --features graphics $(if($target -ne 'default') {"--target=$target"} ) $env:EXTRA_ARGS '--' --nocapture --test-threads=1 -ActionName "Test extendr-api \w graphics for $target target"
+            ci-cargo +$toolchain test graphics_tests:: --manifest-path extendr-api/Cargo.toml --features tests-graphics $(if($target -ne 'default') {"--target=$target"} ) $env:EXTRA_ARGS '--' --nocapture --test-threads=1 -ActionName "Test extendr-api \w graphics for $target target"
 
             ci-cargo +$toolchain test --manifest-path extendr-api/Cargo.toml --features tests-minimal $(if($target -ne 'default') {"--target=$target"} ) $env:EXTRA_ARGS '--' --nocapture -ActionName "Test extendr-api \w tests-minimal for $target target"
                       

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,10 +119,31 @@ jobs:
       - name: Configure Windows (R-devel)
         if: startsWith(runner.os, 'Windows') && matrix.config.r == 'devel'
         run: |
+          $rtools42_home = "$(Rscript.exe -e "cat(Sys.getenv('RTOOLS42_HOME'))")"
+
           # c.f. https://github.com/wch/r-source/blob/f1501504df8df1668a57d3a1b6f80167f24441d3/src/library/profile/Rprofile.windows#L70-L71
-          echo "C:\rtools42\x86_64-w64-mingw32.static.posix\bin"           | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
-          echo "C:\rtools42\usr\bin"                                       | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+          echo "${rtools42_home}\x86_64-w64-mingw32.static.posix\bin"      | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+          echo "${rtools42_home}\usr\bin"                                  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
           echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\x64"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+
+          # The default linker of rustc is "x86_64-w64-mingw32-gcc", however, there's no such name of executable in Rtools42
+          New-Item -Path .cargo -ItemType Directory -Force
+          @'
+          [target.x86_64-pc-windows-gnu]
+          linker = "x86_64-w64-mingw32.static.posix-gcc.exe"
+          '@ | Out-File -FilePath .cargo/config.toml -Encoding utf8 -Append ;
+
+          # rustc adds -lgcc_eh flag to the compiler, but there's no libgcc_eh in Rtools42 (this might be a bug in MSYS2 itself?, but Rtools40
+          # has a workaround for this).
+          cp `
+            "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc.a" `
+            "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc_eh.a"
+          
+          if ('${{ matrix.config.rust-version }}' -eq 'stable-gnu') {
+            cp `
+              "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc.a" `
+              "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc_s.a"
+          }
         env: 
           RUST_TOOLCHAIN: ${{ matrix.config.rust-version }}
 
@@ -377,10 +398,34 @@ jobs:
       - name: Configure Windows (R-devel)
         if: startsWith(runner.os, 'Windows') && matrix.config.r == 'devel'
         run: |
+          $rtools42_home = "$(Rscript.exe -e "cat(Sys.getenv('RTOOLS42_HOME'))")"
+
           echo "::group::Setting up x86_64"
           echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          # c.f. https://github.com/wch/r-source/blob/f1501504df8df1668a57d3a1b6f80167f24441d3/src/library/profile/Rprofile.windows#L70-L71
+          echo "${rtools42_home}\x86_64-w64-mingw32.static.posix\bin"      | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+          echo "${rtools42_home}\usr\bin"                                  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
           echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\x64"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           echo "::endgroup::"
+          
+          # The default linker of rustc is "x86_64-w64-mingw32-gcc", however, there's no such name of executable in Rtools42
+          New-Item -Path .cargo -ItemType Directory -Force
+          @'
+          [target.x86_64-pc-windows-gnu]
+          linker = "x86_64-w64-mingw32.static.posix-gcc.exe"
+          '@ | Out-File -FilePath .cargo/config.toml -Encoding utf8 -Append ;
+
+          # rustc adds -lgcc_eh flag to the compiler, but there's no libgcc_eh in Rtools42 (this might be a bug in MSYS2 itself?, but Rtools40
+          # has a workaround for this).
+          cp `
+            "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc.a" `
+            "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc_eh.a"
+          
+          if ('${{ matrix.config.rust-version }}' -eq 'stable-gnu') {
+            cp `
+              "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc.a" `
+              "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc_s.a"
+          }
         env:
           RUST_TARGETS: ${{ join(matrix.config.rust-targets, ',') }}
 

--- a/extendr-api/Cargo.toml
+++ b/extendr-api/Cargo.toml
@@ -38,6 +38,8 @@ tests-minimal = ["libR-sys/use-bindgen"]
 # and require --test-threads=1, so we decided to exclude it from here (c.f. #378).
 tests = ["tests-minimal", "ndarray", "serde", "num-complex"]
 
+tests-graphics = ["tests-minimal", "graphics"]
+
 # Literally all features to test
 tests-all = ["tests", "graphics"]
 

--- a/tests/extendrtests/src/Makevars.ucrt
+++ b/tests/extendrtests/src/Makevars.ucrt
@@ -1,0 +1,8 @@
+# Use GNU toolchain for R >= 4.2
+TOOLCHAIN = stable-gnu
+
+# Rtools42 doesn't have the linker in the location that cargo expects, so we
+# need to overwrite it via configuration.
+CARGO_LINKER = x86_64-w64-mingw32.static.posix-gcc.exe
+
+include Makevars.win

--- a/tests/extendrtests/src/Makevars.win
+++ b/tests/extendrtests/src/Makevars.win
@@ -13,9 +13,19 @@ all: C_clean
 $(SHLIB): $(STATLIB)
 
 $(STATLIB):
+	# Note: on the GitHub Actions CI, the tests pass without this tweak because
+	#       the same setup is already done in the CI.
+	mkdir -p $(TARGET_DIR)/libgcc_mock
+	cd $(TARGET_DIR)/libgcc_mock && \
+		touch gcc_mock.c && \
+		gcc -c gcc_mock.c -o gcc_mock.o && \
+		ar -r libgcc_eh.a gcc_mock.o && \
+		cp libgcc_eh.a libgcc_s.a
+
 	# CARGO_LINKER is provided in Makevars.ucrt for R >= 4.2
 	export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
-	  cargo +$(TOOLCHAIN) build --target=$(TARGET) --lib --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+		export LIBRARY_PATH="$${LIBRARY_PATH};$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \
+		cargo +$(TOOLCHAIN) build --target=$(TARGET) --lib --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
 
 C_clean:
 	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)

--- a/tests/extendrtests/src/Makevars.win
+++ b/tests/extendrtests/src/Makevars.win
@@ -15,7 +15,7 @@ $(SHLIB): $(STATLIB)
 $(STATLIB):
 	# CARGO_LINKER is provided in Makevars.ucrt for R >= 4.2
 	export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
-	  cargo +$(TOOLCHAIN) build --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+	  cargo +$(TOOLCHAIN) build --target=$(TARGET) --lib --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
 
 C_clean:
 	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)

--- a/tests/extendrtests/src/Makevars.win
+++ b/tests/extendrtests/src/Makevars.win
@@ -1,16 +1,21 @@
 TARGET = $(subst 64,x86_64,$(subst 32,i686,$(WIN)))-pc-windows-gnu
-TOOLCHAIN = stable-msvc
+
+# This is provided in Makevars.ucrt for R >= 4.2
+TOOLCHAIN ?= stable-msvc
+
 TARGET_DIR = ./rust/target
-LIBDIR = $(TARGET_DIR)/$(TARGET)/debug
-STATLIB = $(LIBDIR)/lextendrtest.a
-PKG_LIBS = -L$(LIBDIR) -lextendrtests -lws2_32 -ladvapi32 -luserenv -lbcrypt
+LIBDIR = $(TARGET_DIR)/$(TARGET)/release
+STATLIB = $(LIBDIR)/lib{{{lib_name}}}.a
+PKG_LIBS = -L$(LIBDIR) -l{{{lib_name}}} -lws2_32 -ladvapi32 -luserenv -lbcrypt
 
 all: C_clean
 
 $(SHLIB): $(STATLIB)
 
 $(STATLIB):
-	cargo +$(TOOLCHAIN) build --target=$(TARGET) --lib --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+	# CARGO_LINKER is provided in Makevars.ucrt for R >= 4.2
+	export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
+	  cargo +$(TOOLCHAIN) build --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
 
 C_clean:
 	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)

--- a/tests/extendrtests/src/Makevars.win
+++ b/tests/extendrtests/src/Makevars.win
@@ -4,9 +4,9 @@ TARGET = $(subst 64,x86_64,$(subst 32,i686,$(WIN)))-pc-windows-gnu
 TOOLCHAIN ?= stable-msvc
 
 TARGET_DIR = ./rust/target
-LIBDIR = $(TARGET_DIR)/$(TARGET)/release
-STATLIB = $(LIBDIR)/lib{{{lib_name}}}.a
-PKG_LIBS = -L$(LIBDIR) -l{{{lib_name}}} -lws2_32 -ladvapi32 -luserenv -lbcrypt
+LIBDIR = $(TARGET_DIR)/$(TARGET)/debug
+STATLIB = $(LIBDIR)/lextendrtest.a
+PKG_LIBS = -L$(LIBDIR) -lextendrtests -lws2_32 -ladvapi32 -luserenv -lbcrypt
 
 all: C_clean
 


### PR DESCRIPTION
It seems now r-lib/actions provides Rtools42. Let's try this and see if we can live without cross-compiling...