### PR TITLE
Use bindgen on docs.rs

### DIFF
--- a/extendr-api/Cargo.toml
+++ b/extendr-api/Cargo.toml
@@ -44,4 +44,4 @@ tests-graphics = ["tests-minimal", "graphics"]
 tests-all = ["tests", "graphics"]
 
 [package.metadata.docs.rs]
-features = ["graphics"]
+features = ["graphics", "libR-sys/use-bindgen"]


### PR DESCRIPTION
Currently, the build on docs.rs fails with the following error (ref: [build log](https://docs.rs/crate/extendr-api/0.3.1/builds/567780)). This is because the precomputed bindings for the version of R that docs.rs uses, R 3.6, doesn't contain the graphics-related objects because the file was generated long ago.

We have several options to avoid this error (see https://github.com/extendr/extendr/issues/415#issuecomment-1186461753), but I believe this is the best; we cannot expect what version of R docs.rs will use, but using bindgen should make the build success with arbitrary version.

```
[INFO] [stderr]  Documenting extendr-api v0.3.1 (/opt/rustwide/workdir)
[INFO] [stderr] error[E0432]: unresolved imports `libR_sys::DevDesc`, `libR_sys::R_GE_gcontext`
[INFO] [stderr]   --> src/graphics/mod.rs:83:20
[INFO] [stderr]    |
[INFO] [stderr] 83 | pub use libR_sys::{DevDesc, R_GE_gcontext};
[INFO] [stderr]    |                    ^^^^^^^  ^^^^^^^^^^^^^ no `R_GE_gcontext` in the root
[INFO] [stderr]    |                    |
[INFO] [stderr]    |                    no `DevDesc` in the root
[INFO] [stderr] 
[INFO] [stderr] error[E0412]: cannot find type `DevDesc` in this scope
[INFO] [stderr]   --> src/graphics/device_driver.rs:82:32
[INFO] [stderr]    |
[INFO] [stderr] 82 |     fn activate(&mut self, dd: DevDesc) {}
[INFO] [stderr]    |                                ^^^^^^^ not found in this scope
[INFO] [stderr] 
[INFO] [stderr] error[E0412]: cannot find type `R_GE_gcontext` in this scope
...snip...
```