### PR TITLE
Minor warning clean-up

### DIFF
--- a/extendr-api/src/error.rs
+++ b/extendr-api/src/error.rs
@@ -11,7 +11,6 @@ pub fn unwrap_or_throw<T>(r: std::result::Result<T, &'static str>) -> T {
     match r {
         Err(e) => {
             throw_r_error(e.to_string());
-            unreachable!("");
         }
         Ok(v) => v,
     }
@@ -22,7 +21,6 @@ pub fn unwrap_or_throw_error<T>(r: std::result::Result<T, Error>) -> T {
     match r {
         Err(e) => {
             throw_r_error(e.to_string());
-            unreachable!("");
         }
         Ok(v) => v,
     }

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -787,7 +787,6 @@ make_typed_slice!(Rint, INTEGER, INTSXP);
 make_typed_slice!(f64, REAL, REALSXP);
 make_typed_slice!(Rfloat, REAL, REALSXP);
 make_typed_slice!(u8, RAW, RAWSXP);
-make_typed_slice!(Robj, VECTOR_PTR, VECSXP);
 make_typed_slice!(Rstr, STRING_PTR, STRSXP);
 make_typed_slice!(c64, COMPLEX, CPLXSXP);
 make_typed_slice!(Rcplx, COMPLEX, CPLXSXP);

--- a/extendr-api/src/thread_safety.rs
+++ b/extendr-api/src/thread_safety.rs
@@ -77,23 +77,17 @@ where
 {
     match std::panic::catch_unwind(f) {
         Ok(res) => res,
-        Err(_) => {
-            unsafe {
-                libR_sys::Rf_error(err_str.as_ptr() as *const std::os::raw::c_char);
-            }
-            unreachable!("handle_panic unreachable")
-        }
+        Err(_) => unsafe { libR_sys::Rf_error(err_str.as_ptr() as *const std::os::raw::c_char) },
     }
 }
 
 static mut R_ERROR_BUF: Option<std::ffi::CString> = None;
 
-pub fn throw_r_error<S: AsRef<str>>(s: S) {
+pub fn throw_r_error<S: AsRef<str>>(s: S) -> ! {
     let s = s.as_ref();
     unsafe {
         R_ERROR_BUF = Some(std::ffi::CString::new(s).unwrap());
         libR_sys::Rf_error(R_ERROR_BUF.as_ref().unwrap().as_ptr());
-        unreachable!("Rf_error does not return");
     };
 }
 


### PR DESCRIPTION
Warnings were occurring due to:
- `VECTOR_PTR` being deprecated and thus invoking never-type `!`, so it is removed
- Various places where `unreachable` is called, but now we can just use `!` instead.

This is meant to be a quick PR that relaxes some of the nuisance that comes up..