### PR TITLE
Extra Rf_protect and faster growth.

### DIFF
--- a/extendr-api/tests/issue-397-memory-allocation.rs
+++ b/extendr-api/tests/issue-397-memory-allocation.rs
@@ -1,0 +1,24 @@
+use extendr_api::prelude::*;
+
+#[test]
+fn test_allocation() {
+    test! {
+        const COUNT: u64 = 2_000_000u64;
+        let mut data: Vec<Robj> = vec![];
+        for i in 1u64..COUNT {
+            if i % 1000 == 0 { println!("{}", i); }
+            data.push(i.into());
+        }
+
+        for (ix, v) in data.iter().enumerate() {
+            assert_eq!(Some((ix + 1) as f64), v.as_real())
+        }
+
+        let obj: Robj = List::from_names_and_values(&["A"], vec![data]).into();
+        obj.set_attrib(
+            row_names_symbol(),
+            (1i32..=COUNT as i32).collect_robj(),
+        )?;
+        obj.set_class(&["data.frame"])?;
+    }
+}


### PR DESCRIPTION
Closes issue #397 

The memory protection uses a hashmap to ensure that there is at least one instance of each live SEXP
in a list visible to R.

This issue was because during the growth of the array, the current object was not protected.

I have also increased the initial size of the list and the growth is now exponential. This improves
the performance of the allocation at some risk to memory  overflow.