### PR TITLE
Implement `Sum` for Iterator of `&Rtype`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- `Sum` for scalars like `Rint`, `Rfloat` and `Rcplx`, which accept `Iterator<Item = &Rtype>` [[#454]](https://github.com/extendr/extendr/pull/454) 
 - `Debug` trait implementation for `Rcplx` and `Complexes` [[#444]](https://github.com/extendr/extendr/pull/444)
 - `Function` type that wraps an R function, which can be invoked using the `call()` method. [[#188]](https://github.com/extendr/extendr/pull/188)
 - `pairlist!` macro for generating `Pairlist` objects, e.g. for use in function calls. [[#202]](https://github.com/extendr/extendr/pull/202)

--- a/extendr-api/src/scalar/macros.rs
+++ b/extendr-api/src/scalar/macros.rs
@@ -808,7 +808,7 @@ macro_rules! gen_sum_iter {
         // impl std::iter::Sum for $type {
         //     /// Documentation comments/test built by the #[doc] attributes
         //     fn sum<I: Iterator<Item = Rint>>(iter: I) -> Rint {
-        //         iter.fold(Rint::from(0i32), |a, b| a + b)
+        //         iter.fold(Rint::default(), |a, b| a + b)
         //     }
         // }
         impl std::iter::Sum for $type {
@@ -823,7 +823,32 @@ macro_rules! gen_sum_iter {
                 #[doc = "}"]
                 #[doc = "```"]
                 fn sum<I: Iterator<Item = $type>>(iter: I) -> $type {
-                    iter.fold($type::from($zero), |a, b| a + b)
+                    iter.fold($type::default(), |a, b| a + b)
+                }
+            }
+        }
+
+        // The 'example usage' expands to...
+        //
+        // impl std::iter::Sum for &$type {
+        //     /// Documentation comments/test built by the #[doc] attributes
+        //     fn sum<I: Iterator<Item = &Rint>>(iter: I) -> Rint {
+        //         iter.fold(Rint::default(), |a, b| a + b)
+        //     }
+        // }
+        impl<'a> std::iter::Sum<&'a $type> for $type {
+            paste::paste! {
+                #[doc = "Yields NA on overflow if NAs present."]
+                #[doc = "```"]
+                #[doc = "use extendr_api::prelude::*;"]
+                #[doc = "use std::iter::Sum;"]
+                #[doc = "test! {"]
+                #[doc = "    let x = (0..100).map(|x| &" $type "::default());"]
+                #[doc = "    assert_eq!(<" $type " as Sum>::sum(x), <" $type ">::default());"]
+                #[doc = "}"]
+                #[doc = "```"]
+                fn sum<I: Iterator<Item = &'a $type>>(iter: I) -> $type {
+                    iter.fold($type::default(), |a, b| a + *b)
                 }
             }
         }

--- a/extendr-api/src/scalar/macros.rs
+++ b/extendr-api/src/scalar/macros.rs
@@ -791,18 +791,17 @@ macro_rules! gen_trait_impl {
 
 /// Generates an implementation of `std::iter::Sum` for a scalar type
 ///
-/// This macro requires the following arguments:
+/// This macro requires the following argument:
 ///
 /// * `$type`   - The Type to implement `std::iter::Sum` for
-/// * `$zero`   - The zero value for the primitive counterpart to Type
 ///
 /// Example Usage:
 ///
 /// ```ignore
-/// gen_sum_iter!(Rint, 0i32);
+/// gen_sum_iter!(Rint);
 /// ```
 macro_rules! gen_sum_iter {
-    ($type : tt, $zero : expr) => {
+    ($type : tt) => {
         // The 'example usage' expands to...
         //
         // impl std::iter::Sum for $type {

--- a/extendr-api/src/scalar/macros.rs
+++ b/extendr-api/src/scalar/macros.rs
@@ -843,8 +843,9 @@ macro_rules! gen_sum_iter {
                 #[doc = "use extendr_api::prelude::*;"]
                 #[doc = "use std::iter::Sum;"]
                 #[doc = "test! {"]
-                #[doc = "    let x = (0..100).map(|x| &" $type "::default());"]
-                #[doc = "    assert_eq!(<" $type " as Sum>::sum(x), <" $type ">::default());"]
+                #[doc = "    let z =" $type "::default();"]
+                #[doc = "    let x = (0..100).map(|_| &z);"]
+                #[doc = "    assert_eq!(<" $type " as Sum<& " $type ">>::sum(x), <" $type ">::default());"]
                 #[doc = "}"]
                 #[doc = "```"]
                 fn sum<I: Iterator<Item = &'a $type>>(iter: I) -> $type {

--- a/extendr-api/src/scalar/rcplx_full.rs
+++ b/extendr-api/src/scalar/rcplx_full.rs
@@ -95,7 +95,7 @@ impl From<Rcplx> for Option<c64> {
 gen_trait_impl!(Rcplx, c64, |x: &Rcplx| x.inner().re.is_na(), c64::na());
 gen_from_primitive!(Rcplx, c64);
 // gen_from_scalar!(Rcplx, c64);
-gen_sum_iter!(Rcplx, 0f64);
+gen_sum_iter!(Rcplx);
 
 // Generate binary ops for +, -, * and /
 gen_binop!(

--- a/extendr-api/src/scalar/rfloat.rs
+++ b/extendr-api/src/scalar/rfloat.rs
@@ -40,7 +40,7 @@ impl Rfloat {
 gen_trait_impl!(Rfloat, f64, |x: &Rfloat| x.inner().is_na(), f64::na());
 gen_from_primitive!(Rfloat, f64);
 gen_from_scalar!(Rfloat, f64);
-gen_sum_iter!(Rfloat, 0f64);
+gen_sum_iter!(Rfloat);
 
 // Generate binary ops for +, -, * and /
 gen_binop!(

--- a/extendr-api/src/scalar/rint.rs
+++ b/extendr-api/src/scalar/rint.rs
@@ -20,7 +20,7 @@ impl Rint {
 gen_trait_impl!(Rint, i32, |x: &Rint| x.0 == i32::MIN, i32::MIN);
 gen_from_primitive!(Rint, i32);
 gen_from_scalar!(Rint, i32);
-gen_sum_iter!(Rint, 0i32);
+gen_sum_iter!(Rint);
 
 // Generate binary ops for +, -, * and /
 gen_binop!(


### PR DESCRIPTION
Self-explanatory. We have `Sum` for `Iterator<Item = Rfloat>` but not for `Iterator<Item = &Rfloat>`. This PR adds missing implementation.