### PR TITLE
add features-gated API to docs.rs

### DIFF
--- a/extendr-api/Cargo.toml
+++ b/extendr-api/Cargo.toml
@@ -48,4 +48,4 @@ tests-graphics = ["tests-minimal", "graphics"]
 tests-all = ["tests", "graphics"]
 
 [package.metadata.docs.rs]
-features = ["graphics", "libR-sys/use-bindgen", "serde", "ndarray"]
+features = ["graphics", "libR-sys/use-bindgen", "serde", "ndarray", "num-complex"]

--- a/extendr-api/Cargo.toml
+++ b/extendr-api/Cargo.toml
@@ -19,10 +19,10 @@ repository = "https://github.com/extendr/extendr"
 libR-sys = "0.4.0"
 extendr-macros = { path = "../extendr-macros", version = "0.4.0" }
 extendr-engine = { path = "../extendr-engine", version = "0.4.0" }
-ndarray = { version = "0.15.3", optional = true }
 lazy_static = "1.4"
 paste = "1.0.5"
 serde = { version = "1.0", features = ["derive"], optional = true }
+ndarray = { version = "0.15.3", optional = true }
 num-complex = { version = "0.4", optional = true }
 libc = { version = "0.2", optional = true }
 
@@ -48,4 +48,4 @@ tests-graphics = ["tests-minimal", "graphics"]
 tests-all = ["tests", "graphics"]
 
 [package.metadata.docs.rs]
-features = ["graphics", "libR-sys/use-bindgen"]
+features = ["graphics", "libR-sys/use-bindgen", "serde", "ndarray"]

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -17,7 +17,7 @@ pub(crate) fn str_to_character(s: &str) -> SEXP {
     }
 }
 
-/// Convert a null to an Robj.
+/// Convert a `NULL` to an `Robj`.
 impl From<()> for Robj {
     fn from(_: ()) -> Self {
         // Note: we do not need to protect this.
@@ -25,8 +25,8 @@ impl From<()> for Robj {
     }
 }
 
-/// Convert a Result to an Robj. This is used to allow
-/// functions to use the ? operator and return [Result<T>].
+/// Convert a `Result` to an `Robj`. This is used to allow
+/// functions to use the `?` operator and return [`Result<T>`].
 ///
 /// Panics if there is an error.
 /// ```

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -370,7 +370,7 @@ impl Robj {
     }
 
     /// Get a `Vec<i32>` copied from the object.
-    /// 
+    ///
     /// ```
     /// use extendr_api::prelude::*;
     /// test! {
@@ -399,7 +399,7 @@ impl Robj {
     /// Get a `Vec<Rbool>` copied from the object
     /// using the tri-state [`Rbool`].
     /// Returns `None` if not a logical vector.
-    /// 
+    ///
     /// ```
     /// use extendr_api::prelude::*;
     /// test! {
@@ -450,7 +450,7 @@ impl Robj {
     }
 
     /// Get an iterator over real elements of this slice.
-    /// 
+    ///
     /// ```
     /// use extendr_api::prelude::*;
     /// test! {
@@ -469,7 +469,7 @@ impl Robj {
     }
 
     /// Get a `Vec<f64>` copied from the object.
-    /// 
+    ///
     /// ```
     /// use extendr_api::prelude::*;
     /// test! {

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -369,7 +369,8 @@ impl Robj {
         self.clone().try_into().ok()
     }
 
-    /// Get a Vec<i32> copied from the object.
+    /// Get a `Vec<i32>` copied from the object.
+    /// 
     /// ```
     /// use extendr_api::prelude::*;
     /// test! {
@@ -395,9 +396,10 @@ impl Robj {
         self.as_typed_slice()
     }
 
-    /// Get a Vec<Rbool> copied from the object
-    /// using the tri-state [Rbool].
-    /// Returns None if not a logical vector.
+    /// Get a `Vec<Rbool>` copied from the object
+    /// using the tri-state [`Rbool`].
+    /// Returns `None` if not a logical vector.
+    /// 
     /// ```
     /// use extendr_api::prelude::*;
     /// test! {
@@ -448,6 +450,7 @@ impl Robj {
     }
 
     /// Get an iterator over real elements of this slice.
+    /// 
     /// ```
     /// use extendr_api::prelude::*;
     /// test! {
@@ -465,7 +468,8 @@ impl Robj {
         self.as_real_slice().map(|slice| slice.iter())
     }
 
-    /// Get a Vec<f64> copied from the object.
+    /// Get a `Vec<f64>` copied from the object.
+    /// 
     /// ```
     /// use extendr_api::prelude::*;
     /// test! {

--- a/extendr-api/src/robj_ndarray.rs
+++ b/extendr-api/src/robj_ndarray.rs
@@ -1,10 +1,10 @@
 /*!
-Defines conversions between R objects and the [ndarray](https://docs.rs/ndarray/latest/ndarray/) crate, which offers native Rust array types and numerical computation routines.
+Defines conversions between R objects and the [`ndarray`](https://docs.rs/ndarray/latest/ndarray/) crate, which offers native Rust array types and numerical computation routines.
 
 To enable these conversions, you must first enable the `ndarray` feature for extendr:
 ```toml
 [dependencies]
-extendr-api = { version = "0.3.1", features = ["ndarray"] }
+extendr-api = { version = "0.4", features = ["ndarray"] }
 ```
 
 Specifically, extendr supports the following conversions:

--- a/extendr-api/src/serializer.rs
+++ b/extendr-api/src/serializer.rs
@@ -62,13 +62,13 @@ struct SerializeStructVariant<'a> {
 /// Convert a serializable object to a Robj.
 ///
 /// Requires the "serde" feature.
-/// 
+///
 /// ```toml
 /// extendr-api = { version = "0.4", features = ["serde"] }
 /// ```
 ///
 /// Example:
-/// 
+///
 /// ```rust
 /// use extendr_api::prelude::*;
 /// use extendr_api::serializer::to_robj;

--- a/extendr-api/src/serializer.rs
+++ b/extendr-api/src/serializer.rs
@@ -62,12 +62,14 @@ struct SerializeStructVariant<'a> {
 /// Convert a serializable object to a Robj.
 ///
 /// Requires the "serde" feature.
+/// 
 /// ```toml
-/// extendr-api = { version = "0", features = ["serde"] }
+/// extendr-api = { version = "0.4", features = ["serde"] }
 /// ```
 ///
 /// Example:
-/// ```
+/// 
+/// ```rust
 /// use extendr_api::prelude::*;
 /// use extendr_api::serializer::to_robj;
 /// use serde::Serialize;

--- a/extendr-api/src/wrapper/complexes.rs
+++ b/extendr-api/src/wrapper/complexes.rs
@@ -50,7 +50,7 @@ impl Complexes {
 impl Deref for Complexes {
     type Target = [Rcplx];
 
-    /// Treat Complexes as if it is a slice, like Vec<Rcplx>
+    /// Treat Complexes as if it is a slice, like `Vec<Rcplx>`
     fn deref(&self) -> &Self::Target {
         unsafe {
             let ptr = DATAPTR_RO(self.get()) as *const Rcplx;
@@ -60,7 +60,7 @@ impl Deref for Complexes {
 }
 
 impl DerefMut for Complexes {
-    /// Treat Complexes as if it is a mutable slice, like Vec<Rcplx>
+    /// Treat Complexes as if it is a mutable slice, like `Vec<Rcplx>`
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe {
             let ptr = DATAPTR(self.get()) as *mut Rcplx;

--- a/extendr-api/src/wrapper/doubles.rs
+++ b/extendr-api/src/wrapper/doubles.rs
@@ -62,7 +62,7 @@ impl Doubles {
 impl Deref for Doubles {
     type Target = [Rfloat];
 
-    /// Treat Doubles as if it is a slice, like Vec<Rfloat>
+    /// Treat Doubles as if it is a slice, like `Vec<Rfloat>`
     fn deref(&self) -> &Self::Target {
         unsafe {
             let ptr = DATAPTR_RO(self.get()) as *const Rfloat;
@@ -72,7 +72,7 @@ impl Deref for Doubles {
 }
 
 impl DerefMut for Doubles {
-    /// Treat Doubles as if it is a mutable slice, like Vec<Rfloat>
+    /// Treat Doubles as if it is a mutable slice, like `Vec<Rfloat>`
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe {
             let ptr = DATAPTR(self.get()) as *mut Rfloat;

--- a/extendr-api/src/wrapper/integers.rs
+++ b/extendr-api/src/wrapper/integers.rs
@@ -127,7 +127,7 @@ impl Integers {
 impl Deref for Integers {
     type Target = [Rint];
 
-    /// Treat Integers as if it is a slice, like Vec<Rint>
+    /// Treat Integers as if it is a slice, like `Vec<Rint>`
     fn deref(&self) -> &Self::Target {
         unsafe {
             let ptr = DATAPTR_RO(self.get()) as *const Rint;
@@ -137,7 +137,7 @@ impl Deref for Integers {
 }
 
 impl DerefMut for Integers {
-    /// Treat Integers as if it is a mutable slice, like Vec<Rint>
+    /// Treat Integers as if it is a mutable slice, like `Vec<Rint>`
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe {
             let ptr = DATAPTR(self.get()) as *mut Rint;

--- a/extendr-api/src/wrapper/logicals.rs
+++ b/extendr-api/src/wrapper/logicals.rs
@@ -118,7 +118,7 @@ impl Logicals {
 impl Deref for Logicals {
     type Target = [Rbool];
 
-    /// Treat Logicals as if it is a slice, like Vec<Rint>
+    /// Treat Logicals as if it is a slice, like `Vec<Rint>`
     fn deref(&self) -> &Self::Target {
         unsafe {
             let ptr = DATAPTR_RO(self.get()) as *const Rbool;
@@ -128,7 +128,7 @@ impl Deref for Logicals {
 }
 
 impl DerefMut for Logicals {
-    /// Treat Logicals as if it is a mutable slice, like Vec<Rint>
+    /// Treat Logicals as if it is a mutable slice, like `Vec<Rint>`
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe {
             let ptr = DATAPTR(self.get()) as *mut Rbool;

--- a/extendr-api/src/wrapper/nullable.rs
+++ b/extendr-api/src/wrapper/nullable.rs
@@ -212,7 +212,7 @@ where
 }
 impl<T> Nullable<T> {
     /// Map `Nullable<T>` into `Nullable<U>`
-    /// 
+    ///
     /// ```
     /// use extendr_api::prelude::*;
     /// test! {

--- a/extendr-api/src/wrapper/nullable.rs
+++ b/extendr-api/src/wrapper/nullable.rs
@@ -198,7 +198,7 @@ impl<T> Nullable<T>
 where
     T: TryFrom<Robj, Error = Error>,
 {
-    /// Convert Nullable R object into Option
+    /// Convert Nullable R object into `Option`
     /// ```
     /// use extendr_api::prelude::*;
     /// test! {
@@ -211,7 +211,8 @@ where
     }
 }
 impl<T> Nullable<T> {
-    /// Map Nullable<T> into Nullable<U>
+    /// Map `Nullable<T>` into `Nullable<U>`
+    /// 
     /// ```
     /// use extendr_api::prelude::*;
     /// test! {


### PR DESCRIPTION
Based on this #494.

Using `all-features` on workspace doesn't work, because `libR-sys` has a feature that modifies the build process (with asking for path to generated bindings), rather than being additive.

I've added the currently to features to the metadata-field that was already there.

I've also fixed warnings. I think I fixed these somewhere else, but that PR is blocked because there is a parsing error somewhere that we need to deal with.