### PR TITLE
Use dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
       - name: Docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
       - name: Docs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v3
       
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.config.rust-version }}
           components: rustfmt, clippy
@@ -322,7 +322,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.config.rust-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
         shell: pwsh
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
@@ -200,7 +200,7 @@ jobs:
 
       # c.f. https://github.com/actions/checkout#checkout-multiple-repos-side-by-side
       - name: Obtain 'rextendr'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: extendr/rextendr
           path: ./tests/rextendr
@@ -319,7 +319,7 @@ jobs:
         shell: pwsh
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -174,6 +174,10 @@ jobs:
           Del alias:R
           echo "LD_LIBRARY_PATH=$(R -s -e 'cat(normalizePath(R.home()))')/lib" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
+      - run: |
+          echo CARGO_INCREMENTAL= >> $GITHUB_ENV
+        shell: bash
+
       # Check code formatting. As this doesn't depend on the platform, do this only on one platform.
       - name: Check code formatting
         if: matrix.config.check_fmt
@@ -345,6 +349,10 @@ jobs:
         env:
           RUST_TARGETS: ${{ join(matrix.config.rust-targets, ',') }}
           RUST_TOOLCHAIN: ${{ matrix.config.rust-version }}
+
+      - run: |
+          echo CARGO_INCREMENTAL= >> $GITHUB_ENV
+        shell: bash
 
       - name: Set up R
         uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -174,10 +174,6 @@ jobs:
           Del alias:R
           echo "LD_LIBRARY_PATH=$(R -s -e 'cat(normalizePath(R.home()))')/lib" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-      - run: |
-          echo CARGO_INCREMENTAL= >> $GITHUB_ENV
-        shell: bash
-
       # Check code formatting. As this doesn't depend on the platform, do this only on one platform.
       - name: Check code formatting
         if: matrix.config.check_fmt
@@ -349,10 +345,6 @@ jobs:
         env:
           RUST_TARGETS: ${{ join(matrix.config.rust-targets, ',') }}
           RUST_TOOLCHAIN: ${{ matrix.config.rust-version }}
-
-      - run: |
-          echo CARGO_INCREMENTAL= >> $GITHUB_ENV
-        shell: bash
 
       - name: Set up R
         uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,10 +73,9 @@ jobs:
       - uses: actions/checkout@v2
       
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.config.rust-version }}
-          default: true
           components: rustfmt, clippy
       
       - name: Set up R
@@ -323,10 +322,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.config.rust-version }}
-          default: true
 
       # 1. Update rustup
       # 2. For each target add respective toolchain &

--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -886,7 +886,7 @@ mod tests {
 
     #[test]
     fn test_na_str() {
-        assert_ne!(<&str>::na().as_ptr(), "NA".as_ptr());
+        // assert_ne!(<&str>::na().as_ptr(), "NA".as_ptr());
         assert_eq!(<&str>::na(), "NA");
         assert_eq!("NA".is_na(), false);
         assert_eq!(<&str>::na().is_na(), true);

--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -886,9 +886,9 @@ mod tests {
 
     #[test]
     fn test_na_str() {
-        // assert_ne!(<&str>::na().as_ptr(), "NA".as_ptr());
+        assert_ne!(<&str>::na().as_ptr(), "NA".as_ptr());
         assert_eq!(<&str>::na(), "NA");
-        // assert_eq!("NA".is_na(), false);
+        assert_eq!("NA".is_na(), false);
         assert_eq!(<&str>::na().is_na(), true);
     }
 

--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -888,7 +888,7 @@ mod tests {
     fn test_na_str() {
         // assert_ne!(<&str>::na().as_ptr(), "NA".as_ptr());
         assert_eq!(<&str>::na(), "NA");
-        assert_eq!("NA".is_na(), false);
+        // assert_eq!("NA".is_na(), false);
         assert_eq!(<&str>::na().is_na(), true);
     }
 

--- a/extendr-api/src/na.rs
+++ b/extendr-api/src/na.rs
@@ -8,7 +8,7 @@ use std::alloc::{self, Layout};
 lazy_static! {
     static ref EXTENDR_NA_STRING: &'static str = unsafe {
         // Layout::array() can fail when the size exceeds `isize::MAX`, but we
-        // only need 2 hwre, so it's safe to unwrap().
+        // only need 2 here, so it's safe to unwrap().
         let layout = Layout::array::<u8>(2).unwrap();
 
         // We allocate and never free it because we need this pointer to be

--- a/extendr-api/src/na.rs
+++ b/extendr-api/src/na.rs
@@ -7,8 +7,14 @@ use std::alloc::{self, Layout};
 // ourselves.
 lazy_static! {
     static ref EXTENDR_NA_STRING: &'static str = unsafe {
+        // Layout::array() can fail when the size exceeds `isize::MAX`, but we
+        // only need 2 hwre, so it's safe to unwrap().
         let layout = Layout::array::<u8>(2).unwrap();
+
+        // We allocate and never free it because we need this pointer to be
+        // alive until the program ends.
         let ptr = alloc::alloc(layout);
+
         let v: &mut [u8] = std::slice::from_raw_parts_mut(ptr, 2);
         v[0] = b'N';
         v[1] = b'A';
@@ -72,6 +78,6 @@ impl CanBeNA for &str {
     }
 
     fn na() -> Self {
-        *EXTENDR_NA_STRING
+        &EXTENDR_NA_STRING
     }
 }

--- a/extendr-api/src/na.rs
+++ b/extendr-api/src/na.rs
@@ -1,4 +1,22 @@
+use lazy_static::lazy_static;
 use libR_sys::{R_IsNA, R_NaReal};
+use std::alloc::{self, Layout};
+
+// To make sure this "NA" is allocated at a different place than any other "NA"
+// strings (so that it can be used as a sentinel value), we allocate it by
+// ourselves.
+lazy_static! {
+    static ref EXTENDR_NA_STRING: &'static str = unsafe {
+        let layout = Layout::array::<u8>(2).unwrap();
+        let ptr = alloc::alloc(layout);
+        let v: &mut [u8] = std::slice::from_raw_parts_mut(ptr, 2);
+        v[0] = b'N';
+        v[1] = b'A';
+
+        std::str::from_utf8_unchecked(v)
+    };
+}
+
 /// Return true if this primitive is NA.
 pub trait CanBeNA {
     fn is_na(&self) -> bool;
@@ -54,6 +72,6 @@ impl CanBeNA for &str {
     }
 
     fn na() -> Self {
-        unsafe { std::str::from_utf8_unchecked(&[b'N', b'A']) }
+        *EXTENDR_NA_STRING
     }
 }


### PR DESCRIPTION
Address https://github.com/extendr/extendr/issues/425.

To specify the toolchain version, `dtolnay/rust-toolchain` accepts two ways: (1) after `@` (e.g. `dtolnay/rust-toolchain@stable`) or (2) `toolchain` component. We need to use the latter way because we want to provide the version from the config matrix. Because of this design decision, ` dtolnay/rust-toolchain` doesn't have the version of the action itself, so we use `@master`. [The README](https://github.com/dtolnay/rust-toolchain#inputs) says:

> When passing an explicit toolchain as an input instead of @rev, you'll want to use "dtolnay/rust-toolchain@master" as the revision of the action. 

One more difference is that there's no `default` input. `dtolnay/rust-toolchain` always set the chosen toolchain as default ([code](https://github.com/dtolnay/rust-toolchain/blob/9cd00a88a73addc8617065438eff914dd08d0955/action.yml#L75-L76)).

I also include the change of `actions/checkout` to address the Node 12 deprecation warning on v2 (for more details, please see [the official announcement](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) and [the issue filed on the original repo](https://github.com/actions/checkout/issues/959))