### PR TITLE
Add `CannotBeNA`-trait to be able to distinguish (maybe) between types

### DIFF
--- a/extendr-api/src/na.rs
+++ b/extendr-api/src/na.rs
@@ -23,9 +23,11 @@ lazy_static! {
     };
 }
 
-/// Return true if this primitive is NA.
+/// Trait signifying if a given type may take the value `NA` in the R sense.
 pub trait CanBeNA {
+    /// Returns `true` if it is `NA`.
     fn is_na(&self) -> bool;
+    /// Returns the sentinel `NA` value for this type.
     fn na() -> Self;
 }
 
@@ -81,3 +83,17 @@ impl CanBeNA for &str {
         &EXTENDR_NA_STRING
     }
 }
+
+/// Marker trait for types that may not be `NA` in the R sense.
+///
+/// See [`CanBeNA`].
+pub trait CannotBeNA {}
+
+impl CannotBeNA for u8 {}
+impl CannotBeNA for u16 {}
+impl CannotBeNA for u32 {}
+impl CannotBeNA for u64 {}
+impl CannotBeNA for i8 {}
+impl CannotBeNA for i16 {}
+impl CannotBeNA for i64 {}
+impl CannotBeNA for f32 {}


### PR DESCRIPTION
I'd admit this is a little naive.
If we are to make generic impls instead of macro-based ones, I think we need
the tools to distinguish between `CanBeNA` and `CannotBeNA`. Rust doesn't
support negative bounds, but hopefully this distinction can be useful.
For now, this is a DRAFT, and I hope the use-case appears soon.