### PR TITLE
Fixed warnings that comes from calling

### DIFF
--- a/extendr-api/src/graphics/color.rs
+++ b/extendr-api/src/graphics/color.rs
@@ -38,7 +38,7 @@ impl Color {
 pub mod predefined {
     use super::Color;
 
-    /// https://www.w3.org/TR/2018/REC-css-color-3-20180619/
+    /// <https://www.w3.org/TR/2018/REC-css-color-3-20180619/>
     pub fn aliceblue() -> Color {
         Color::hex(0xF0F8FF)
     }

--- a/extendr-api/src/graphics/device_descriptor.rs
+++ b/extendr-api/src/graphics/device_descriptor.rs
@@ -74,7 +74,7 @@ pub(crate) enum DevCapLocator {
     Yes = 2,
 }
 
-/// A builder of [DevDesc].
+/// A builder of `DevDesc`.
 ///
 // # Design notes (which feels a bit too internal to be exposed as an official document)
 //
@@ -237,7 +237,7 @@ impl DeviceDescriptor {
 
     /// Sets the initial value of font face.
     ///
-    /// If not specified, [FontFace::PlainFont] will be used.
+    /// If not specified, [FontFace::Plain] will be used.
     pub fn startfont(mut self, startfont: FontFace) -> Self {
         self.startfont = startfont;
         self

--- a/extendr-api/src/graphics/device_driver.rs
+++ b/extendr-api/src/graphics/device_driver.rs
@@ -85,7 +85,7 @@ pub trait DeviceDriver: std::marker::Sized {
     /// * If `col` is `NA_INTEGER` then no border should be drawn.
     /// * If `fill` is `NA_INTEGER` then the circle should not be filled.
     ///
-    /// [^1]: https://github.com/wch/r-source/blob/9f284035b7e503aebe4a804579e9e80a541311bb/src/include/R_ext/GraphicsDevice.h#L205-L210
+    /// [^1]: <https://github.com/wch/r-source/blob/9f284035b7e503aebe4a804579e9e80a541311bb/src/include/R_ext/GraphicsDevice.h#L205-L210>
     fn circle(&mut self, center: (f64, f64), r: f64, gc: R_GE_gcontext, dd: DevDesc) {}
 
     /// A callback function to clip.
@@ -207,9 +207,9 @@ pub trait DeviceDriver: std::marker::Sized {
     /// > detected by device-specific code.
     ///
     /// [The header file]:
-    ///     https://github.com/wch/r-source/blob/8ebcb33a9f70e729109b1adf60edd5a3b22d3c6f/src/include/R_ext/GraphicsDevice.h#L508-L527
+    ///     <https://github.com/wch/r-source/blob/8ebcb33a9f70e729109b1adf60edd5a3b22d3c6f/src/include/R_ext/GraphicsDevice.h#L508-L527>
     /// [`cbm_Size()` in the cairo device]:
-    ///     https://github.com/wch/r-source/blob/8ebcb33a9f70e729109b1adf60edd5a3b22d3c6f/src/library/grDevices/src/cairo/cairoBM.c#L73-L83
+    ///     <https://github.com/wch/r-source/blob/8ebcb33a9f70e729109b1adf60edd5a3b22d3c6f/src/library/grDevices/src/cairo/cairoBM.c#L73-L83>
     fn size(&mut self, dd: DevDesc) -> (f64, f64, f64, f64) {
         (dd.left, dd.right, dd.bottom, dd.top)
     }
@@ -225,7 +225,7 @@ pub trait DeviceDriver: std::marker::Sized {
     /// - for performance
     /// - to decide what to do when font metric information is not available
     ///
-    /// [^1]: https://github.com/wch/r-source/blob/9bb47ca929c41a133786fa8fff7c70162bb75e50/src/include/R_ext/GraphicsDevice.h#L67-L74
+    /// [^1]: <https://github.com/wch/r-source/blob/9bb47ca929c41a133786fa8fff7c70162bb75e50/src/include/R_ext/GraphicsDevice.h#L67-L74>
     fn text_width(&mut self, text: &str, gc: R_GE_gcontext, dd: DevDesc) -> f64 {
         text.chars()
             .map(|c| self.char_metric(c, gc, dd).width)

--- a/extendr-api/src/graphics/mod.rs
+++ b/extendr-api/src/graphics/mod.rs
@@ -771,7 +771,7 @@ impl Device {
     }
 
     /// Draw a special symbol centered on pos.
-    /// See https://stat.ethz.ch/R-manual/R-devel/library/graphics/html/points.html
+    /// See <https://stat.ethz.ch/R-manual/R-devel/library/graphics/html/points.html>
     pub fn symbol(&self, pos: (f64, f64), symbol: i32, size: f64, gc: &Context) {
         unsafe {
             let (x, y) = gc.t(pos);

--- a/extendr-api/src/serializer.rs
+++ b/extendr-api/src/serializer.rs
@@ -1,4 +1,4 @@
-//! See https://serde.rs/impl-serializer.html
+//! See <https://serde.rs/impl-serializer.html>
 
 use crate::error::{Error, Result};
 use crate::na::CanBeNA;

--- a/extendr-api/src/wrapper/altrep.rs
+++ b/extendr-api/src/wrapper/altrep.rs
@@ -141,7 +141,7 @@ pub trait AltrepImpl: Clone + std::fmt::Debug {
         }
     }
 
-    /// Implement subsetting (eg. x[10:19]) for this Altrep vector.
+    /// Implement subsetting (eg. `x[10:19]`) for this Altrep vector.
     fn extract_subset(_x: Robj, _indx: Robj, _call: Robj) -> Robj {
         // only available in later versions of R.
         // x.extract_subset(indx, call)


### PR DESCRIPTION
`cargo doc`. URLs being invalid, and
renamed variants, etc.