### PR TITLE
Do not specify the toolchain on Windows with R >= 4.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -199,9 +199,7 @@ jobs:
       - name: Obtain 'rextendr'
         uses: actions/checkout@v2
         with:
-          # TODO
-          repository: yutannihilation/rextendr
-          ref: poc/support-msvc-toolchain-again
+          repository: extendr/rextendr
           path: ./tests/rextendr
 
       - name: Install dependencies for extendrtests and rcmdcheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,9 @@ jobs:
           # Windows jobs with unspecific Rust architecture build for both i686 and x86_64
           # R integration tests are also executed for both architectures
           - {os: windows-latest, r: 'release', rust-version: 'stable-gnu',  rtools-version: '42'}
+          - {os: windows-latest, r: 'release', rust-version: 'stable-msvc', rtools-version: '42'}
           - {os: windows-latest, r: 'devel',   rust-version: 'stable-gnu',  rtools-version: '42'}
+          - {os: windows-latest, r: 'devel',   rust-version: 'stable-msvc', rtools-version: '42'}
           # For R < 4.2, the MSVC toolchain is used to support cross-compilation for the 32-bit.
           # TODO: Remove this runner when we drop the support for R < 4.2
           - {os: windows-latest, r: '4.1',     rust-version: 'stable-msvc'}
@@ -113,18 +115,15 @@ jobs:
           # for the `x86_64-pc-windows-gnu` target.
           #  
           # If we use the Rtools' toolchain, the second tweak is also required.
-          # `rustc` adds `-lgcc_eh` and `-lgcc_s` flags to the compiler, but
-          # Rtools' GCC doesn't have `libgcc_eh` or `libgcc_a` due to the 
-          # compilation settings. So, in order to please the compiler, we need
-          # to add empty `libgcc_eh` or `libgcc_a` to the library search paths.
+          # `rustc` adds `-lgcc_eh` flag to the compiler, but Rtools' GCC doesn't
+          # have `libgcc_eh` due to the compilation settings. So, in order to 
+          # please the compiler, we need to add empty `libgcc_eh` to the library
+          # search paths.
           # 
           # For more details, please refer to https://github.com/r-windows/rtools-packages/blob/2407b23f1e0925bbb20a4162c963600105236318/mingw-w64-gcc/PKGBUILD#L313-L316
 
           New-Item -Path libgcc_mock -Type Directory
-          New-Item -Path libgcc_mock\gcc.c -Type File
-          x86_64-w64-mingw32.static.posix-gcc.exe -c libgcc_mock\gcc.c -o libgcc_mock\gcc.o
-          x86_64-w64-mingw32.static.posix-ar.exe -r libgcc_mock\libgcc_eh.a libgcc_mock\gcc.o
-          x86_64-w64-mingw32.static.posix-ar.exe -r libgcc_mock\libgcc_s.a libgcc_mock\gcc.o
+          New-Item -Path libgcc_mock\libgcc_eh.a -Type File
 
           New-Item -Path .cargo -ItemType Directory -Force
           $pwd_slash = echo "${PWD}" | % {$_ -replace '\\','/'}
@@ -215,15 +214,6 @@ jobs:
           cache-version: 2
           working-directory: tests/rextendr
 
-      # TODO: remove this when we decide which to use stable-gnu or stable-msvc for R >= 4.2
-      - name: Tweak Makevars.ucrt
-        if: startsWith(runner.os, 'Windows') && matrix.config.r == 'devel' && matrix.config.rust-version == 'stable-msvc'
-        run: |
-          sed -i 's/stable-gnu/stable-msvc/g' tests/extendrtests/src/Makevars.ucrt
-          sed -i 's/stable-gnu/stable-msvc/g' tests/rextendr/inst/templates/Makevars.ucrt
-          sed -i 's/stable-gnu/stable-msvc/g' tests/rextendr/tests/testthat/_snaps/use_extendr.md
-        shell: bash
-
       # Regex is used to inject absolute path into Cargo.toml
       - name: Configure R for integration testing
         run: |
@@ -307,7 +297,9 @@ jobs:
           - {os: ubuntu-20.04,   r: 'devel', rust-version: 'stable'}
           - {os: macOS-latest,   r: 'devel', rust-version: 'stable'}
           - {os: windows-latest, r: 'release', rust-version: 'stable-gnu',   rust-targets: ['x86_64-pc-windows-gnu'], rtools-version: '42'}
+          - {os: windows-latest, r: 'release', rust-version: 'stable-msvc',  rust-targets: ['x86_64-pc-windows-gnu'], rtools-version: '42'}
           - {os: windows-latest, r: 'devel',   rust-version: 'stable-gnu',   rust-targets: ['x86_64-pc-windows-gnu'], rtools-version: '42'}
+          - {os: windows-latest, r: 'devel',   rust-version: 'stable-msvc',  rust-targets: ['x86_64-pc-windows-gnu'], rtools-version: '42'}
           # For R < 4.2, the MSVC toolchain is used to support cross-compilation for the 32-bit.
           # Since it does cross-compilation from MSVC to GNU, we need `-Zdoctest-xcompile` to
           # let the doctests run, which accordingly require the nightly toolchain.
@@ -400,18 +392,15 @@ jobs:
           # for the `x86_64-pc-windows-gnu` target.
           #  
           # If we use the Rtools' toolchain, the second tweak is also required.
-          # `rustc` adds `-lgcc_eh` and `-lgcc_s` flags to the compiler, but
-          # Rtools' GCC doesn't have `libgcc_eh` or `libgcc_a` due to the 
-          # compilation settings. So, in order to please the compiler, we need
-          # to add empty `libgcc_eh` or `libgcc_a` to the library search paths.
+          # `rustc` adds `-lgcc_eh` flag to the compiler, but Rtools' GCC doesn't
+          # have `libgcc_eh` due to the compilation settings. So, in order to 
+          # please the compiler, we need to add empty `libgcc_eh` to the library
+          # search paths.
           # 
           # For more details, please refer to https://github.com/r-windows/rtools-packages/blob/2407b23f1e0925bbb20a4162c963600105236318/mingw-w64-gcc/PKGBUILD#L313-L316
 
           New-Item -Path libgcc_mock -Type Directory
-          New-Item -Path libgcc_mock\gcc.c -Type File
-          x86_64-w64-mingw32.static.posix-gcc.exe -c libgcc_mock\gcc.c -o libgcc_mock\gcc.o
-          x86_64-w64-mingw32.static.posix-ar.exe -r libgcc_mock\libgcc_eh.a libgcc_mock\gcc.o
-          x86_64-w64-mingw32.static.posix-ar.exe -r libgcc_mock\libgcc_s.a libgcc_mock\gcc.o
+          New-Item -Path libgcc_mock\libgcc_eh.a -Type File
 
           New-Item -Path .cargo -ItemType Directory -Force
           $pwd_slash = echo "${PWD}" | % {$_ -replace '\\','/'}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,18 +26,18 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          # Windows jobs with unspecific Rust architecture build for both i686 and x86_64
-          # R integration tests are also executed for both architectures
-          - {os: windows-latest, r: 'release', rust-version: 'stable-gnu',  rtools-version: '42'}
+          # On Windows,
+          #
+          # * for R >= 4.2, both the MSVC toolchain and the GNU toolchain should
+          #   work. Since our main support is on MSVC, we mainly test MSVC here.
+          #   Also, at least one GNU case should be included so that we can
+          #   detect when something gets broken. 
+          # * for R < 4.2, the MSVC toolchain must be used to support
+          #   cross-compilation for the 32-bit. 
           - {os: windows-latest, r: 'release', rust-version: 'stable-msvc', rtools-version: '42'}
-          - {os: windows-latest, r: 'devel',   rust-version: 'stable-gnu',  rtools-version: '42'}
           - {os: windows-latest, r: 'devel',   rust-version: 'stable-msvc', rtools-version: '42'}
-          # For R < 4.2, the MSVC toolchain is used to support cross-compilation for the 32-bit.
-          # TODO: Remove this runner when we drop the support for R < 4.2
-          - {os: windows-latest, r: '4.1',     rust-version: 'stable-msvc'}
-          # - {os: windows-latest, r: 'release', rust-version: 'nightly-msvc'}
-          # - {os: windows-latest, r: 'devel', rust-version: 'stable-msvc'}
-          # - {os: windows-latest, r: 'oldrel', rust-version: 'stable-msvc'}
+          - {os: windows-latest, r: 'release', rust-version: 'stable-gnu',  rtools-version: '42'}
+          - {os: windows-latest, r: '4.1',     rust-version: 'stable-msvc'}  # TODO: Remove this runner when we drop the support for R < 4.2
 
           - {os: macOS-latest,   r: 'release', rust-version: 'stable'}
           # - {os: macOS-latest,   r: 'release', rust-version: 'nightly'}
@@ -301,7 +301,6 @@ jobs:
           - {os: macOS-latest,   r: 'devel', rust-version: 'stable'}
           - {os: windows-latest, r: 'release', rust-version: 'stable-gnu',   rust-targets: ['x86_64-pc-windows-gnu'], rtools-version: '42'}
           - {os: windows-latest, r: 'release', rust-version: 'stable-msvc',  rust-targets: ['x86_64-pc-windows-gnu'], rtools-version: '42'}
-          - {os: windows-latest, r: 'devel',   rust-version: 'stable-gnu',   rust-targets: ['x86_64-pc-windows-gnu'], rtools-version: '42'}
           - {os: windows-latest, r: 'devel',   rust-version: 'stable-msvc',  rust-targets: ['x86_64-pc-windows-gnu'], rtools-version: '42'}
           # When the MSVC target is used, since it's cross-compilation from MSVC
           # to GNU, the doc tests are usually skipped. Adding `-Zdoctest-xcompile`

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -199,7 +199,9 @@ jobs:
       - name: Obtain 'rextendr'
         uses: actions/checkout@v2
         with:
-          repository: extendr/rextendr
+          # TODO
+          repository: yutannihilation/rextendr
+          ref: poc/support-msvc-toolchain-again
           path: ./tests/rextendr
 
       - name: Install dependencies for extendrtests and rcmdcheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -303,10 +303,10 @@ jobs:
           - {os: windows-latest, r: 'release', rust-version: 'stable-msvc',  rust-targets: ['x86_64-pc-windows-gnu'], rtools-version: '42'}
           - {os: windows-latest, r: 'devel',   rust-version: 'stable-gnu',   rust-targets: ['x86_64-pc-windows-gnu'], rtools-version: '42'}
           - {os: windows-latest, r: 'devel',   rust-version: 'stable-msvc',  rust-targets: ['x86_64-pc-windows-gnu'], rtools-version: '42'}
-          # For R < 4.2, the MSVC toolchain is used to support cross-compilation for the 32-bit.
-          # Since it does cross-compilation from MSVC to GNU, we need `-Zdoctest-xcompile` to
-          # let the doctests run, which accordingly require the nightly toolchain.
-          # TODO: Remove these runners when we drop the support for R < 4.2.
+          # When the MSVC target is used, since it's cross-compilation from MSVC
+          # to GNU, the doc tests are usually skipped. Adding `-Zdoctest-xcompile`
+          # lets the doctests run, which accordingly require the nightly toolchain.
+          - {os: windows-latest, r: 'release', rust-version: 'nightly-msvc', rust-targets: ['x86_64-pc-windows-gnu'], rtools-version: '42', extra-args: ['-Zdoctest-xcompile']}
           - {os: windows-latest, r: '4.1',     rust-version: 'nightly-msvc', rust-targets: ['x86_64-pc-windows-gnu'], extra-args: ['-Zdoctest-xcompile']}
           - {os: windows-latest, r: '4.1',     rust-version: 'nightly-msvc', rust-targets: ['i686-pc-windows-gnu'],   extra-args: ['-Zdoctest-xcompile']}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,15 +115,16 @@ jobs:
           # for the `x86_64-pc-windows-gnu` target.
           #  
           # If we use the Rtools' toolchain, the second tweak is also required.
-          # `rustc` adds `-lgcc_eh` flag to the compiler, but Rtools' GCC doesn't
-          # have `libgcc_eh` due to the compilation settings. So, in order to 
-          # please the compiler, we need to add empty `libgcc_eh` to the library
-          # search paths.
+          # `rustc` adds `-lgcc_eh` and `-lgcc_s` flags to the compiler, but
+          # Rtools' GCC doesn't have `libgcc_eh` or `libgcc_s` due to the 
+          # compilation settings. So, in order to please the compiler, we need
+          # to add empty `libgcc_eh` or `libgcc_s` to the library search paths.
           # 
           # For more details, please refer to https://github.com/r-windows/rtools-packages/blob/2407b23f1e0925bbb20a4162c963600105236318/mingw-w64-gcc/PKGBUILD#L313-L316
 
           New-Item -Path libgcc_mock -Type Directory
           New-Item -Path libgcc_mock\libgcc_eh.a -Type File
+          New-Item -Path libgcc_mock\libgcc_s.a -Type File
 
           New-Item -Path .cargo -ItemType Directory -Force
           $pwd_slash = echo "${PWD}" | % {$_ -replace '\\','/'}
@@ -392,15 +393,16 @@ jobs:
           # for the `x86_64-pc-windows-gnu` target.
           #  
           # If we use the Rtools' toolchain, the second tweak is also required.
-          # `rustc` adds `-lgcc_eh` flag to the compiler, but Rtools' GCC doesn't
-          # have `libgcc_eh` due to the compilation settings. So, in order to 
-          # please the compiler, we need to add empty `libgcc_eh` to the library
-          # search paths.
+          # `rustc` adds `-lgcc_eh` and `-lgcc_s` flags to the compiler, but
+          # Rtools' GCC doesn't have `libgcc_eh` or `libgcc_s` due to the 
+          # compilation settings. So, in order to please the compiler, we need
+          # to add empty `libgcc_eh` or `libgcc_s` to the library search paths.
           # 
           # For more details, please refer to https://github.com/r-windows/rtools-packages/blob/2407b23f1e0925bbb20a4162c963600105236318/mingw-w64-gcc/PKGBUILD#L313-L316
 
           New-Item -Path libgcc_mock -Type Directory
           New-Item -Path libgcc_mock\libgcc_eh.a -Type File
+          New-Item -Path libgcc_mock\libgcc_s.a -Type File
 
           New-Item -Path .cargo -ItemType Directory -Force
           $pwd_slash = echo "${PWD}" | % {$_ -replace '\\','/'}

--- a/tests/extendrtests/src/Makevars.ucrt
+++ b/tests/extendrtests/src/Makevars.ucrt
@@ -1,6 +1,3 @@
-# Use GNU toolchain for R >= 4.2
-TOOLCHAIN = stable
-
 # Rtools42 doesn't have the linker in the location that cargo expects, so we
 # need to overwrite it via configuration.
 CARGO_LINKER = x86_64-w64-mingw32.static.posix-gcc.exe

--- a/tests/extendrtests/src/Makevars.ucrt
+++ b/tests/extendrtests/src/Makevars.ucrt
@@ -1,5 +1,5 @@
 # Use GNU toolchain for R >= 4.2
-TOOLCHAIN = stable-gnu
+TOOLCHAIN = stable
 
 # Rtools42 doesn't have the linker in the location that cargo expects, so we
 # need to overwrite it via configuration.

--- a/tests/extendrtests/src/Makevars.win
+++ b/tests/extendrtests/src/Makevars.win
@@ -1,8 +1,5 @@
 TARGET = $(subst 64,x86_64,$(subst 32,i686,$(WIN)))-pc-windows-gnu
 
-# This is provided in Makevars.ucrt for R >= 4.2
-TOOLCHAIN ?= stable-msvc
-
 TARGET_DIR = ./rust/target
 LIBDIR = $(TARGET_DIR)/$(TARGET)/debug
 STATLIB = $(LIBDIR)/lextendrtest.a
@@ -16,16 +13,18 @@ $(STATLIB):
 	# Note: on the GitHub Actions CI, the tests pass without this tweak because
 	#       the same setup is already done in the CI.
 	mkdir -p $(TARGET_DIR)/libgcc_mock
-	cd $(TARGET_DIR)/libgcc_mock && \
-		touch gcc_mock.c && \
-		gcc -c gcc_mock.c -o gcc_mock.o && \
-		ar -r libgcc_eh.a gcc_mock.o && \
-		cp libgcc_eh.a libgcc_s.a
+	# `rustc` adds `-lgcc_eh` flags to the compiler, but Rtools' GCC doesn't have
+	# `libgcc_eh` due to the compilation settings. So, in order to please the
+	# compiler, we need to add empty `libgcc_eh` to the library search paths.
+	#
+	# For more details, please refer to
+	# https://github.com/r-windows/rtools-packages/blob/2407b23f1e0925bbb20a4162c963600105236318/mingw-w64-gcc/PKGBUILD#L313-L316
+	touch $(TARGET_DIR)/libgcc_mock/libgcc_eh.a
 
 	# CARGO_LINKER is provided in Makevars.ucrt for R >= 4.2
 	export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
 		export LIBRARY_PATH="$${LIBRARY_PATH};$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \
-		cargo +$(TOOLCHAIN) build --target=$(TARGET) --lib --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+		cargo build --target=$(TARGET) --lib --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
 
 C_clean:
 	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)


### PR DESCRIPTION
Related to https://github.com/extendr/extendr/issues/437

* Add a runner to test MSVC toolchain on R >= 4.2
* Remove the toolchain specification (`+$(TOOLCHAIN)`) from `Makevars.win`
* (minor) Follow-up of https://github.com/extendr/rextendr/pull/218