### PR TITLE
[bug] Fix test macro

### DIFF
--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -10,6 +10,8 @@
 //! See [Robj] for much of the content of this crate.
 //! [Robj] provides a safe wrapper for the R object type.
 //!
+//! ## Examples
+//!
 //! Use attributes and macros to export to R.
 //! ```ignore
 //! use extendr_api::prelude::*;
@@ -215,6 +217,38 @@
 //!     // and cannot live longer than robj.
 //!     let slice = robj.as_integer_slice().ok_or("expected slice")?;
 //!     assert_eq!(slice.len(), 3);
+//! }
+//! ```
+//!
+//! ## Writing tests
+//!
+//! To test the functions exposed to R, wrap your code in the [`test!`] macro.
+//! This macro starts up the necessary R machinery for tests to work.
+//!
+//! ```no_run
+//! use extendr_api::prelude::*;
+//!
+//! #[extendr]
+//! fn things() ->  Strings {
+//!     Strings::from_values(vec!["Test", "this"])
+//! }
+//!
+//! // define exports using extendr_module
+//! extendr_module! {
+//!    mod mymodule;
+//!    fn things;    
+//! }
+//!
+//!
+//! #[cfg(test)]
+//! mod test {
+//!     use super::*;
+//!     use extendr_api::prelude::*;
+//!
+//!     #[test]
+//!     fn test_simple_function() {
+//!         assert_eq!(things().elt(0), "Test")
+//!     }
 //! }
 //! ```
 //!

--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -267,7 +267,7 @@ pub use std::ops::DerefMut;
 pub use robj::Robj;
 
 //////////////////////////////////////////////////
-// Note these pub use statements are deprectaed
+// Note these pub use statements are deprecated
 //
 // `use extendr_api::prelude::*;`
 //

--- a/extendr-api/src/prelude.rs
+++ b/extendr-api/src/prelude.rs
@@ -31,6 +31,9 @@ pub use super::wrapper::symbol::{
 // Exported macros have crate scope.
 pub use crate::{append, append_lang, append_with_name, args, lang, make_lang};
 
+// Export inner functionality needed in the test! macro
+pub use extendr_engine;
+
 // Exported macros have crate scope.
 pub use crate::{
     data_frame, factor, global, list, r, reprint, reprintln, rprint, rprintln, sym, test, var,

--- a/extendr-api/src/rmacros.rs
+++ b/extendr-api/src/rmacros.rs
@@ -187,7 +187,8 @@ macro_rules! reprintln {
 
 /// Macro for running tests.
 ///
-/// This allows us to use `?` in example code instead of `unwrap()`.
+/// This starts up the underlying [`extendr_engine`] so that interactions with R will work.
+/// Additionally, this allows us to use `?` in example code instead of `unwrap()`.
 ///
 /// **Note:** This macro is meant to be used in test code (annotated with
 /// `#[cfg(test)]`) or in doc strings. If it is used in library code that


### PR DESCRIPTION
The `test!` macro depends on `extendr_engine` being in scope to use. This PR re-exports `estendr_engine` in the prelude so that `test!` will work without adding a silent `dev-dependency`.

This also documents how to test code in Rust.

Fixes: https://github.com/extendr/extendr/issues/391