### PR TITLE
Missing `unsafe` on module wrappers

### DIFF
--- a/extendr-macros/src/extendr_module.rs
+++ b/extendr-macros/src/extendr_module.rs
@@ -92,7 +92,7 @@ pub fn extendr_module(item: TokenStream) -> TokenStream {
         }
 
         #[no_mangle]
-        #[allow(non_snake_case)]
+        #[allow(non_snake_case, clippy::not_unsafe_ptr_arg_deref)]
         pub extern "C" fn #wrap_make_module_wrappers(
             use_symbols_sexp: extendr_api::SEXP,
             package_name_sexp: extendr_api::SEXP,


### PR DESCRIPTION
Running `cargo clippy` on a freshly minted rust-r-package from `{rextendr}`-template, i.e.

```rust
use extendr_api::prelude::*;

/// Return string `"Hello world!"` to R.
/// @export
#[extendr]
fn hello_world() -> &'static str {
    "Hello world!"
}

// Macro to generate exports.
// This ensures exported functions are registered with R.
// See corresponding C code in `entrypoint.c`.
extendr_module! {
    mod EID_ABM;
    fn hello_world;
}
```

yields this error:
```
this public function might dereference a raw pointer but is not marked `unsafe`
for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref
`#[deny(clippy::not_unsafe_ptr_arg_deref)]` on by default
```
And if I look at the expanded code, I find places where

```rust
#[allow(non_snake_case, clippy::not_unsafe_ptr_arg_deref)]
```

Thus I've added it to the missing part here.

I need a review on this from someone who knows what's going on.

