### PR TITLE
Add private items to developer docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           toolchain: nightly
       - name: Docs
-        run: cargo doc --workspace --no-deps --all-features
+        run: cargo doc --workspace --no-deps --document-private-items --features full-support 
         env:
           RUSTDOCFLAGS: "--enable-index-page -Zunstable-options"
       - name: Deploy

--- a/extendr-api/Cargo.toml
+++ b/extendr-api/Cargo.toml
@@ -34,6 +34,8 @@ rstest = "0.16.0"
 [features]
 default = []
 
+full_support = ["graphics", "either", "ndarray", "num-complex", "serde"]
+
 # libc is needed to allocate a DevDesc (c.f., https://bugs.r-project.org/show_bug.cgi?id=18292)
 graphics = ["libc"]
 

--- a/extendr-api/Cargo.toml
+++ b/extendr-api/Cargo.toml
@@ -50,5 +50,5 @@ tests-graphics = ["tests-minimal", "graphics"]
 tests-all = ["tests", "graphics"]
 
 [package.metadata.docs.rs]
-features = ["graphics", "either", "ndarray", "num-complex", "serde", "libR-sys/use-bindgen"]
+features = ["graphics", "either", "ndarray", "num-complex", "serde"]
 

--- a/extendr-api/Cargo.toml
+++ b/extendr-api/Cargo.toml
@@ -34,7 +34,7 @@ rstest = "0.16.0"
 [features]
 default = []
 
-full_support = ["graphics", "either", "ndarray", "num-complex", "serde"]
+full-support = ["graphics", "either", "ndarray", "num-complex", "serde"]
 
 # libc is needed to allocate a DevDesc (c.f., https://bugs.r-project.org/show_bug.cgi?id=18292)
 graphics = ["libc"]
@@ -53,4 +53,3 @@ tests-all = ["tests", "graphics"]
 
 [package.metadata.docs.rs]
 features = ["graphics", "either", "ndarray", "num-complex", "serde"]
-


### PR DESCRIPTION
This PR adds private items to the generated docs on our website.
Plus there is a feature now called `full-support`, that includes on source-code-additive features,
such that we can have that for docs-generation; 
Before, `"libR-sys/use-bindgen"` was included. This feature is really not additive, and while it is vital for compilation,
it isn't supposed to be included.

Reasons for inclusion of private items:

* Lately on discord users have references private items in ExtendR, that they might want to use or
learn from. These should be discoverable atleast on our website.
* I use the website docs to learn about ExtendR myself, as there are aspects of it that is not known to me.
Plus I intend to document *all items* including the private ones for the betterment of this project.
Having somewhere where this is shown and could be readily accessed is a good.

I hope that convinces you. Thanks!
