### PR TITLE
Skip extendr-macros test on Windows

### DIFF
--- a/extendr-macros/src/lib.rs
+++ b/extendr-macros/src/lib.rs
@@ -180,21 +180,24 @@ pub fn Rraw(item: TokenStream) -> TokenStream {
 /// In the below example, `foo_from_list` is an instance of the `Foo` struct, that has been converted
 /// from an R list:
 /// ```
-/// use extendr_api::prelude::*;
-/// use extendr_macros::TryFromRobj;
-/// # use extendr_api::test;
-/// # test!{
+/// #[cfg(not(target_os = "windows"))]
+/// {
+///     use extendr_api::prelude::*;
+///     use extendr_macros::TryFromRobj;
+///     # use extendr_api::test;
+///     # test!{
 ///
-/// #[derive(TryFromRobj, PartialEq, Debug)]
-/// struct Foo {
-///     a: u64,
-///     b: String
+///     #[derive(TryFromRobj, PartialEq, Debug)]
+///     struct Foo {
+///         a: u64,
+///         b: String
+///     }
+///     let native_foo = Foo { a: 5, b: "bar".into() };
+///     let foo_from_list: Foo = R!("list(a = 5, b = 'bar')")?.try_into()?;
+///     assert_eq!(native_foo, foo_from_list);
+///     # }
+///     # Ok::<(), extendr_api::Error>(())
 /// }
-/// let native_foo = Foo { a: 5, b: "bar".into() };
-/// let foo_from_list: Foo = R!("list(a = 5, b = 'bar')")?.try_into()?;
-/// assert_eq!(native_foo, foo_from_list);
-/// # }
-/// # Ok::<(), extendr_api::Error>(())
 /// ```
 #[proc_macro_derive(TryFromRobj)]
 pub fn derive_try_from_robj(item: TokenStream) -> TokenStream {
@@ -210,23 +213,26 @@ pub fn derive_try_from_robj(item: TokenStream) -> TokenStream {
 /// In the below example, `converted` contains an R list object with the same fields as the
 /// `Foo` struct.
 /// ```
-/// use extendr_api::prelude::*;
-/// use extendr_macros::IntoRobj;
+/// #[cfg(not(target_os = "windows"))]
+/// {
+///     use extendr_api::prelude::*;
+///     use extendr_macros::IntoRobj;
 ///
-/// # use extendr_api::test;
-/// # test!{
-/// #[derive(IntoRobj)]
-/// struct Foo {
-///     a: u32,
-///     b: String
+///     # use extendr_api::test;
+///     # test!{
+///     #[derive(IntoRobj)]
+///     struct Foo {
+///         a: u32,
+///         b: String
+///     }
+///     let converted: Robj = Foo {
+///         a: 5,
+///         b: String::from("bar")
+///     }.into();
+///     assert_eq!(converted, R!(r"list(a=5, b='bar')")?);
+///     # }
+///     # Ok::<(), extendr_api::Error>(())
 /// }
-/// let converted: Robj = Foo {
-///     a: 5,
-///     b: String::from("bar")
-/// }.into();
-/// assert_eq!(converted, R!(r"list(a=5, b='bar')")?);
-/// # }
-/// # Ok::<(), extendr_api::Error>(())
 /// ```
 /// # Details
 /// Note, the `From<Struct> for Robj` behaviour is different from what is obtained by applying the standard `#[extendr]` macro

--- a/extendr-macros/src/lib.rs
+++ b/extendr-macros/src/lib.rs
@@ -179,7 +179,7 @@ pub fn Rraw(item: TokenStream) -> TokenStream {
 /// # Examples
 /// In the below example, `foo_from_list` is an instance of the `Foo` struct, that has been converted
 /// from an R list:
-/// ```
+/// ```ignore
 /// use extendr_api::prelude::*;
 /// use extendr_macros::TryFromRobj;
 /// # use extendr_api::test;
@@ -209,7 +209,7 @@ pub fn derive_try_from_robj(item: TokenStream) -> TokenStream {
 /// # Examples
 /// In the below example, `converted` contains an R list object with the same fields as the
 /// `Foo` struct.
-/// ```
+/// ```ignore
 /// use extendr_api::prelude::*;
 /// use extendr_macros::IntoRobj;
 ///

--- a/extendr-macros/src/lib.rs
+++ b/extendr-macros/src/lib.rs
@@ -180,24 +180,21 @@ pub fn Rraw(item: TokenStream) -> TokenStream {
 /// In the below example, `foo_from_list` is an instance of the `Foo` struct, that has been converted
 /// from an R list:
 /// ```
-/// #[cfg(not(target_os = "windows"))]
-/// {
-///     use extendr_api::prelude::*;
-///     use extendr_macros::TryFromRobj;
-///     # use extendr_api::test;
-///     # test!{
+/// use extendr_api::prelude::*;
+/// use extendr_macros::TryFromRobj;
+/// # use extendr_api::test;
+/// # test!{
 ///
-///     #[derive(TryFromRobj, PartialEq, Debug)]
-///     struct Foo {
-///         a: u64,
-///         b: String
-///     }
-///     let native_foo = Foo { a: 5, b: "bar".into() };
-///     let foo_from_list: Foo = R!("list(a = 5, b = 'bar')")?.try_into()?;
-///     assert_eq!(native_foo, foo_from_list);
-///     # }
-///     # Ok::<(), extendr_api::Error>(())
+/// #[derive(TryFromRobj, PartialEq, Debug)]
+/// struct Foo {
+///     a: u64,
+///     b: String
 /// }
+/// let native_foo = Foo { a: 5, b: "bar".into() };
+/// let foo_from_list: Foo = R!("list(a = 5, b = 'bar')")?.try_into()?;
+/// assert_eq!(native_foo, foo_from_list);
+/// # }
+/// # Ok::<(), extendr_api::Error>(())
 /// ```
 #[proc_macro_derive(TryFromRobj)]
 pub fn derive_try_from_robj(item: TokenStream) -> TokenStream {
@@ -213,26 +210,23 @@ pub fn derive_try_from_robj(item: TokenStream) -> TokenStream {
 /// In the below example, `converted` contains an R list object with the same fields as the
 /// `Foo` struct.
 /// ```
-/// #[cfg(not(target_os = "windows"))]
-/// {
-///     use extendr_api::prelude::*;
-///     use extendr_macros::IntoRobj;
+/// use extendr_api::prelude::*;
+/// use extendr_macros::IntoRobj;
 ///
-///     # use extendr_api::test;
-///     # test!{
-///     #[derive(IntoRobj)]
-///     struct Foo {
-///         a: u32,
-///         b: String
-///     }
-///     let converted: Robj = Foo {
-///         a: 5,
-///         b: String::from("bar")
-///     }.into();
-///     assert_eq!(converted, R!(r"list(a=5, b='bar')")?);
-///     # }
-///     # Ok::<(), extendr_api::Error>(())
+/// # use extendr_api::test;
+/// # test!{
+/// #[derive(IntoRobj)]
+/// struct Foo {
+///     a: u32,
+///     b: String
 /// }
+/// let converted: Robj = Foo {
+///     a: 5,
+///     b: String::from("bar")
+/// }.into();
+/// assert_eq!(converted, R!(r"list(a=5, b='bar')")?);
+/// # }
+/// # Ok::<(), extendr_api::Error>(())
 /// ```
 /// # Details
 /// Note, the `From<Struct> for Robj` behaviour is different from what is obtained by applying the standard `#[extendr]` macro

--- a/extendr-macros/tests/test_derive_into_list.rs
+++ b/extendr-macros/tests/test_derive_into_list.rs
@@ -1,6 +1,12 @@
 use extendr_api::prelude::*;
 use extendr_macros::{IntoRobj, TryFromRobj};
 
+// TODO: On a crate with `proc_macro = true`, Rust doesn't allow
+// cross-compilation, so this test cannot be executed on Windows as long as it
+// requires corss-compilation.
+//
+// c.f. https://github.com/extendr/extendr/issues/372
+#[cfg(not(target_os = "windows"))]
 #[test]
 fn test_derive_list() {
     test! {


### PR DESCRIPTION
Close #372

Please refer to the issue for the details, but in case it's too long to read to you, I quote myself here:

> The reason is simply `proc_macro` doesn't allow cross-compilation.
> 
> > `--crate-type=proc-macro`, `#[crate_type = "proc-macro"]` - (...snip...) The crates are always compiled with the same target that the compiler itself was built with. For example, if you are executing the compiler from Linux with an x86_64 CPU, the target will be `x86_64-unknown-linux-gnu` even if the crate is a dependency of another crate being built for a different target.  
>     (<https://doc.rust-lang.org/reference/linkage.html>)
> 
> So, I think this is a game over. I'd suggest documenting this limitation and waiting for R 4.2 to avoid cross-compilation at all.