### PR TITLE
Update libR-sys to 0.4.0

### DIFF
--- a/extendr-api/Cargo.toml
+++ b/extendr-api/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT"
 repository = "https://github.com/extendr/extendr"
 
 [dependencies]
-libR-sys = "0.3.0"
+libR-sys = "0.4.0"
 extendr-macros = { path = "../extendr-macros", version = "0.3.1" }
 extendr-engine = { path = "../extendr-engine", version = "0.3.1" }
 ndarray = { version = "0.15.3", optional = true }

--- a/extendr-engine/Cargo.toml
+++ b/extendr-engine/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT"
 repository = "https://github.com/extendr/extendr"
 
 [dependencies]
-libR-sys = "0.3.0"
+libR-sys = "0.4.0"
 
 [features]
 default = []


### PR DESCRIPTION
I didn't expect this, but bumping the version of libR-sys makes extendr fail because `[patch.crates-io]` doesn't work. It doesn't work because

* the version of libR-sys on Git is v0.4.0, but
* the version of libR-sys extendr specifies is v0.3.0

```
  warning: Patch `libR-sys v0.4.0 (https://github.com/extendr/libR-sys#9d21fc23)` was not used in the crate graph.
  Check that the patched package version and available features are compatible
  with the dependency requirements. If the patch has a different version from
  what is locked in the Cargo.lock file, run `cargo update` to use the new
  version. This may also occur with an optional dependency that is not enabled.
```

https://github.com/extendr/extendr/actions/runs/4266437196/jobs/7437481677#step:11:22

so we have to update these lines.