### PR TITLE
Switch CI to cache v3 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -206,14 +206,14 @@ jobs:
       - name: Install dependencies for extendrtests and rcmdcheck
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          cache-version: 2
+          cache-version: 3
           working-directory: tests/extendrtests
           extra-packages: any::rcmdcheck
 
       - name: Install dependencies for rextendr
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          cache-version: 2
+          cache-version: 3
           working-directory: tests/rextendr
 
       # TODO: remove this when we decide which to use stable-gnu or stable-msvc for R >= 4.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - master
+      - '*'
   pull_request:
     branches:
       - main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - master
-      - '*'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Closes #414. See improvements in [`actions/cache@v3`](https://github.com/actions/cache#v3).