### PR TITLE
Use Rtools43

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,11 +93,15 @@ jobs:
       - name: Configure Windows (R >= 4.2)
         if: startsWith(runner.os, 'Windows') && matrix.config.r != '4.1'
         run: |
-          $rtools42_home = "C:\rtools42"
+          if ("${{ matrix.config.rtools_version }}" -eq "42") {
+            $rtools_home = "C:\rtools42"   # for R 4.2
+          } else {
+            $rtools_home = "C:\rtools43"   # for R >= 4.3
+          }
 
           # c.f. https://github.com/wch/r-source/blob/f1501504df8df1668a57d3a1b6f80167f24441d3/src/library/profile/Rprofile.windows#L70-L71
-          echo "${rtools42_home}\x86_64-w64-mingw32.static.posix\bin"      | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
-          echo "${rtools42_home}\usr\bin"                                  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+          echo "${rtools_home}\x86_64-w64-mingw32.static.posix\bin"      | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+          echo "${rtools_home}\usr\bin"                                  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
           echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\x64"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
 
           # Add target
@@ -371,13 +375,17 @@ jobs:
       - name: Configure Windows (R >= 4.2)
         if: startsWith(runner.os, 'Windows') && matrix.config.r != '4.1'
         run: |
-          $rtools42_home = "C:\rtools42"
+          if ("${{ matrix.config.rtools_version }}" -eq "42") {
+            $rtools_home = "C:\rtools42"   # for R 4.2
+          } else {
+            $rtools_home = "C:\rtools43"   # for R >= 4.3
+          }
 
           echo "::group::Setting up x86_64"
           echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           # c.f. https://github.com/wch/r-source/blob/f1501504df8df1668a57d3a1b6f80167f24441d3/src/library/profile/Rprofile.windows#L70-L71
-          echo "${rtools42_home}\x86_64-w64-mingw32.static.posix\bin"      | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
-          echo "${rtools42_home}\usr\bin"                                  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+          echo "${rtools_home}\x86_64-w64-mingw32.static.posix\bin"      | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
+          echo "${rtools_home}\usr\bin"                                  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
           echo "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\x64"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           echo "::endgroup::"
           

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
           # * for R < 4.2, the MSVC toolchain must be used to support
           #   cross-compilation for the 32-bit. 
           - {os: windows-latest, r: 'release', rust-version: 'stable-msvc', rtools-version: '42'}
-          - {os: windows-latest, r: 'devel',   rust-version: 'stable-msvc', rtools-version: '42'}
+          - {os: windows-latest, r: 'devel',   rust-version: 'stable-msvc'}
           - {os: windows-latest, r: 'release', rust-version: 'stable-gnu',  rtools-version: '42'}
           - {os: windows-latest, r: '4.1',     rust-version: 'stable-msvc'}  # TODO: Remove this runner when we drop the support for R < 4.2
 
@@ -299,7 +299,7 @@ jobs:
           - {os: macOS-latest,   r: 'devel', rust-version: 'stable'}
           - {os: windows-latest, r: 'release', rust-version: 'stable-gnu',   rust-targets: ['x86_64-pc-windows-gnu'], rtools-version: '42'}
           - {os: windows-latest, r: 'release', rust-version: 'stable-msvc',  rust-targets: ['x86_64-pc-windows-gnu'], rtools-version: '42'}
-          - {os: windows-latest, r: 'devel',   rust-version: 'stable-msvc',  rust-targets: ['x86_64-pc-windows-gnu'], rtools-version: '42'}
+          - {os: windows-latest, r: 'devel',   rust-version: 'stable-msvc',  rust-targets: ['x86_64-pc-windows-gnu']}
           # When the MSVC target is used, since it's cross-compilation from MSVC
           # to GNU, the doc tests are usually skipped. Adding `-Zdoctest-xcompile`
           # lets the doctests run, which accordingly require the nightly toolchain.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Configure Windows (R >= 4.2)
         if: startsWith(runner.os, 'Windows') && matrix.config.r != '4.1'
         run: |
-          if ("${{ matrix.config.rtools_version }}" -eq "42") {
+          if ("${{ matrix.config.rtools-version }}" -eq "42") {
             $rtools_home = "C:\rtools42"   # for R 4.2
           } else {
             $rtools_home = "C:\rtools43"   # for R >= 4.3
@@ -375,7 +375,7 @@ jobs:
       - name: Configure Windows (R >= 4.2)
         if: startsWith(runner.os, 'Windows') && matrix.config.r != '4.1'
         run: |
-          if ("${{ matrix.config.rtools_version }}" -eq "42") {
+          if ("${{ matrix.config.rtools-version }}" -eq "42") {
             $rtools_home = "C:\rtools42"   # for R 4.2
           } else {
             $rtools_home = "C:\rtools43"   # for R >= 4.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -203,8 +203,7 @@ jobs:
       - name: Obtain 'rextendr'
         uses: actions/checkout@v2
         with:
-          repository: yutannihilation/rextendr
-          ref: use-rtools43
+          repository: extendr/rextendr
           path: ./tests/rextendr
 
       - name: Install dependencies for extendrtests and rcmdcheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -209,14 +209,14 @@ jobs:
       - name: Install dependencies for extendrtests and rcmdcheck
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          cache-version: 2
+          cache-version: 3
           working-directory: tests/extendrtests
           extra-packages: any::rcmdcheck
 
       - name: Install dependencies for rextendr
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          cache-version: 2
+          cache-version: 3
           working-directory: tests/rextendr
 
       # Regex is used to inject absolute path into Cargo.toml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -203,7 +203,8 @@ jobs:
       - name: Obtain 'rextendr'
         uses: actions/checkout@v2
         with:
-          repository: extendr/rextendr
+          repository: yutannihilation/rextendr
+          ref: use-rtools43
           path: ./tests/rextendr
 
       - name: Install dependencies for extendrtests and rcmdcheck


### PR DESCRIPTION
Address https://github.com/extendr/extendr/issues/442.

As r-lib/actions now uses Rtools43 by default, this pull request remove the outdated specification of `'42'`.

https://github.com/r-lib/actions/commit/740a0e7ce930b6357f16388c0b2acee8337adb01