### PR TITLE
document external pointer

### DIFF
--- a/extendr-api/src/wrapper/externalptr.rs
+++ b/extendr-api/src/wrapper/externalptr.rs
@@ -7,8 +7,8 @@ use std::fmt::Debug;
 /// Your R code can use external pointers to reference objects in Rust memory.
 ///
 /// External pointers can be made avaialable as their underlying type by dereferencing. 
-// In order to deference, the object must either implement the `Copy` trait or be a reference—e.g. `&T`. 
-//
+/// In order to deference, the object must either implement the `Copy` trait or be a reference—e.g. `&T`. 
+///
 /// ```
 /// use extendr_api::prelude::*;
 /// test! {
@@ -19,6 +19,7 @@ use std::fmt::Debug;
 ///     assert_eq!(*extptr2, 1);
 /// }
 /// ```
+///
 #[derive(PartialEq, Clone)]
 pub struct ExternalPtr<T: Debug + 'static> {
     /// This is the contained Robj.

--- a/extendr-api/src/wrapper/externalptr.rs
+++ b/extendr-api/src/wrapper/externalptr.rs
@@ -2,12 +2,12 @@ use super::*;
 use std::any::Any;
 use std::fmt::Debug;
 
-/// Wrapper for creating R objects containing any Rust object. 
-/// External pointers (`ExternalPtr`) are accessible from R as an object of class `externalptr`. 
+/// Wrapper for creating R objects containing any Rust object.
+/// External pointers (`ExternalPtr`) are accessible from R as an object of class `externalptr`.
 /// Your R code can use external pointers to reference objects in Rust memory.
 ///
-/// External pointers can be made avaialable as their underlying type by dereferencing. 
-/// In order to deference, the object must either implement the `Copy` trait or be a reference—e.g. `&T`. 
+/// External pointers can be made avaialable as their underlying type by dereferencing.
+/// In order to deference, the object must either implement the `Copy` trait or be a reference—e.g. `&T`.
 ///
 /// ```
 /// use extendr_api::prelude::*;

--- a/extendr-api/src/wrapper/externalptr.rs
+++ b/extendr-api/src/wrapper/externalptr.rs
@@ -2,8 +2,13 @@ use super::*;
 use std::any::Any;
 use std::fmt::Debug;
 
-/// Wrapper for creating R objects containing any Rust object.
+/// Wrapper for creating R objects containing any Rust object. 
+/// External pointers (`ExternalPtr`) are accessible from R as an object of class `externalptr`. 
+/// Your R code can use external pointers to reference objects in Rust memory.
 ///
+/// External pointers can be made avaialable as their underlying type by dereferencing. 
+// In order to deference, the object must either implement the `Copy` trait or be a reference—e.g. `&T`. 
+//
 /// ```
 /// use extendr_api::prelude::*;
 /// test! {
@@ -14,7 +19,6 @@ use std::fmt::Debug;
 ///     assert_eq!(*extptr2, 1);
 /// }
 /// ```
-///
 #[derive(PartialEq, Clone)]
 pub struct ExternalPtr<T: Debug + 'static> {
     /// This is the contained Robj.


### PR DESCRIPTION
This PR adds a few lines of documentation for the external pointer per https://discord.com/channels/751419551132155925/1067823507712516146/1067824501598986421.

Adds language that might be a bit more helpful for R users to understand. Additionally makes a note that in order to dereference the objects must have the Clone trait or be a reference.