### PR TITLE
Use ubuntu-latest on CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   docs:
     name: Deploy the dev version of documents to GitHub Pages
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,11 +44,11 @@ jobs:
           # - {os: macOS-latest,   r: 'devel', rust-version: 'stable'}
           # - {os: macOS-latest,   r: 'oldrel', rust-version: 'stable'}
 
-          - {os: ubuntu-20.04,   r: 'release', rust-version: 'stable', check_fmt: true}
-          - {os: ubuntu-20.04,   r: 'release', rust-version: 'nightly'}
+          - {os: ubuntu-latest,   r: 'release', rust-version: 'stable', check_fmt: true}
+          - {os: ubuntu-latest,   r: 'release', rust-version: 'nightly'}
           # R-devel requires LD_LIBRARY_PATH
-          - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable'}
-          - {os: ubuntu-20.04,   r: 'oldrel',  rust-version: 'stable'}
+          - {os: ubuntu-latest,   r: 'devel',   rust-version: 'stable'}
+          - {os: ubuntu-latest,   r: 'oldrel',  rust-version: 'stable'}
 
 
 
@@ -299,7 +299,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: ubuntu-20.04,   r: 'devel', rust-version: 'stable'}
+          - {os: ubuntu-latest,   r: 'devel', rust-version: 'stable'}
           - {os: macOS-latest,   r: 'devel', rust-version: 'stable'}
           - {os: windows-latest, r: 'release', rust-version: 'stable-gnu',   rust-targets: ['x86_64-pc-windows-gnu'], rtools-version: '42'}
           - {os: windows-latest, r: 'release', rust-version: 'stable-msvc',  rust-targets: ['x86_64-pc-windows-gnu'], rtools-version: '42'}


### PR DESCRIPTION
I noticed `ubuntu-latest` now refers to Ubuntu 22.04 while we pin the version to 20.04. I think there's no reason to hold the version.

https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/