### PR TITLE
explicitly drop box ptr

### DIFF
--- a/extendr-api/src/wrapper/altrep.rs
+++ b/extendr-api/src/wrapper/altrep.rs
@@ -492,7 +492,7 @@ impl Altrep {
             unsafe extern "C" fn finalizer<StateType: 'static>(x: SEXP) {
                 let state = Altrep::get_state_mut::<StateType>(x);
                 let ptr = state as *mut StateType;
-                Box::from_raw(ptr);
+                drop(Box::from_raw(ptr));
             }
 
             let ptr: *mut StateType = Box::into_raw(Box::new(state));

--- a/extendr-api/src/wrapper/externalptr.rs
+++ b/extendr-api/src/wrapper/externalptr.rs
@@ -99,7 +99,7 @@ impl<T: Any + Debug> ExternalPtr<T> {
 
                     // Convert the pointer to a box and drop it implictly.
                     // This frees up the memory we have used and calls the "T::drop" method if there is one.
-                    Box::from_raw(ptr);
+                    drop(Box::from_raw(ptr));
                 }
             }
 

--- a/extendr-macros/src/extendr_impl.rs
+++ b/extendr-macros/src/extendr_impl.rs
@@ -167,7 +167,7 @@ pub fn extendr_impl(mut item_impl: ItemImpl) -> TokenStream {
                 if robj.check_external_ptr(#self_ty_name) {
                     //eprintln!("finalize {}", #self_ty_name);
                     let ptr = robj.external_ptr_addr::<#self_ty>();
-                    Box::from_raw(ptr);
+                    drop(Box::from_raw(ptr));
                 }
             }
         }


### PR DESCRIPTION
compiling extendr with latest rust nightly I get warnings for every #[extendr] macro invocation
```
warning: unused return value of `Box::<T>::from_raw` that must be used
     --> src/rdataframe/mod.rs:98:1
      |
   98 | #[extendr]
      | ^^^^^^^^^^
      |
      = note: `#[warn(unused_must_use)]` on by default
      = note: call `drop(from_raw(ptr))` if you intend to drop the `Box`
      = note: this warning originates in the attribute macro `extendr` (in Nightly builds, run with -Z macro-backtrace for more info)
```


the warnings come from [this update](https://github.com/rust-lang/git2-rs/pull/860), where it is required to explicitly drop boxed pointers


another contributer to rust-lang solved it like [this](https://github.com/rust-lang/git2-rs/pull/860/files):

I have used the same pattern in this PR