### PR TITLE
Fix clippy::extra_unused_lifetimes, clippy::bool_to_int_with_if, clippy::map_flatten, clippy::iter_kv_map, and clippy::borrow_deref_ref

### DIFF
--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -572,28 +572,28 @@ impl_from_into_iter! {&'a [T]}
 impl_from_as_iterator! {Range<T>}
 impl_from_as_iterator! {RangeInclusive<T>}
 
-impl<'a> From<Vec<Robj>> for Robj {
+impl From<Vec<Robj>> for Robj {
     /// Convert a vector of Robj into a list.
     fn from(val: Vec<Robj>) -> Self {
         List::from_values(val.iter()).into()
     }
 }
 
-impl<'a> From<Vec<Rstr>> for Robj {
+impl From<Vec<Rstr>> for Robj {
     /// Convert a vector of Rstr into strings.
     fn from(val: Vec<Rstr>) -> Self {
         Strings::from_values(val.into_iter()).into()
     }
 }
 
-impl<'a> From<Vec<Rint>> for Robj {
+impl From<Vec<Rint>> for Robj {
     /// Convert a vector of Rint into integers.
     fn from(val: Vec<Rint>) -> Self {
         Integers::from_values(val.into_iter()).into()
     }
 }
 
-impl<'a> From<Vec<Rfloat>> for Robj {
+impl From<Vec<Rfloat>> for Robj {
     /// Convert a vector of Rfloat into doubles.
     fn from(val: Vec<Rfloat>) -> Self {
         Doubles::from_values(val.into_iter()).into()

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -1031,14 +1031,14 @@ pub unsafe fn new_owned(sexp: SEXP) -> Robj {
 }
 
 /// Compare equality with integer slices.
-impl<'a> PartialEq<[i32]> for Robj {
+impl PartialEq<[i32]> for Robj {
     fn eq(&self, rhs: &[i32]) -> bool {
         self.as_integer_slice() == Some(rhs)
     }
 }
 
 /// Compare equality with slices of double.
-impl<'a> PartialEq<[f64]> for Robj {
+impl PartialEq<[f64]> for Robj {
     fn eq(&self, rhs: &[f64]) -> bool {
         self.as_real_slice() == Some(rhs)
     }

--- a/extendr-api/src/scalar/rbool.rs
+++ b/extendr-api/src/scalar/rbool.rs
@@ -55,7 +55,7 @@ gen_from_primitive!(Rbool, i32);
 
 impl From<bool> for Rbool {
     fn from(v: bool) -> Self {
-        Rbool(if v { 1 } else { 0 })
+        Rbool(i32::from(v))
     }
 }
 

--- a/extendr-api/src/wrapper/altrep.rs
+++ b/extendr-api/src/wrapper/altrep.rs
@@ -599,11 +599,7 @@ impl Altrep {
             pvec: c_int,
             func: Option<unsafe extern "C" fn(arg1: SEXP, arg2: c_int, arg3: c_int, arg4: c_int)>,
         ) -> Rboolean {
-            if Altrep::get_state::<StateType>(x).inspect(pre, deep == 1, pvec) {
-                1
-            } else {
-                0
-            }
+            u32::from(Altrep::get_state::<StateType>(x).inspect(pre, deep == 1, pvec))
         }
 
         unsafe extern "C" fn altrep_Length<StateType: AltrepImpl + 'static>(x: SEXP) -> R_xlen_t {
@@ -723,11 +719,7 @@ impl Altrep {
             unsafe extern "C" fn altinteger_No_NA<StateType: AltIntegerImpl + 'static>(
                 x: SEXP,
             ) -> c_int {
-                if Altrep::get_state::<StateType>(x).no_na() {
-                    1
-                } else {
-                    0
-                }
+                i32::from(Altrep::get_state::<StateType>(x).no_na())
             }
 
             unsafe extern "C" fn altinteger_Sum<StateType: AltIntegerImpl + 'static>(
@@ -799,11 +791,7 @@ impl Altrep {
             }
 
             unsafe extern "C" fn altreal_No_NA<StateType: AltRealImpl + 'static>(x: SEXP) -> c_int {
-                if Altrep::get_state::<StateType>(x).no_na() {
-                    1
-                } else {
-                    0
-                }
+                i32::from(Altrep::get_state::<StateType>(x).no_na())
             }
 
             unsafe extern "C" fn altreal_Sum<StateType: AltRealImpl + 'static>(
@@ -876,11 +864,7 @@ impl Altrep {
             unsafe extern "C" fn altlogical_No_NA<StateType: AltLogicalImpl + 'static>(
                 x: SEXP,
             ) -> c_int {
-                if Altrep::get_state::<StateType>(x).no_na() {
-                    1
-                } else {
-                    0
-                }
+                i32::from(Altrep::get_state::<StateType>(x).no_na())
             }
 
             unsafe extern "C" fn altlogical_Sum<StateType: AltLogicalImpl + 'static>(
@@ -1007,11 +991,7 @@ impl Altrep {
             unsafe extern "C" fn altstring_No_NA<StateType: AltStringImpl + 'static>(
                 x: SEXP,
             ) -> c_int {
-                if Altrep::get_state::<StateType>(x).no_na() {
-                    1
-                } else {
-                    0
-                }
+                i32::from(Altrep::get_state::<StateType>(x).no_na())
             }
 
             R_set_altstring_Elt_method(class_ptr, Some(altstring_Elt::<StateType>));

--- a/extendr-api/src/wrapper/externalptr.rs
+++ b/extendr-api/src/wrapper/externalptr.rs
@@ -180,6 +180,6 @@ impl<T: Any + Debug> From<ExternalPtr<T>> for Robj {
 
 impl<T: Debug + 'static> std::fmt::Debug for ExternalPtr<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        (&*self as &T).fmt(f)
+        (&**self as &T).fmt(f)
     }
 }

--- a/extendr-api/src/wrapper/list.rs
+++ b/extendr-api/src/wrapper/list.rs
@@ -92,8 +92,8 @@ impl List {
     where
         K: Into<String>,
     {
-        let mut res: Self = Self::from_values(val.iter().map(|(_, v)| v));
-        res.set_names(val.into_iter().map(|(k, _)| k.into()))?;
+        let mut res: Self = Self::from_values(val.values());
+        res.set_names(val.into_keys().map(|k| k.into()))?;
         Ok(res)
     }
 

--- a/extendr-api/src/wrapper/matrix.rs
+++ b/extendr-api/src/wrapper/matrix.rs
@@ -133,11 +133,10 @@ where
         f: F,
     ) -> Self {
         let robj = (0..ncols)
-            .map(|c| {
+            .flat_map(|c| {
                 let mut g = f.clone();
                 (0..nrows).map(move |r| g(r, c))
             })
-            .flatten()
             .collect_robj();
         let dim = [nrows, ncols];
         let mut robj = robj.set_attrib(wrapper::symbol::dim_symbol(), dim).unwrap();
@@ -167,16 +166,13 @@ where
         f: F,
     ) -> Self {
         let robj = (0..nmatrix)
-            .map(|m| {
+            .flat_map(|m| {
                 let h = f.clone();
-                (0..ncols)
-                    .map(move |c| {
-                        let mut g = h.clone();
-                        (0..nrows).map(move |r| g(r, c, m))
-                    })
-                    .flatten()
+                (0..ncols).flat_map(move |c| {
+                    let mut g = h.clone();
+                    (0..nrows).map(move |r| g(r, c, m))
+                })
             })
-            .flatten()
             .collect_robj();
         let dim = [nrows, ncols, nmatrix];
         let mut robj = robj.set_attrib(wrapper::symbol::dim_symbol(), dim).unwrap();


### PR DESCRIPTION
As I wrote in https://github.com/extendr/extendr/pull/451#issuecomment-1387190738, it's not realistic to address all the clippy warnings. This pull request addresses only the ones that are apparently fine to fix.

<details>
<summary>extra_unused_lifetimes</summary>

``` 
❯ cargo clippy -- -A clippy::all -W clippy::extra_unused_lifetimes
warning: this lifetime isn't used in the impl
   --> extendr-api\src\robj\into_robj.rs:575:6
    |
575 | impl<'a> From<Vec<Robj>> for Robj {
    |      ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#extra_unused_lifetimes
    = note: requested on the command line with `-W clippy::extra-unused-lifetimes`

warning: this lifetime isn't used in the impl
   --> extendr-api\src\robj\into_robj.rs:582:6
    |
582 | impl<'a> From<Vec<Rstr>> for Robj {
    |      ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#extra_unused_lifetimes

warning: this lifetime isn't used in the impl
   --> extendr-api\src\robj\into_robj.rs:589:6
    |
589 | impl<'a> From<Vec<Rint>> for Robj {
    |      ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#extra_unused_lifetimes

warning: this lifetime isn't used in the impl
   --> extendr-api\src\robj\into_robj.rs:596:6
    |
596 | impl<'a> From<Vec<Rfloat>> for Robj {
    |      ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#extra_unused_lifetimes

warning: this lifetime isn't used in the impl
    --> extendr-api\src\robj\mod.rs:1034:6
     |
1034 | impl<'a> PartialEq<[i32]> for Robj {
     |      ^^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#extra_unused_lifetimes

warning: this lifetime isn't used in the impl
    --> extendr-api\src\robj\mod.rs:1041:6
     |
1041 | impl<'a> PartialEq<[f64]> for Robj {
     |      ^^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#extra_unused_lifetimes

warning: `extendr-api` (lib) generated 6 warnings
    Finished dev [unoptimized + debuginfo] target(s) in 0.06s
```

</details>

<details>
<summary>bool_to_int_with_if</summary>

```
❯ cargo clippy -- -A clippy::all -W clippy::bool_to_int_with_if
warning: boolean to int conversion using if
  --> extendr-api\src\scalar\rbool.rs:58:15
   |
58 |         Rbool(if v { 1 } else { 0 })
   |               ^^^^^^^^^^^^^^^^^^^^^ help: replace with from: `i32::from(v)`
   |
   = note: `v as i32` or `v.into()` can also be valid options
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#bool_to_int_with_if
   = note: requested on the command line with `-W clippy::bool-to-int-with-if`

warning: boolean to int conversion using if
   --> extendr-api\src\wrapper\altrep.rs:602:13
    |
602 | /             if Altrep::get_state::<StateType>(x).inspect(pre, deep == 1, pvec) {
603 | |                 1
604 | |             } else {
605 | |                 0
606 | |             }
    | |_____________^ help: replace with from: `u32::from(Altrep::get_state::<StateType>(x).inspect(pre, deep == 1, pvec))`
    |
    = note: `Altrep::get_state::<StateType>(x).inspect(pre, deep == 1, pvec) as u32` or `Altrep::get_state::<StateType>(x).inspect(pre, deep == 1, pvec).into()` can also be valid options
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#bool_to_int_with_if

warning: boolean to int conversion using if
   --> extendr-api\src\wrapper\altrep.rs:726:17
    |
726 | /                 if Altrep::get_state::<StateType>(x).no_na() {
727 | |                     1
728 | |                 } else {
729 | |                     0
730 | |                 }
    | |_________________^ help: replace with from: `i32::from(Altrep::get_state::<StateType>(x).no_na())`
    |
    = note: `Altrep::get_state::<StateType>(x).no_na() as i32` or `Altrep::get_state::<StateType>(x).no_na().into()` can also be valid options
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#bool_to_int_with_if

warning: boolean to int conversion using if
   --> extendr-api\src\wrapper\altrep.rs:802:17
    |
802 | /                 if Altrep::get_state::<StateType>(x).no_na() {
803 | |                     1
804 | |                 } else {
805 | |                     0
806 | |                 }
    | |_________________^ help: replace with from: `i32::from(Altrep::get_state::<StateType>(x).no_na())`
    |
    = note: `Altrep::get_state::<StateType>(x).no_na() as i32` or `Altrep::get_state::<StateType>(x).no_na().into()` can also be valid options
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#bool_to_int_with_if

warning: boolean to int conversion using if
   --> extendr-api\src\wrapper\altrep.rs:879:17
    |
879 | /                 if Altrep::get_state::<StateType>(x).no_na() {
880 | |                     1
881 | |                 } else {
882 | |                     0
883 | |                 }
    | |_________________^ help: replace with from: `i32::from(Altrep::get_state::<StateType>(x).no_na())`
    |
    = note: `Altrep::get_state::<StateType>(x).no_na() as i32` or `Altrep::get_state::<StateType>(x).no_na().into()` can also be valid options
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#bool_to_int_with_if

warning: boolean to int conversion using if
    --> extendr-api\src\wrapper\altrep.rs:1010:17
     |
1010 | /                 if Altrep::get_state::<StateType>(x).no_na() {
1011 | |                     1
1012 | |                 } else {
1013 | |                     0
1014 | |                 }
     | |_________________^ help: replace with from: `i32::from(Altrep::get_state::<StateType>(x).no_na())`
     |
     = note: `Altrep::get_state::<StateType>(x).no_na() as i32` or `Altrep::get_state::<StateType>(x).no_na().into()` can also be valid options
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#bool_to_int_with_if

warning: `extendr-api` (lib) generated 6 warnings
    Finished dev [unoptimized + debuginfo] target(s) in 0.08s
```
</details>

<details>
<summary>map_flatten </summary>

```
❯ cargo +nightly clippy -- -A clippy::all -W clippy::map_flatten    
warning: called `map(..).flatten()` on `Iterator`
   --> extendr-api\src\wrapper\matrix.rs:136:14
    |
136 |               .map(|c| {
    |  ______________^
137 | |                 let mut g = f.clone();
138 | |                 (0..nrows).map(move |r| g(r, c))
139 | |             })
140 | |             .flatten()
    | |______________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#map_flatten
    = note: requested on the command line with `-W clippy::map-flatten`
help: try replacing `map` with `flat_map` and remove the `.flatten()`
    |
136 ~             .flat_map(|c| {
137 +                 let mut g = f.clone();
138 +                 (0..nrows).map(move |r| g(r, c))
139 +             })
    |

warning: called `map(..).flatten()` on `Iterator`
   --> extendr-api\src\wrapper\matrix.rs:170:14
    |
170 |               .map(|m| {
    |  ______________^
171 | |                 let h = f.clone();
172 | |                 (0..ncols)
173 | |                     .map(move |c| {
...   |
178 | |             })
179 | |             .flatten()
    | |______________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#map_flatten
help: try replacing `map` with `flat_map` and remove the `.flatten()`
    |
170 ~             .flat_map(|m| {
171 +                 let h = f.clone();
172 +                 (0..ncols)
173 +                     .map(move |c| {
174 +                         let mut g = h.clone();
175 +                         (0..nrows).map(move |r| g(r, c, m))
176 +                     })
177 +                     .flatten()
178 +             })
    |

warning: called `map(..).flatten()` on `Iterator`
   --> extendr-api\src\wrapper\matrix.rs:173:22
    |
173 |                       .map(move |c| {
    |  ______________________^
174 | |                         let mut g = h.clone();
175 | |                         (0..nrows).map(move |r| g(r, c, m))
176 | |                     })
177 | |                     .flatten()
    | |______________________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#map_flatten
help: try replacing `map` with `flat_map` and remove the `.flatten()`
    |
173 ~                     .flat_map(move |c| {
174 +                         let mut g = h.clone();
175 +                         (0..nrows).map(move |r| g(r, c, m))
176 +                     })
    |

warning: `extendr-api` (lib) generated 3 warnings (run `cargo clippy --fix --lib -p extendr-api` to apply 3 suggestions)
    Finished dev [unoptimized + debuginfo] target(s) in 4.91s
```
</details>

<details>
<summary>iter_kv_map</summary>

```
❯ cargo +nightly clippy -- -A clippy::all -W clippy::iter_kv_map
warning: iterating on a map's values
  --> extendr-api\src\wrapper\list.rs:95:47
   |
95 |         let mut res: Self = Self::from_values(val.iter().map(|(_, v)| v));
   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `val.values()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#iter_kv_map
   = note: requested on the command line with `-W clippy::iter-kv-map`

warning: iterating on a map's keys
  --> extendr-api\src\wrapper\list.rs:96:23
   |
96 |         res.set_names(val.into_iter().map(|(k, _)| k.into()))?;
   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `val.into_keys().map(|k| k.into())`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#iter_kv_map

warning: `extendr-api` (lib) generated 2 warnings (run `cargo clippy --fix --lib -p extendr-api` to apply 2 suggestions)
    Finished dev [unoptimized + debuginfo] target(s) in 0.05s
```
</details>

<details>
<summary>borrow_deref_ref</summary>

```
❯ cargo +nightly clippy -- -A clippy::all -W clippy::borrow_deref_ref
warning: deref on an immutable reference
   --> extendr-api\src\wrapper\externalptr.rs:183:10
    |
183 |         (&*self as &T).fmt(f)
    |          ^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#borrow_deref_ref
    = note: requested on the command line with `-W clippy::borrow-deref-ref`
help: if you would like to reborrow, try removing `&*`
    |
183 |         (self as &T).fmt(f)
    |          ~~~~
help: if you would like to deref, try using `&**`
    |
183 |         (&**self as &T).fmt(f)
    |          ~~~~~~~

warning: `extendr-api` (lib) generated 1 warning (run `cargo clippy --fix --lib -p extendr-api` to apply 1 suggestion)
    Finished dev [unoptimized + debuginfo] target(s) in 0.05s
```

</details>