### PR TITLE
Use official GitHub Actions for deploying GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Documents
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["master"]
+    branches: [$default-branch]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,10 +32,12 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: nightly
 
       - name: Docs
         run: cargo doc --workspace --no-deps --all-features
+        env:
+          RUSTDOCFLAGS: "--enable-index-page -Zunstable-options"
 
       - name: Setup Pages
         uses: actions/configure-pages@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
+
       - name: Docs
         run: cargo doc --workspace --no-deps --all-features
         env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,10 +40,10 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v3
 
-      # - name: Upload artifact
-      #   uses: actions/upload-pages-artifact@v1
-      #   with:
-      #     path: './target/doc'
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: './target/doc'
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,24 +1,50 @@
 name: Documents
 
 on:
+  # Runs on pushes targeting the default branch
   push:
-    branches:
-      - master
+    branches: ["master"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
 
 jobs:
-  docs:
-    name: Deploy the dev version of documents to GitHub Pages
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
+
       - name: Docs
         run: cargo doc --workspace --no-deps --all-features
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./target/doc
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
+      # - name: Upload artifact
+      #   uses: actions/upload-pages-artifact@v1
+      #   with:
+      #     path: './target/doc'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Documents
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: [$default-branch]
+    branches: ["master"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
extendr currently uses `gh-pages` branch to deploy GitHub Pages. Nowadays, we can deploy GitHub Pages directly by using the official GitHub Actions.

Note that there's no need to migrate in a hurry. So, we can wait for a while to see if https://github.com/extendr/libR-sys/pull/143 works fine on the libR-sys's repo.