### PR TITLE
Allow more clippy::not_unsafe_ptr_arg_deref and clippy::transmute_ptr_to_ref

### DIFF
--- a/extendr-macros/src/extendr_impl.rs
+++ b/extendr-macros/src/extendr_impl.rs
@@ -116,6 +116,7 @@ pub fn extendr_impl(mut item_impl: ItemImpl) -> TokenStream {
         impl<'a> extendr_api::FromRobj<'a> for &#self_ty {
             fn from_robj(robj: &'a Robj) -> std::result::Result<Self, &'static str> {
                 if robj.check_external_ptr_type::<#self_ty>() {
+                    #[allow(clippy::transmute_ptr_to_ref)]
                     Ok(unsafe { std::mem::transmute(robj.external_ptr_addr::<#self_ty>()) })
                 } else {
                     Err(concat!("expected ", #self_ty_name))
@@ -127,6 +128,7 @@ pub fn extendr_impl(mut item_impl: ItemImpl) -> TokenStream {
         impl<'a> extendr_api::FromRobj<'a> for &mut #self_ty {
             fn from_robj(robj: &'a Robj) -> std::result::Result<Self, &'static str> {
                 if robj.check_external_ptr_type::<#self_ty>() {
+                    #[allow(clippy::transmute_ptr_to_ref)]
                     Ok(unsafe { std::mem::transmute(robj.external_ptr_addr::<#self_ty>()) })
                 } else {
                     Err(concat!("expected ", #self_ty_name))

--- a/extendr-macros/src/wrappers.rs
+++ b/extendr-macros/src/wrappers.rs
@@ -102,7 +102,7 @@ pub fn make_function_wrappers(
     // ```
     wrappers.push(parse_quote!(
         #[no_mangle]
-        #[allow(non_snake_case)]
+        #[allow(non_snake_case, clippy::not_unsafe_ptr_arg_deref)]
         pub extern "C" fn #wrap_name(#formal_args) -> extendr_api::SEXP {
             unsafe {
                 use extendr_api::robj::*;


### PR DESCRIPTION
A followup of #451 as it didn't cover the case of `impl` wrappers.

Currently, if a user provides this code:

``` rs
use extendr_api::prelude::*;

struct Person {
    pub name: String,
}

#[extendr]
impl Person {
    fn new() -> Self {
        Self {
            name: "".to_string(),
        }
    }

    fn set_name(&mut self, name: &str) {
        self.name = name.to_string();
    }

    fn name(&self) -> &str {
        self.name.as_str()
    }
}

#[extendr]
fn aux_func() {}

// Macro to generate exports
extendr_module! {
    mod classes;
    impl Person;
    fn aux_func;
}
```

they will get this clippy error and warning:

```
❯ cargo +nightly clippy
    Checking foooo v0.1.0 (C:\Users\Yutani\Documents\GitHub\foooo)
error: this public function might dereference a raw pointer but is not marked `unsafe`
 --> src\lib.rs:7:1
  |
7 | #[extendr]
  | ^^^^^^^^^^
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref
  = note: `#[deny(clippy::not_unsafe_ptr_arg_deref)]` on by default
  = note: this error originates in the attribute macro `extendr` (in Nightly builds, run with -Z macro-backtrace for more info)

error: this public function might dereference a raw pointer but is not marked `unsafe`
  --> src\lib.rs:15:28
   |
15 |     fn set_name(&mut self, name: &str) {
   |                            ^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
 --> src\lib.rs:7:1
  |
7 | #[extendr]
  | ^^^^^^^^^^
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref
  = note: this error originates in the attribute macro `extendr` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: transmute from a pointer type (`*mut Person`) to a reference type (`&Person`)
 --> src\lib.rs:7:1
  |
7 | #[extendr]
  | ^^^^^^^^^^
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#transmute_ptr_to_ref
  = note: `#[warn(clippy::transmute_ptr_to_ref)]` on by default
  = note: this warning originates in the attribute macro `extendr` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: transmute from a pointer type (`*mut Person`) to a reference type (`&mut Person`)
 --> src\lib.rs:7:1
  |
7 | #[extendr]
  | ^^^^^^^^^^
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#transmute_ptr_to_ref
  = note: this warning originates in the attribute macro `extendr` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: `foooo` (lib) generated 2 warnings
error: could not compile `foooo` due to 3 previous errors; 2 warnings emitted

```