### PR TITLE
Use Rf_mkCharLenCE() instead of Rf_mkCharLen()

### DIFF
--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -6,7 +6,13 @@ pub(crate) fn str_to_character(s: &str) -> SEXP {
         if s.is_na() {
             R_NaString
         } else {
-            single_threaded(|| Rf_mkCharLen(s.as_ptr() as *const raw::c_char, s.len() as i32))
+            single_threaded(|| {
+                Rf_mkCharLenCE(
+                    s.as_ptr() as *const raw::c_char,
+                    s.len() as i32,
+                    cetype_t_CE_UTF8,
+                )
+            })
         }
     }
 }

--- a/extendr-api/src/wrapper/strings.rs
+++ b/extendr-api/src/wrapper/strings.rs
@@ -52,7 +52,6 @@ impl Strings {
             for (i, v) in values.into_iter().take(maxlen).enumerate() {
                 let v = v.as_ref();
                 let ch = str_to_character(v);
-                // let ch = Rf_mkCharLen(v.as_ptr() as *mut c_char, v.len() as c_int);
                 SET_STRING_ELT(sexp, i as R_xlen_t, ch);
             }
             Self { robj }


### PR DESCRIPTION
Just happened to find this. This can be a problem only on Windows with R < 4.2 (`Rf_mkCharLen()` uses the native encoding), where UTF-8 is not R's default encoding, so this is almost just a nitpicking. 

For reference, cpp11 also uses `Rf_mkCharLenCE()`.

https://github.com/r-lib/cpp11/blob/c22dc9b611fe7d56ddfc57add2e01b1424869c0f/inst/include/cpp11/r_string.hpp#L19-L20