### PR TITLE
`is_na` method works only if underlying type is a scalar

### DIFF
--- a/extendr-api/src/na.rs
+++ b/extendr-api/src/na.rs
@@ -23,9 +23,11 @@ lazy_static! {
     };
 }
 
-/// Return true if this primitive is NA.
+/// Trait signifying if a given type may take the value `NA` in the R sense.
 pub trait CanBeNA {
+    /// Returns `true` if it is `NA`.
     fn is_na(&self) -> bool;
+    /// Returns the sentinel `NA` value for this type.
     fn na() -> Self;
 }
 

--- a/extendr-api/src/robj/from_robj.rs
+++ b/extendr-api/src/robj/from_robj.rs
@@ -78,7 +78,7 @@ impl<'a> FromRobj<'a> for bool {
 
 impl<'a> FromRobj<'a> for &'a str {
     fn from_robj(robj: &'a Robj) -> std::result::Result<Self, &'static str> {
-        if robj.is_na() {
+        if robj.is_na_scalar() {
             Err("Input must not be NA.")
         } else if let Some(s) = robj.as_str() {
             Ok(s)
@@ -90,7 +90,7 @@ impl<'a> FromRobj<'a> for &'a str {
 
 impl<'a> FromRobj<'a> for String {
     fn from_robj(robj: &'a Robj) -> std::result::Result<Self, &'static str> {
-        if robj.is_na() {
+        if robj.is_na_scalar() {
             Err("Input must not be NA.")
         } else if let Some(s) = robj.as_str() {
             Ok(s.to_string())
@@ -122,7 +122,7 @@ impl<'a> FromRobj<'a> for Vec<f64> {
 
 impl<'a> FromRobj<'a> for Vec<String> {
     fn from_robj(robj: &'a Robj) -> std::result::Result<Self, &'static str> {
-        if robj.is_na() {
+        if robj.is_na_scalar() {
             Err("Input must be a character vector. Got 'NA'.")
         } else if let Some(v) = robj.as_string_vector() {
             let str_vec = v.to_vec();
@@ -187,7 +187,7 @@ impl<'a> FromRobj<'a> for HashMap<&str, Robj> {
 // NA-sensitive integer input handling
 impl<'a> FromRobj<'a> for Option<i32> {
     fn from_robj(robj: &'a Robj) -> std::result::Result<Self, &'static str> {
-        if robj.is_na() {
+        if robj.is_na_scalar() {
             Ok(None)
         } else if let Some(val) = robj.as_integer() {
             Ok(Some(val))
@@ -215,7 +215,7 @@ impl<'a> FromRobj<'a> for Option<bool> {
 // NA-sensitive real input handling
 impl<'a> FromRobj<'a> for Option<f64> {
     fn from_robj(robj: &'a Robj) -> std::result::Result<Self, &'static str> {
-        if robj.is_na() {
+        if robj.is_na_scalar() {
             Ok(None)
         } else if let Some(val) = robj.as_real() {
             Ok(Some(val))
@@ -228,7 +228,7 @@ impl<'a> FromRobj<'a> for Option<f64> {
 // NA-sensitive string input handling
 impl<'a> FromRobj<'a> for Option<&'a str> {
     fn from_robj(robj: &'a Robj) -> std::result::Result<Self, &'static str> {
-        if robj.is_na() {
+        if robj.is_na_scalar() {
             Ok(None)
         } else if let Some(val) = robj.as_str() {
             Ok(Some(val))
@@ -241,7 +241,7 @@ impl<'a> FromRobj<'a> for Option<&'a str> {
 // NA-sensitive string input handling
 impl<'a> FromRobj<'a> for Option<String> {
     fn from_robj(robj: &'a Robj) -> std::result::Result<Self, &'static str> {
-        if robj.is_na() {
+        if robj.is_na_scalar() {
             Ok(None)
         } else if let Some(val) = robj.as_str() {
             Ok(Some(val.to_string()))

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -322,7 +322,7 @@ pub trait Types: GetSexp {
 impl Types for Robj {}
 
 impl Robj {
-    /// Is this object is an NA scalar?
+    /// Is this object is an `NA` scalar?
     /// Works for character, integer and numeric types.
     /// ```
     /// use extendr_api::prelude::*;
@@ -333,7 +333,7 @@ impl Robj {
     /// assert_eq!(r!(NA_STRING).is_na(), true);
     /// }
     /// ```
-    pub fn is_na(&self) -> bool {
+    pub fn is_na_scalar(&self) -> bool {
         if self.len() != 1 {
             false
         } else {

--- a/extendr-api/src/robj/tests.rs
+++ b/extendr-api/src/robj/tests.rs
@@ -247,20 +247,20 @@ fn test_to_robj() {
         assert_eq!(ab, ab2);
 
         assert_eq!(Robj::from(Some(1)), Robj::from(1));
-        assert!(!Robj::from(Some(1)).is_na());
-        assert!(Robj::from(<Option<i32>>::None).is_na());
+        assert!(!Robj::from(Some(1)).is_na_scalar());
+        assert!(Robj::from(<Option<i32>>::None).is_na_scalar());
 
         assert_eq!(Robj::from(Some(true)), Robj::from(true));
-        assert!(!Robj::from(Some(true)).is_na());
-        assert!(Robj::from(<Option<bool>>::None).is_na());
+        assert!(!Robj::from(Some(true)).is_na_scalar());
+        assert!(Robj::from(<Option<bool>>::None).is_na_scalar());
 
         assert_eq!(Robj::from(Some(1.)), Robj::from(1.));
-        assert!(!Robj::from(Some(1.)).is_na());
-        assert!(Robj::from(<Option<f64>>::None).is_na());
+        assert!(!Robj::from(Some(1.)).is_na_scalar());
+        assert!(Robj::from(<Option<f64>>::None).is_na_scalar());
 
         assert_eq!(Robj::from(Some("xyz")), Robj::from("xyz"));
-        assert!(!Robj::from(Some("xyz")).is_na());
-        assert!(Robj::from(<Option<&str>>::None).is_na());
+        assert!(!Robj::from(Some("xyz")).is_na_scalar());
+        assert!(Robj::from(<Option<&str>>::None).is_na_scalar());
     }
 }
 

--- a/extendr-api/src/robj/try_from_robj.rs
+++ b/extendr-api/src/robj/try_from_robj.rs
@@ -17,7 +17,7 @@ macro_rules! impl_try_from_scalar_integer {
                 };
 
                 // Check if the value is not a missing value
-                if robj.is_na() {
+                if robj.is_na_scalar() {
                     return Err(Error::MustNotBeNA(robj.clone()));
                 }
 
@@ -68,7 +68,7 @@ macro_rules! impl_try_from_scalar_real {
                 };
 
                 // Check if the value is not a missing value
-                if robj.is_na() {
+                if robj.is_na_scalar() {
                     return Err(Error::MustNotBeNA(robj.clone()));
                 }
 
@@ -107,7 +107,7 @@ impl TryFrom<&Robj> for bool {
     /// Convert an LGLSXP object into a boolean.
     /// NAs are not allowed.
     fn try_from(robj: &Robj) -> Result<Self> {
-        if robj.is_na() {
+        if robj.is_na_scalar() {
             Err(Error::MustNotBeNA(robj.clone()))
         } else {
             Ok(<Rbool>::try_from(robj)?.is_true())
@@ -121,7 +121,7 @@ impl TryFrom<&Robj> for &str {
     /// Convert a scalar STRSXP object into a string slice.
     /// NAs are not allowed.
     fn try_from(robj: &Robj) -> Result<Self> {
-        if robj.is_na() {
+        if robj.is_na_scalar() {
             return Err(Error::MustNotBeNA(robj.clone()));
         }
         match robj.len() {
@@ -360,7 +360,7 @@ impl TryFrom<&Robj> for Rcplx {
         };
 
         // Check if the value is not a missing value.
-        if robj.is_na() {
+        if robj.is_na_scalar() {
             return Ok(Rcplx::na());
         }
 
@@ -401,7 +401,7 @@ macro_rules! impl_try_from_robj {
                 type Error = Error;
 
                 fn try_from(robj: &Robj) -> Result<Self> {
-                    if robj.is_null() || robj.is_na() {
+                    if robj.is_null() || robj.is_na_scalar() {
                         Ok(None)
                     } else {
                         Ok(Some(<$type>::try_from(robj)?))

--- a/extendr-api/src/scalar/rfloat.rs
+++ b/extendr-api/src/scalar/rfloat.rs
@@ -118,7 +118,7 @@ impl TryFrom<&Robj> for Rfloat {
         };
 
         // Check if the value is not a missing value.
-        if robj.is_na() {
+        if robj.is_na_scalar() {
             return Ok(Rfloat::na());
         }
 

--- a/extendr-api/src/scalar/rint.rs
+++ b/extendr-api/src/scalar/rint.rs
@@ -106,7 +106,7 @@ impl TryFrom<&Robj> for Rint {
         };
 
         // Check if the value is not a missing value
-        if robj.is_na() {
+        if robj.is_na_scalar() {
             return Ok(Rint::na());
         }
 

--- a/extendr-api/tests/vector_tests.rs
+++ b/extendr-api/tests/vector_tests.rs
@@ -67,16 +67,16 @@ fn test_list() {
         assert_eq!(v, vec![("a", r!("x")), ("b", r!("y")), ("c", r!("z"))]);
 
         let s = List::from_values(["x", <&str>::na(), "z"]);
-        assert_eq!(s.elt(1)?.is_na(), true);
-        assert_eq!(s.as_slice().iter().any(|s| s.is_na()), true);
+        assert_eq!(s.elt(1)?.is_na_scalar(), true);
+        assert_eq!(s.as_slice().iter().any(|s| s.is_na_scalar()), true);
 
         // Deref allows all the immutable methods from slice.
         let v = s.as_slice().iter().collect::<Vec<_>>();
         assert_eq!(v, vec![&r!("x"), &r!(<&str>::na()), &r!("z")]);
         assert_eq!(v[0], "x");
-        assert_eq!(v[1].is_na(), true);
+        assert_eq!(v[1].is_na_scalar(), true);
         assert_eq!(v.contains(&&r!("x")), true);
-        assert_eq!(s.as_slice().iter().any(Robj::is_na), true);
+        assert_eq!(s.as_slice().iter().any(Robj::is_na_scalar), true);
     }
 }
 


### PR DESCRIPTION
This is about clarity.

`Robj` has a public method `is_na`, which only returns true if it is `NA` **scalar**.
Meaning if the underlying r-type is of length not equal `1`, the `NA` is not ignored.

I've renamed it for clarity.

I hope you'll agree with me that this is better. 