### PR TITLE
Fix `extendr_module` importing

### DIFF
--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -1,11 +1,11 @@
 //! R object handling.
 //!
-//! See. <https://cran.r-project.org/doc/manuals/R-exts.html>
+//! See. [Writing R Extensions](https://cran.r-project.org/doc/manuals/R-exts.html)
 //!
 //! Fundamental principals:
 //!
 //! * Any function that can break the protection mechanism is unsafe.
-//! * Users should be able to do almost everything without using libR_sys.
+//! * Users should be able to do almost everything without using `libR_sys`.
 //! * The interface should be friendly to R users without Rust experience.
 //!
 

--- a/extendr-api/tests/extendr_module_tests.rs
+++ b/extendr-api/tests/extendr_module_tests.rs
@@ -1,0 +1,30 @@
+//! Tests for [`extendr_module`] procedural macro.
+//!
+mod root {
+    use extendr_api::extendr;
+    use extendr_api::extendr_module;
+    use extendr_api::GetSexp;
+
+    mod nested_module {
+        use extendr_api::extendr;
+        use extendr_api::extendr_module;
+        use extendr_api::GetSexp;
+
+        #[extendr]
+        fn dummy() {}
+
+        extendr_module! {
+            mod nested_module;
+            fn dummy;
+        }
+    }
+
+    #[extendr]
+    fn hello_dummy() {}
+
+    extendr_module! {
+        mod top_level;
+        use nested_module;
+        fn hello_dummy;
+    }
+}

--- a/extendr-api/tests/extendr_module_tests.rs
+++ b/extendr-api/tests/extendr_module_tests.rs
@@ -1,12 +1,12 @@
 //! Tests for [`extendr_module`] procedural macro.
 //!
+use extendr_api::{extendr, extendr_module};
+
 mod root {
-    use extendr_api::extendr;
-    use extendr_api::extendr_module;
+    use super::*;
 
     mod nested_module {
-        use extendr_api::extendr;
-        use extendr_api::extendr_module;
+        use super::*;
 
         #[extendr]
         fn dummy() {}
@@ -23,6 +23,19 @@ mod root {
     extendr_module! {
         mod top_level;
         use nested_module;
+        use adjacent_module;
         fn hello_dummy;
+    }
+}
+
+mod adjacent_module {
+    use super::*;
+
+    #[extendr]
+    fn foo() {}
+
+    extendr_module! {
+        mod adjacent_module;
+        fn foo;
     }
 }

--- a/extendr-api/tests/extendr_module_tests.rs
+++ b/extendr-api/tests/extendr_module_tests.rs
@@ -3,12 +3,10 @@
 mod root {
     use extendr_api::extendr;
     use extendr_api::extendr_module;
-    use extendr_api::GetSexp;
 
     mod nested_module {
         use extendr_api::extendr;
         use extendr_api::extendr_module;
-        use extendr_api::GetSexp;
 
         #[extendr]
         fn dummy() {}

--- a/extendr-engine/src/lib.rs
+++ b/extendr-engine/src/lib.rs
@@ -1,17 +1,18 @@
-//! A sigleton instance of the R interpreter.
+//! A singleton instance of the R interpreter.
 //!
-//! Only call this from main() if you want to run stand-alone.
+//! Only call this from `main()` if you want to run stand-alone.
 //!
 //! Its principal use is for testing.
 //!
-//! See <https://github.com/wch/r-source/blob/trunk/src/unix/Rembedded.c>
+//! See [Rembedded.c](https://github.com/wch/r-source/blob/trunk/src/unix/Rembedded.c).
+//! 
 
 use libR_sys::*;
 use std::os::raw;
 use std::sync::Once;
 
 // Generate mutable static strings.
-// Much more efficient than CString.
+// Much more efficient than `CString`.
 // Generates asciiz.
 macro_rules! cstr_mut {
     ($s: expr) => {

--- a/extendr-engine/src/lib.rs
+++ b/extendr-engine/src/lib.rs
@@ -5,7 +5,7 @@
 //! Its principal use is for testing.
 //!
 //! See [Rembedded.c](https://github.com/wch/r-source/blob/trunk/src/unix/Rembedded.c).
-//! 
+//!
 
 use libR_sys::*;
 use std::os::raw;

--- a/extendr-macros/src/extendr_module.rs
+++ b/extendr-macros/src/extendr_module.rs
@@ -48,8 +48,8 @@ pub fn extendr_module(item: TokenStream) -> TokenStream {
             #( #implmetanames(&mut impls); )*
 
             // Extends functions and impls with the submodules metadata
-            #( functions.extend(#usemetanames().functions); )*
-            #( impls.extend(#usemetanames().impls); )*
+            #( functions.extend(#usenames::#usemetanames().functions); )*
+            #( impls.extend(#usenames::#usemetanames().impls); )*
 
             // Add this function to the list, but set hidden: true.
             functions.push(extendr_api::metadata::Func {

--- a/extendr-macros/src/extendr_module.rs
+++ b/extendr-macros/src/extendr_module.rs
@@ -88,6 +88,7 @@ pub fn extendr_module(item: TokenStream) -> TokenStream {
         #[no_mangle]
         #[allow(non_snake_case)]
         pub extern "C" fn #wrap_module_metadata_name() -> extendr_api::SEXP {
+            use extendr_api::GetSexp;
             unsafe { extendr_api::Robj::from(#module_metadata_name()).get() }
         }
 
@@ -99,6 +100,7 @@ pub fn extendr_module(item: TokenStream) -> TokenStream {
         ) -> extendr_api::SEXP {
             unsafe {
                 use extendr_api::robj::*;
+                use extendr_api::GetSexp;
                 let robj = new_owned(use_symbols_sexp);
                 let use_symbols: bool = <bool>::from_robj(&robj).unwrap();
 

--- a/extendr-macros/src/lib.rs
+++ b/extendr-macros/src/lib.rs
@@ -71,6 +71,22 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, Item};
 
+
+/// Derive macro for wrapping Rust modules, functions and traits to R.
+/// 
+/// On functions:
+/// 
+/// - Supported types are converted from [`Robj`].
+/// - `extendr(use_try_from = true)`
+/// - `extendr(r_name = "r_wrapper_name")`
+/// - `extendr(mod_name = "r_wrapper_module_name")`
+/// - To set default arguments on the R-side, use `#[default = "value"]`
+/// 
+/// On `impl`-blocks:
+/// 
+/// - Create S4 wrapper methods on the type.
+/// 
+/// 
 #[proc_macro_attribute]
 pub fn extendr(attr: TokenStream, item: TokenStream) -> TokenStream {
     let args = parse_macro_input!(attr as syn::AttributeArgs);

--- a/extendr-macros/src/lib.rs
+++ b/extendr-macros/src/lib.rs
@@ -71,22 +71,6 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, Item};
 
-
-/// Derive macro for wrapping Rust modules, functions and traits to R.
-/// 
-/// On functions:
-/// 
-/// - Supported types are converted from [`Robj`].
-/// - `extendr(use_try_from = true)`
-/// - `extendr(r_name = "r_wrapper_name")`
-/// - `extendr(mod_name = "r_wrapper_module_name")`
-/// - To set default arguments on the R-side, use `#[default = "value"]`
-/// 
-/// On `impl`-blocks:
-/// 
-/// - Create S4 wrapper methods on the type.
-/// 
-/// 
 #[proc_macro_attribute]
 pub fn extendr(attr: TokenStream, item: TokenStream) -> TokenStream {
     let args = parse_macro_input!(attr as syn::AttributeArgs);

--- a/tests/extendrtests/src/rust/src/lib.rs
+++ b/tests/extendrtests/src/rust/src/lib.rs
@@ -1,7 +1,6 @@
 use extendr_api::{graphics::*, prelude::*};
 
 mod submodule;
-use submodule::*;
 
 mod graphic_device;
 
@@ -167,7 +166,7 @@ fn check_default(#[default = "NULL"] x: Robj) -> bool {
 }
 
 // Weird behavior of parameter descriptions:
-// first passes tests as is, second -- only in backqutoes.
+// first passes tests as is, second -- only in backquotes.
 /// Test whether `_arg` parameters are treated correctly in R
 /// Executes \code{`_x` - `_y`}
 /// @param _x an integer scalar, ignored


### PR DESCRIPTION
The issue is that these `get_<module>_metadata` are generated in their respective modules, but then they aren't realy imported in the place where they get recursively called.
Others experienced this, see [discord message](https://discord.com/channels/751419551132155925/751419551132155928/1067806341491609772)

