### PR TITLE
Add `use_rng` option to attribute macro `extendr`.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   docs:
     name: Deploy the dev version of documents to GitHub Pages
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
       - name: Docs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,11 +44,11 @@ jobs:
           # - {os: macOS-latest,   r: 'devel', rust-version: 'stable'}
           # - {os: macOS-latest,   r: 'oldrel', rust-version: 'stable'}
 
-          - {os: ubuntu-20.04,   r: 'release', rust-version: 'stable', check_fmt: true}
-          - {os: ubuntu-20.04,   r: 'release', rust-version: 'nightly'}
+          - {os: ubuntu-latest,   r: 'release', rust-version: 'stable', check_fmt: true}
+          - {os: ubuntu-latest,   r: 'release', rust-version: 'nightly'}
           # R-devel requires LD_LIBRARY_PATH
-          - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable'}
-          - {os: ubuntu-20.04,   r: 'oldrel',  rust-version: 'stable'}
+          - {os: ubuntu-latest,   r: 'devel',   rust-version: 'stable'}
+          - {os: ubuntu-latest,   r: 'oldrel',  rust-version: 'stable'}
 
 
 
@@ -299,7 +299,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: ubuntu-20.04,   r: 'devel', rust-version: 'stable'}
+          - {os: ubuntu-latest,   r: 'devel', rust-version: 'stable'}
           - {os: macOS-latest,   r: 'devel', rust-version: 'stable'}
           - {os: windows-latest, r: 'release', rust-version: 'stable-gnu',   rust-targets: ['x86_64-pc-windows-gnu'], rtools-version: '42'}
           - {os: windows-latest, r: 'release', rust-version: 'stable-msvc',  rust-targets: ['x86_64-pc-windows-gnu'], rtools-version: '42'}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,13 +70,12 @@ jobs:
         shell: pwsh
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.config.rust-version }}
-          default: true
           components: rustfmt, clippy
       
       - name: Set up R
@@ -201,7 +200,7 @@ jobs:
 
       # c.f. https://github.com/actions/checkout#checkout-multiple-repos-side-by-side
       - name: Obtain 'rextendr'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: extendr/rextendr
           path: ./tests/rextendr
@@ -320,13 +319,12 @@ jobs:
         shell: pwsh
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.config.rust-version }}
-          default: true
 
       # 1. Update rustup
       # 2. For each target add respective toolchain &

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- `use_rng` option for the `extendr` attribute macro, which enables the use of
+random number sampling methods from R, e.g. `#[extendr(use_rng = true)`. [[#476]](https://github.com/extendr/extendr/pull/476)
 - [**ndarray**] `TryFrom<&Robj>` for `ArrayView1<T>` and `ArrayView2<T>`, where `T` is `i32`, `f64`, `c64`, `Rint`, `Rfloat`, `Rcplx`, `Rstr`, `Rbool` [[#443]](https://github.com/extendr/extendr/pull/443)
 - `Sum` for scalars like `Rint`, `Rfloat` and `Rcplx`, which accept `Iterator<Item = &Rtype>` [[#454]](https://github.com/extendr/extendr/pull/454)
 - `Nullable<T>` is now part of `extendr_api::prelude` [[#446]](https://github.com/extendr/extendr/pull/446)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,9 @@
 
 members = [
 	"extendr-api",
-	"extendr-engine",
-	"extendr-macros",
-]
+
+[workspace.dependencies]
+libR-sys = "0.3.0"
 
 [patch.crates-io]
 # When uncommenting this, do not forget to uncomment the same line in

--- a/extendr-api/Cargo.toml
+++ b/extendr-api/Cargo.toml
@@ -15,9 +15,10 @@ license = "MIT"
 repository = "https://github.com/extendr/extendr"
 
 [dependencies]
-libR-sys = "0.3.0"
+libR-sys = { workspace = true }
 extendr-macros = { path = "../extendr-macros", version = "0.3.1" }
 extendr-engine = { path = "../extendr-engine", version = "0.3.1" }
+libR-sys = "0.3.0"
 ndarray = { version = "0.15.3", optional = true }
 lazy_static = "1.4"
 paste = "1.0.5"

--- a/extendr-api/src/na.rs
+++ b/extendr-api/src/na.rs
@@ -1,4 +1,28 @@
+use lazy_static::lazy_static;
 use libR_sys::{R_IsNA, R_NaReal};
+use std::alloc::{self, Layout};
+
+// To make sure this "NA" is allocated at a different place than any other "NA"
+// strings (so that it can be used as a sentinel value), we allocate it by
+// ourselves.
+lazy_static! {
+    static ref EXTENDR_NA_STRING: &'static str = unsafe {
+        // Layout::array() can fail when the size exceeds `isize::MAX`, but we
+        // only need 2 here, so it's safe to unwrap().
+        let layout = Layout::array::<u8>(2).unwrap();
+
+        // We allocate and never free it because we need this pointer to be
+        // alive until the program ends.
+        let ptr = alloc::alloc(layout);
+
+        let v: &mut [u8] = std::slice::from_raw_parts_mut(ptr, 2);
+        v[0] = b'N';
+        v[1] = b'A';
+
+        std::str::from_utf8_unchecked(v)
+    };
+}
+
 /// Return true if this primitive is NA.
 pub trait CanBeNA {
     fn is_na(&self) -> bool;
@@ -54,6 +78,6 @@ impl CanBeNA for &str {
     }
 
     fn na() -> Self {
-        unsafe { std::str::from_utf8_unchecked(&[b'N', b'A']) }
+        &EXTENDR_NA_STRING
     }
 }

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -477,6 +477,43 @@ pub trait RobjItertools: Iterator {
         assert!(vec.iter().size_hint() == (vec.len(), Some(vec.len())));
         vec.into_iter().collect_robj()
     }
+
+    /// Collects an iterable into an [`RArray`].
+    /// The iterable must yield items column by column (aka Fortan order)
+    ///
+    /// # Arguments
+    ///
+    /// * `dims` - an array containing the length of each dimension
+    fn collect_rarray<'a, const LEN: usize>(
+        self,
+        dims: [usize; LEN],
+    ) -> Result<RArray<Self::Item, [usize; LEN]>>
+    where
+        Self: Iterator,
+        Self: Sized,
+        Self::Item: ToVectorValue,
+        Robj: AsTypedSlice<'a, Self::Item>,
+        Self::Item: 'a,
+    {
+        let vector = self.collect_robj();
+        let prod = dims.iter().product::<usize>();
+        if prod != vector.len() {
+            return Err(Error::Other(format!(
+                "The vector length ({}) does not match the length implied by the dimensions ({})",
+                vector.len(),
+                prod
+            )));
+        }
+        let mut robj =
+            vector.set_attrib(wrapper::symbol::dim_symbol(), dims.iter().collect_robj())?;
+        let data = robj
+            .as_typed_slice_mut()
+            .ok_or(Error::Other(
+                "Unknown error in converting to slice".to_string(),
+            ))?
+            .as_mut_ptr();
+        Ok(RArray::from_parts(robj, data, dims))
+    }
 }
 
 // Thanks to *pretzelhammer* on stackoverflow for this.
@@ -603,5 +640,54 @@ impl From<Vec<Rfloat>> for Robj {
     /// Convert a vector of Rfloat into doubles.
     fn from(val: Vec<Rfloat>) -> Self {
         Doubles::from_values(val.into_iter()).into()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_collect_rarray_matrix() {
+        test! {
+            // Check that collect_rarray works the same as R's matrix() function
+            let rmat = (1i32..=16).collect_rarray([4, 4]);
+            assert!(rmat.is_ok());
+            assert_eq!(Robj::from(rmat), R!("matrix(1:16, nrow=4)").unwrap());
+        }
+    }
+
+    #[test]
+    fn test_collect_rarray_tensor() {
+        test! {
+            // Check that collect_rarray works the same as R's array() function
+            let rmat = (1i32..=16).collect_rarray([2, 4, 2]);
+            assert!(rmat.is_ok());
+            assert_eq!(Robj::from(rmat), R!("array(1:16, dim=c(2, 4, 2))").unwrap());
+        }
+    }
+
+    #[test]
+    fn test_collect_rarray_matrix_failure() {
+        test! {
+            // Check that collect_rarray fails when given an invalid shape
+            let rmat = (1i32..=16).collect_rarray([3, 3]);
+            assert!(rmat.is_err());
+            let msg = rmat.unwrap_err().to_string();
+            assert!(msg.contains("9"));
+            assert!(msg.contains("dimension"));
+        }
+    }
+
+    #[test]
+    fn test_collect_tensor_failure() {
+        test! {
+            // Check that collect_rarray fails when given an invalid shape
+            let rmat = (1i32..=16).collect_rarray([3, 3, 3]);
+            assert!(rmat.is_err());
+            let msg = rmat.unwrap_err().to_string();
+            assert!(msg.contains("27"));
+            assert!(msg.contains("dimension"));
+        }
     }
 }

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -6,7 +6,13 @@ pub(crate) fn str_to_character(s: &str) -> SEXP {
         if s.is_na() {
             R_NaString
         } else {
-            single_threaded(|| Rf_mkCharLen(s.as_ptr() as *const raw::c_char, s.len() as i32))
+            single_threaded(|| {
+                Rf_mkCharLenCE(
+                    s.as_ptr() as *const raw::c_char,
+                    s.len() as i32,
+                    cetype_t_CE_UTF8,
+                )
+            })
         }
     }
 }

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -1,11 +1,11 @@
 //! R object handling.
 //!
-//! See. <https://cran.r-project.org/doc/manuals/R-exts.html>
+//! See. [Writing R Extensions](https://cran.r-project.org/doc/manuals/R-exts.html)
 //!
 //! Fundamental principals:
 //!
 //! * Any function that can break the protection mechanism is unsafe.
-//! * Users should be able to do almost everything without using libR_sys.
+//! * Users should be able to do almost everything without using `libR_sys`.
 //! * The interface should be friendly to R users without Rust experience.
 //!
 

--- a/extendr-api/src/robj_ndarray.rs
+++ b/extendr-api/src/robj_ndarray.rs
@@ -1,3 +1,63 @@
+/*!
+Defines conversions between R objects and the [ndarray](https://docs.rs/ndarray/latest/ndarray/) crate, which offers native Rust array types and numerical computation routines.
+
+To enable these conversions, you must first enable the `ndarray` feature for extendr:
+```toml
+[dependencies]
+extendr-api = { version = "0.3.1", features = ["ndarray"] }
+```
+
+Specifically, extendr supports the following conversions:
+* [`Robj` → `ArrayView1`](FromRobj#impl-FromRobj<%27a>-for-ArrayView1<%27a%2C%20T>), for when you have an R vector that you want to analyse in Rust:
+    ```rust
+    use extendr_api::prelude::*;
+    use ndarray::ArrayView1;
+
+    #[extendr]
+    fn describe_vector(vector: ArrayView1<f64>){
+        println!("This R vector has length {:?}", vector.len())
+    }
+    ```
+* [`Robj` → `ArrayView2`](FromRobj#impl-FromRobj<%27a>-for-ArrayView2<%27a%2C%20f64>), for when you have an R matrix that you want to analyse in Rust.
+    ```rust
+    use extendr_api::prelude::*;
+    use ndarray::ArrayView2;
+
+    #[extendr]
+    fn describe_matrix(matrix: ArrayView2<f64>){
+        println!("This R matrix has shape {:?}", matrix.dim())
+    }
+    ```
+* [`ArrayBase` → `Robj`](Robj#impl-TryFrom<ArrayBase<S%2C%20D>>-for-Robj), for when you want to return a reference to an [`ndarray`] Array from Rust back to R.
+    ```rust
+    use extendr_api::prelude::*;
+    use ndarray::Array2;
+
+    #[extendr]
+    fn return_matrix() -> Robj {
+        Array2::<f64>::zeros((4, 4)).try_into().unwrap()
+    }
+    ```
+
+The item type (ie the `T` in [`Array2<T>`]) can be a variety of Rust types that can represent scalars: [`u32`], [`i32`], [`f64`] and, if you have the `num_complex` compiled feature
+enabled, `Complex<f64>`. Items can also be extendr's wrapper types: [`Rbool`], [`Rint`], [`Rfloat`] and [`Rcplx`].
+
+Note that the extendr-ndarray integration only supports accessing R arrays as [`ArrayView`], which are immutable.
+Therefore, instead of directly editing the input array, it is recommended that you instead return a new array from your `#[extendr]`-annotated function, which you allocate in Rust.
+It will then be copied into a new block of memory managed by R.
+This is made easier by the fact that [ndarray allocates a new array automatically when performing operations on array references](ArrayBase#binary-operators-with-array-and-scalar):
+```rust
+use extendr_api::prelude::*;
+use ndarray::Array2;
+
+#[extendr]
+fn scalar_multiplication(matrix: ArrayView2<f64>, scalar: f64) -> Robj {
+    (&matrix * scalar).try_into().unwrap()
+}
+```
+
+For all array uses in Rust, refer to the [`ndarray::ArrayBase`] documentation, which explains the usage for all of the above types.
+*/
 #[doc(hidden)]
 use ndarray::prelude::*;
 use ndarray::{Data, ShapeBuilder};
@@ -113,6 +173,8 @@ where
 {
     type Error = Error;
 
+    /// Converts a reference to an ndarray Array into an equivalent R array.
+    /// The data itself is copied.
     fn try_from(value: &ArrayBase<S, D>) -> Result<Self> {
         // Refer to https://github.com/rust-ndarray/ndarray/issues/1060 for an excellent discussion
         // on how to convert from `ndarray` types to R/fortran arrays
@@ -139,6 +201,21 @@ where
                         ))
                     })?,
             )
+    }
+}
+
+impl<A, S, D> TryFrom<ArrayBase<S, D>> for Robj
+where
+    S: Data<Elem = A>,
+    A: Copy + ToVectorValue,
+    D: Dimension,
+{
+    type Error = Error;
+
+    /// Converts an ndarray Array into an equivalent R array.
+    /// The data itself is copied.
+    fn try_from(value: ArrayBase<S, D>) -> Result<Self> {
+        Robj::try_from(&value)
     }
 }
 
@@ -201,45 +278,55 @@ mod test {
     #[rstest]
     #[case(
         // An empty array should still convert to an empty R array with the same shape
-        &Array4::<i32>::zeros((0, 1, 2, 3).f()),
+        Array4::<i32>::zeros((0, 1, 2, 3).f()),
         "array(integer(), c(0, 1, 2, 3))"
     )]
     #[case(
-        &array![1., 2., 3.],
+        array![1., 2., 3.],
         "array(c(1, 2, 3))"
     )]
     #[case(
         // We give both R and Rust the same 1d vector and tell them both to read it as a matrix in C order.
         // Therefore these arrays should be the same.
-        &Array::from_shape_vec((2, 3), vec![1., 2., 3., 4., 5., 6.]).unwrap(),
+        Array::from_shape_vec((2, 3), vec![1., 2., 3., 4., 5., 6.]).unwrap(),
         "matrix(c(1, 2, 3, 4, 5, 6), nrow=2, byrow=TRUE)"
     )]
     #[case(
         // We give both R and Rust the same 1d vector and tell them both to read it as a matrix
         // in fortran order. Therefore these arrays should be the same.
-        &Array::from_shape_vec((2, 3).f(), vec![1., 2., 3., 4., 5., 6.]).unwrap(),
+        Array::from_shape_vec((2, 3).f(), vec![1., 2., 3., 4., 5., 6.]).unwrap(),
         "matrix(c(1, 2, 3, 4, 5, 6), nrow=2, byrow=FALSE)"
     )]
     #[case(
         // We give both R and Rust the same 1d vector and tell them both to read it as a 3d array
         // in fortran order. Therefore these arrays should be the same.
-        &Array::from_shape_vec((1, 2, 3).f(), vec![1, 2, 3, 4, 5, 6]).unwrap(),
+        Array::from_shape_vec((1, 2, 3).f(), vec![1, 2, 3, 4, 5, 6]).unwrap(),
         "array(1:6, c(1, 2, 3))"
     )]
     #[case(
         // We give R a 1d vector and tell it to read it as a 3d vector
         // Then we give Rust the equivalent vector manually split out.
-        &array![[[1, 5], [3, 7]], [[2, 6], [4, 8]]],
+        array![[[1, 5], [3, 7]], [[2, 6], [4, 8]]],
         "array(1:8, dim=c(2, 2, 2))"
     )]
-    fn test_to_robj<T>(#[case] array: T, #[case] r_expr: &str)
-    where
-        Robj: TryFrom<T>,
-        <Robj as TryFrom<T>>::Error: std::fmt::Debug,
+    fn test_to_robj<ElementType, DimType>(
+        #[case] array: Array<ElementType, DimType>,
+        #[case] r_expr: &str,
+    ) where
+        Robj: TryFrom<Array<ElementType, DimType>>,
+        for<'a> Robj: TryFrom<&'a Array<ElementType, DimType>>,
+        <robj::Robj as TryFrom<Array<ElementType, DimType>>>::Error: std::fmt::Debug,
+        for<'a> <robj::Robj as TryFrom<&'a Array<ElementType, DimType>>>::Error: std::fmt::Debug,
     {
         // Tests for the Rust → R conversion, so we therefore perform the
         // comparison in R
         test! {
+            // Test for borrowed array
+            assert_eq!(
+                &(Robj::try_from(&array).unwrap()),
+                &eval_string(r_expr).unwrap()
+            );
+            // Test for owned array
             assert_eq!(
                 &(Robj::try_from(array).unwrap()),
                 &eval_string(r_expr).unwrap()

--- a/extendr-api/src/wrapper/matrix.rs
+++ b/extendr-api/src/wrapper/matrix.rs
@@ -126,7 +126,16 @@ where
     Robj: AsTypedSlice<'a, T>,
 {
     /// Create a new matrix wrapper.
-    /// Make a new column type.
+    ///
+    /// # Arguments
+    ///
+    /// * `nrows` - the number of rows the returned matrix will have
+    /// * `ncols` - the number of columns the returned matrix will have
+    /// * `f` - a function that will be called for each entry of the matrix in order to populate it with values.
+    ///     It must return a scalar value that can be converted to an R scalar, such as `u32`, `f64`, i.e. see [ToVectorValue].
+    ///     It accepts two arguments:
+    ///     * `r` - the current row of the entry we are creating
+    ///     * `c` - the current column of the entry we are creating
     pub fn new_matrix<F: Clone + FnMut(usize, usize) -> T>(
         nrows: usize,
         ncols: usize,

--- a/extendr-api/src/wrapper/strings.rs
+++ b/extendr-api/src/wrapper/strings.rs
@@ -52,7 +52,6 @@ impl Strings {
             for (i, v) in values.into_iter().take(maxlen).enumerate() {
                 let v = v.as_ref();
                 let ch = str_to_character(v);
-                // let ch = Rf_mkCharLen(v.as_ptr() as *mut c_char, v.len() as c_int);
                 SET_STRING_ELT(sexp, i as R_xlen_t, ch);
             }
             Self { robj }

--- a/extendr-api/tests/extendr_module_tests.rs
+++ b/extendr-api/tests/extendr_module_tests.rs
@@ -1,0 +1,41 @@
+//! Tests for [`extendr_module`] procedural macro.
+//!
+use extendr_api::{extendr, extendr_module};
+
+mod root {
+    use super::*;
+
+    mod nested_module {
+        use super::*;
+
+        #[extendr]
+        fn dummy() {}
+
+        extendr_module! {
+            mod nested_module;
+            fn dummy;
+        }
+    }
+
+    #[extendr]
+    fn hello_dummy() {}
+
+    extendr_module! {
+        mod top_level;
+        use nested_module;
+        use adjacent_module;
+        fn hello_dummy;
+    }
+}
+
+mod adjacent_module {
+    use super::*;
+
+    #[extendr]
+    fn foo() {}
+
+    extendr_module! {
+        mod adjacent_module;
+        fn foo;
+    }
+}

--- a/extendr-api/tests/rng_tests.rs
+++ b/extendr-api/tests/rng_tests.rs
@@ -1,0 +1,40 @@
+//! Tests the ability to use R to generate random numbers.
+//!
+//! The `extendr` attribute macro now has a `use_rng` argument.
+//! If this is used, then a `GetRNGstate()` is invoked before the function is called,
+//! and a `PutRNGstate()` is invoked after, even if said method panics.
+//!
+//! These tests has to check two things:
+//!
+//! * That the seed is set and affects the sampling functions on the rust-side
+//! in the same way, as on the r-side.
+//! * That the resulting sampled vector is not equal 0, as it would be that
+//! if `GetRNGstate()` is not called prior to sampling.
+//!
+//!
+use extendr_api::prelude::*;
+
+#[extendr(use_rng = true)]
+fn generate_big_random_vec() -> Vec<f64> {
+    let n = 100;
+    let param = 10e3;
+    (0..n)
+        .map(|_| unsafe { libR_sys::R_unif_index(param) })
+        .collect()
+}
+
+#[test]
+fn test_extendr_rng() {
+    test! {
+        R!(r#"set.seed(20230205)"#).unwrap();
+        let x = generate_big_random_vec();
+        R!(r#"set.seed(20230205)"#).unwrap();
+        let y = generate_big_random_vec();
+        assert_eq!(y, x);
+        // if the rng state isn't retrieved, then distribution is
+        // 0 always
+        assert!(
+            !x.iter().all(|x|x.round() as isize == 0)
+        );
+    }
+}

--- a/extendr-engine/src/lib.rs
+++ b/extendr-engine/src/lib.rs
@@ -1,17 +1,18 @@
-//! A sigleton instance of the R interpreter.
+//! A singleton instance of the R interpreter.
 //!
-//! Only call this from main() if you want to run stand-alone.
+//! Only call this from `main()` if you want to run stand-alone.
 //!
 //! Its principal use is for testing.
 //!
-//! See <https://github.com/wch/r-source/blob/trunk/src/unix/Rembedded.c>
+//! See [Rembedded.c](https://github.com/wch/r-source/blob/trunk/src/unix/Rembedded.c).
+//!
 
 use libR_sys::*;
 use std::os::raw;
 use std::sync::Once;
 
 // Generate mutable static strings.
-// Much more efficient than CString.
+// Much more efficient than `CString`.
 // Generates asciiz.
 macro_rules! cstr_mut {
     ($s: expr) => {

--- a/extendr-macros/Cargo.toml
+++ b/extendr-macros/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "Mossa Merhi Reimert <mossa@sund.ku.dk>",
     "Claus O. Wilke <wilke@austin.utexas.edu>",
     "Hiroaki Yutani",
-    "Ilia A. Kosenkov <ilia.kosenkov@outlook.com>"
+    "Ilia A. Kosenkov <ilia.kosenkov@outlook.com>",
 ]
 edition = "2021"
 description = "Generate bindings from R to Rust."
@@ -25,3 +25,4 @@ proc-macro2 = { version = "1.0" }
 [dev-dependencies]
 extendr-api = { path = "../extendr-api" }
 extendr-engine = { path = "../extendr-engine" }
+libR-sys = { workspace = true }

--- a/extendr-macros/src/extendr_function.rs
+++ b/extendr-macros/src/extendr_function.rs
@@ -10,7 +10,6 @@ pub fn extendr_function(args: Vec<syn::NestedMeta>, mut func: ItemFn) -> TokenSt
     for arg in &args {
         parse_options(&mut opts, arg);
     }
-
     let mut wrappers: Vec<ItemFn> = Vec::new();
     wrappers::make_function_wrappers(&opts, &mut wrappers, "", &func.attrs, &mut func.sig, None);
 
@@ -21,12 +20,17 @@ pub fn extendr_function(args: Vec<syn::NestedMeta>, mut func: ItemFn) -> TokenSt
     })
 }
 
-/// Parse a set of attribute arguments for #[extendr(opts...)]
+/// Parse a set of attribute arguments for `#[extendr(opts...)]`
+///
+/// Supported options:
+///
+/// - `use_try_from = bool` which employs `TryFrom<Robj>` for argument conversions.
+/// - `r_name = "name"` which
 pub fn parse_options(opts: &mut wrappers::ExtendrOptions, arg: &syn::NestedMeta) {
     use syn::{Lit, LitBool, Meta, MetaNameValue, NestedMeta};
 
     fn help_message() -> ! {
-        panic!("expected #[extendr(use_try_from=bool, r_name=\"name\")]");
+        panic!("expected #[extendr(use_try_from = bool, r_name = \"name\", mod_name = \"r_mod_name\", use_rng = bool)]");
     }
 
     match arg {
@@ -50,6 +54,12 @@ pub fn parse_options(opts: &mut wrappers::ExtendrOptions, arg: &syn::NestedMeta)
             } else if path.is_ident("mod_name") {
                 if let Lit::Str(litstr) = lit {
                     opts.mod_name = Some(litstr.value());
+                } else {
+                    help_message();
+                }
+            } else if path.is_ident("use_rng") {
+                if let Lit::Bool(LitBool { value, .. }) = lit {
+                    opts.use_rng = *value;
                 } else {
                     help_message();
                 }

--- a/extendr-macros/src/extendr_module.rs
+++ b/extendr-macros/src/extendr_module.rs
@@ -48,8 +48,8 @@ pub fn extendr_module(item: TokenStream) -> TokenStream {
             #( #implmetanames(&mut impls); )*
 
             // Extends functions and impls with the submodules metadata
-            #( functions.extend(#usemetanames().functions); )*
-            #( impls.extend(#usemetanames().impls); )*
+            #( functions.extend(#usenames::#usemetanames().functions); )*
+            #( impls.extend(#usenames::#usemetanames().impls); )*
 
             // Add this function to the list, but set hidden: true.
             functions.push(extendr_api::metadata::Func {
@@ -88,6 +88,7 @@ pub fn extendr_module(item: TokenStream) -> TokenStream {
         #[no_mangle]
         #[allow(non_snake_case)]
         pub extern "C" fn #wrap_module_metadata_name() -> extendr_api::SEXP {
+            use extendr_api::GetSexp;
             unsafe { extendr_api::Robj::from(#module_metadata_name()).get() }
         }
 
@@ -99,6 +100,7 @@ pub fn extendr_module(item: TokenStream) -> TokenStream {
         ) -> extendr_api::SEXP {
             unsafe {
                 use extendr_api::robj::*;
+                use extendr_api::GetSexp;
                 let robj = new_owned(use_symbols_sexp);
                 let use_symbols: bool = <bool>::from_robj(&robj).unwrap();
 

--- a/extendr-macros/src/lib.rs
+++ b/extendr-macros/src/lib.rs
@@ -71,6 +71,22 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, Item};
 
+
+/// Derive macro for wrapping Rust modules, functions and traits to R.
+/// 
+/// On functions:
+/// 
+/// - Supported types are converted from [`Robj`].
+/// - `extendr(use_try_from = true)`
+/// - `extendr(r_name = "r_wrapper_name")`
+/// - `extendr(mod_name = "r_wrapper_module_name")`
+/// - To set default arguments on the R-side, use `#[default = "value"]`
+/// 
+/// On `impl`-blocks:
+/// 
+/// - Create S4 wrapper methods on the type.
+/// 
+/// 
 #[proc_macro_attribute]
 pub fn extendr(attr: TokenStream, item: TokenStream) -> TokenStream {
     let args = parse_macro_input!(attr as syn::AttributeArgs);

--- a/extendr-macros/src/lib.rs
+++ b/extendr-macros/src/lib.rs
@@ -71,22 +71,6 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, Item};
 
-
-/// Derive macro for wrapping Rust modules, functions and traits to R.
-/// 
-/// On functions:
-/// 
-/// - Supported types are converted from [`Robj`].
-/// - `extendr(use_try_from = true)`
-/// - `extendr(r_name = "r_wrapper_name")`
-/// - `extendr(mod_name = "r_wrapper_module_name")`
-/// - To set default arguments on the R-side, use `#[default = "value"]`
-/// 
-/// On `impl`-blocks:
-/// 
-/// - Create S4 wrapper methods on the type.
-/// 
-/// 
 #[proc_macro_attribute]
 pub fn extendr(attr: TokenStream, item: TokenStream) -> TokenStream {
     let args = parse_macro_input!(attr as syn::AttributeArgs);

--- a/tests/extendrtests/src/rust/src/lib.rs
+++ b/tests/extendrtests/src/rust/src/lib.rs
@@ -1,7 +1,6 @@
 use extendr_api::{graphics::*, prelude::*};
 
 mod submodule;
-use submodule::*;
 
 mod ndarray;
 use ndarray::*;
@@ -170,7 +169,7 @@ fn check_default(#[default = "NULL"] x: Robj) -> bool {
 }
 
 // Weird behavior of parameter descriptions:
-// first passes tests as is, second -- only in backqutoes.
+// first passes tests as is, second -- only in backquotes.
 /// Test whether `_arg` parameters are treated correctly in R
 /// Executes \code{`_x` - `_y`}
 /// @param _x an integer scalar, ignored


### PR DESCRIPTION
Fixes #474.
But depends on extendr/libR-sys#123 and corresponding `generated_bindings` pr before merging this.
I tested this on my forks of this, and you can too!
This also depends on #469.