### PR TITLE
[Breaking changes]: Optional features overhaul

### DIFF
--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -293,8 +293,6 @@ pub mod wrapper;
 pub mod na;
 
 pub mod optional;
-#[cfg(feature = "ndarray")]
-pub mod robj_ndarray;
 
 pub use std::convert::{TryFrom, TryInto};
 pub use std::ops::Deref;
@@ -319,9 +317,6 @@ pub use thread_safety::{
     catch_r_error, handle_panic, single_threaded, this_thread_id, throw_r_error,
 };
 pub use wrapper::*;
-
-#[cfg(feature = "ndarray")]
-pub use robj_ndarray::*;
 
 pub use extendr_macros::*;
 

--- a/extendr-api/src/optional/either.rs
+++ b/extendr-api/src/optional/either.rs
@@ -1,3 +1,36 @@
+/*!
+Enables support for [`either`](https://docs.rs/either/latest/either/) crate, allowing accepting and returning `Either<L,R>` values if both `L` and `R` are convertible to/from `Robj`.
+
+`either` crate support is currently available in the dev version of `extendr-api` and requires enabling `either` feature:
+```toml
+[dependencies]
+extendr-api = { git = "https://github.com/extendr/extendr" , features = ["either"] }
+```
+
+Accepting `Either<L,R>` as an input requires enabling `extendr` option `use_try_from = TRUE`:
+
+```rust
+use extendr_api::prelude::*;
+use either::Either;
+
+#[extendr(use_try_from = TRUE)]
+fn accept_numeric(input : Either<Integers, Doubles>) {}
+```
+
+Here is an example of `either` usage -- a type-aware sum:
+```rust
+use extendr_api::prelude::*;
+use either::Either::{self, Left, Right};
+
+#[extendr(use_try_from = TRUE)]
+fn type_aware_sum(input : Either<Integers, Doubles>) -> Either<Rint, Rfloat> {
+    match input {
+        Left(ints) => Left(ints.iter().sum::<Rint>()),
+        Right(dbls) => Right(dbls.iter().sum::<Rfloat>()),
+    }
+}
+```
+*/
 use crate::{Error, Robj};
 use either::Either::{self, Left, Right};
 

--- a/extendr-api/src/optional/either.rs
+++ b/extendr-api/src/optional/either.rs
@@ -1,5 +1,5 @@
 /*!
-Enables support for [`either`](https://docs.rs/either/latest/either/) crate, allowing accepting and returning `Either<L,R>` values if both `L` and `R` are convertible to/from `Robj`.
+Enables support for the [`either`](https://docs.rs/either/latest/either/) crate, to allow accepting and returning `Either<L, R>` values if both `L` and `R` are convertible to/from `Robj`.
 
 `either` crate support is currently available in the dev version of `extendr-api` and requires enabling `either` feature:
 ```toml
@@ -7,7 +7,7 @@ Enables support for [`either`](https://docs.rs/either/latest/either/) crate, all
 extendr-api = { git = "https://github.com/extendr/extendr" , features = ["either"] }
 ```
 
-Accepting `Either<L,R>` as an input requires enabling `extendr` option `use_try_from = TRUE`:
+Accepting `Either<L, R>` as an input requires enabling the `extendr` option `use_try_from = TRUE`:
 
 ```rust
 use extendr_api::prelude::*;

--- a/extendr-api/src/optional/either.rs
+++ b/extendr-api/src/optional/either.rs
@@ -11,18 +11,18 @@ Accepting `Either<L,R>` as an input requires enabling `extendr` option `use_try_
 
 ```rust
 use extendr_api::prelude::*;
-use either::Either;
+use ::either::Either;
 
-#[extendr(use_try_from = TRUE)]
+#[extendr(use_try_from = true)]
 fn accept_numeric(input : Either<Integers, Doubles>) {}
 ```
 
 Here is an example of `either` usage -- a type-aware sum:
 ```rust
 use extendr_api::prelude::*;
-use either::Either::{self, Left, Right};
+use ::either::Either::{self, Left, Right};
 
-#[extendr(use_try_from = TRUE)]
+#[extendr(use_try_from = true)]
 fn type_aware_sum(input : Either<Integers, Doubles>) -> Either<Rint, Rfloat> {
     match input {
         Left(ints) => Left(ints.iter().sum::<Rint>()),

--- a/extendr-api/src/optional/either.rs
+++ b/extendr-api/src/optional/either.rs
@@ -11,7 +11,6 @@ Accepting `Either<L,R>` as an input requires enabling `extendr` option `use_try_
 
 ```rust
 use extendr_api::prelude::*;
-use ::either::Either;
 
 #[extendr(use_try_from = true)]
 fn accept_numeric(input : Either<Integers, Doubles>) {}
@@ -20,7 +19,6 @@ fn accept_numeric(input : Either<Integers, Doubles>) {}
 Here is an example of `either` usage -- a type-aware sum:
 ```rust
 use extendr_api::prelude::*;
-use ::either::Either::{self, Left, Right};
 
 #[extendr(use_try_from = true)]
 fn type_aware_sum(input : Either<Integers, Doubles>) -> Either<Rint, Rfloat> {
@@ -31,8 +29,8 @@ fn type_aware_sum(input : Either<Integers, Doubles>) -> Either<Rint, Rfloat> {
 }
 ```
 */
+use crate::prelude::*;
 use crate::{Error, Robj};
-use either::Either::{self, Left, Right};
 
 impl<'a, L, R> TryFrom<&'a Robj> for Either<L, R>
 where
@@ -43,7 +41,7 @@ where
 
     /// Returns the first type that matches the provided `Robj`, starting from
     /// `L`-type, and if that fails, then the `R`-type is converted.
-    fn try_from(value: &'a Robj) -> Result<Self, Self::Error> {
+    fn try_from(value: &'a Robj) -> Result<Self> {
         match L::try_from(value) {
             Ok(left) => Ok(Left(left)),
             Err(left_err) => match R::try_from(value) {
@@ -62,7 +60,7 @@ where
 
     /// Returns the first type that matches the provided `Robj`, starting from
     /// `L`-type, and if that fails, then the `R`-type is converted.
-    fn try_from(value: Robj) -> Result<Self, Self::Error> {
+    fn try_from(value: Robj) -> Result<Self> {
         (&value).try_into()
     }
 }

--- a/extendr-api/src/optional/mod.rs
+++ b/extendr-api/src/optional/mod.rs
@@ -1,2 +1,5 @@
+/*!
+A set of optional features and third-party crate integrations, usually hidden behind feature gates.
+*/
 #[cfg(feature = "either")]
 pub mod either;

--- a/extendr-api/src/optional/mod.rs
+++ b/extendr-api/src/optional/mod.rs
@@ -3,3 +3,5 @@ A set of optional features and third-party crate integrations, usually hidden be
 */
 #[cfg(feature = "either")]
 pub mod either;
+#[cfg(feature = "ndarray")]
+pub mod ndarray;

--- a/extendr-api/src/optional/ndarray.rs
+++ b/extendr-api/src/optional/ndarray.rs
@@ -11,7 +11,7 @@ Specifically, extendr supports the following conversions:
 * [`Robj` → `ArrayView1`](FromRobj#impl-FromRobj<%27a>-for-ArrayView1<%27a%2C%20T>), for when you have an R vector that you want to analyse in Rust:
     ```rust
     use extendr_api::prelude::*;
-    use ndarray::ArrayView1;
+    use ::ndarray::ArrayView1;
 
     #[extendr]
     fn describe_vector(vector: ArrayView1<f64>){
@@ -21,7 +21,7 @@ Specifically, extendr supports the following conversions:
 * [`Robj` → `ArrayView2`](FromRobj#impl-FromRobj<%27a>-for-ArrayView2<%27a%2C%20f64>), for when you have an R matrix that you want to analyse in Rust.
     ```rust
     use extendr_api::prelude::*;
-    use ndarray::ArrayView2;
+    use ::ndarray::ArrayView2;
 
     #[extendr]
     fn describe_matrix(matrix: ArrayView2<f64>){
@@ -31,7 +31,7 @@ Specifically, extendr supports the following conversions:
 * [`ArrayBase` → `Robj`](Robj#impl-TryFrom<ArrayBase<S%2C%20D>>-for-Robj), for when you want to return a reference to an [`ndarray`] Array from Rust back to R.
     ```rust
     use extendr_api::prelude::*;
-    use ndarray::Array2;
+    use ::ndarray::Array2;
 
     #[extendr]
     fn return_matrix() -> Robj {
@@ -48,7 +48,7 @@ It will then be copied into a new block of memory managed by R.
 This is made easier by the fact that [ndarray allocates a new array automatically when performing operations on array references](ArrayBase#binary-operators-with-array-and-scalar):
 ```rust
 use extendr_api::prelude::*;
-use ndarray::Array2;
+use ::ndarray::ArrayView2;
 
 #[extendr]
 fn scalar_multiplication(matrix: ArrayView2<f64>, scalar: f64) -> Robj {

--- a/extendr-api/src/optional/ndarray.rs
+++ b/extendr-api/src/optional/ndarray.rs
@@ -11,7 +11,6 @@ Specifically, extendr supports the following conversions:
 * [`Robj` → `ArrayView1`](FromRobj#impl-FromRobj<%27a>-for-ArrayView1<%27a%2C%20T>), for when you have an R vector that you want to analyse in Rust:
     ```rust
     use extendr_api::prelude::*;
-    use ::ndarray::ArrayView1;
 
     #[extendr]
     fn describe_vector(vector: ArrayView1<f64>){
@@ -21,7 +20,6 @@ Specifically, extendr supports the following conversions:
 * [`Robj` → `ArrayView2`](FromRobj#impl-FromRobj<%27a>-for-ArrayView2<%27a%2C%20f64>), for when you have an R matrix that you want to analyse in Rust.
     ```rust
     use extendr_api::prelude::*;
-    use ::ndarray::ArrayView2;
 
     #[extendr]
     fn describe_matrix(matrix: ArrayView2<f64>){
@@ -31,7 +29,6 @@ Specifically, extendr supports the following conversions:
 * [`ArrayBase` → `Robj`](Robj#impl-TryFrom<ArrayBase<S%2C%20D>>-for-Robj), for when you want to return a reference to an [`ndarray`] Array from Rust back to R.
     ```rust
     use extendr_api::prelude::*;
-    use ::ndarray::Array2;
 
     #[extendr]
     fn return_matrix() -> Robj {
@@ -48,7 +45,6 @@ It will then be copied into a new block of memory managed by R.
 This is made easier by the fact that [ndarray allocates a new array automatically when performing operations on array references](ArrayBase#binary-operators-with-array-and-scalar):
 ```rust
 use extendr_api::prelude::*;
-use ::ndarray::ArrayView2;
 
 #[extendr]
 fn scalar_multiplication(matrix: ArrayView2<f64>, scalar: f64) -> Robj {

--- a/extendr-api/src/prelude.rs
+++ b/extendr-api/src/prelude.rs
@@ -60,8 +60,6 @@ pub use super::wrapper::{
     Primitive, Promise, Raw, Rstr, Strings, Symbol,
 };
 
-pub use super::optional::*;
-
 pub use extendr_macros::{call, extendr, extendr_module, pairlist, IntoDataFrameRow, Rraw, R};
 
 pub use super::iter::StrIter;
@@ -73,3 +71,11 @@ pub use std::ops::Index;
 pub use super::scalar::*;
 
 pub use super::Nullable::*;
+
+pub use super::optional::*;
+
+#[cfg(feature = "ndarray")]
+pub use ::ndarray::*;
+
+#[cfg(feature = "either")]
+pub use ::either::*;

--- a/extendr-api/src/prelude.rs
+++ b/extendr-api/src/prelude.rs
@@ -60,11 +60,7 @@ pub use super::wrapper::{
     Primitive, Promise, Raw, Rstr, Strings, Symbol,
 };
 
-#[cfg(feature = "ndarray")]
-pub use super::robj_ndarray::*;
-
-#[cfg(feature = "ndarray")]
-pub use ndarray::*;
+pub use super::optional::*;
 
 pub use extendr_macros::{call, extendr, extendr_module, pairlist, IntoDataFrameRow, Rraw, R};
 

--- a/extendr-api/tests/ndarray_try_from_tests.rs
+++ b/extendr-api/tests/ndarray_try_from_tests.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "ndarray")]
 mod ndarray_try_from_tests {
+    use ::ndarray::*;
     use extendr_api::prelude::*;
 
     #[test]

--- a/extendr-api/tests/ndarray_try_from_tests.rs
+++ b/extendr-api/tests/ndarray_try_from_tests.rs
@@ -1,6 +1,5 @@
 #[cfg(feature = "ndarray")]
 mod ndarray_try_from_tests {
-    use ::ndarray::*;
     use extendr_api::prelude::*;
 
     #[test]

--- a/extendr-api/tests/optional/either/either_mock_into_robj.rs
+++ b/extendr-api/tests/optional/either/either_mock_into_robj.rs
@@ -1,4 +1,4 @@
-use either::Either::{self, Left, Right};
+use ::either::Either::{self, Left, Right};
 use extendr_api::prelude::*;
 
 #[derive(Debug, PartialEq)]

--- a/extendr-api/tests/optional/either/either_mock_into_robj.rs
+++ b/extendr-api/tests/optional/either/either_mock_into_robj.rs
@@ -1,4 +1,3 @@
-use ::either::Either::{self, Left, Right};
 use extendr_api::prelude::*;
 
 #[derive(Debug, PartialEq)]

--- a/extendr-api/tests/optional/either/either_mock_try_from_robj.rs
+++ b/extendr-api/tests/optional/either/either_mock_try_from_robj.rs
@@ -1,4 +1,4 @@
-use either::Either::{self, Left, Right};
+use ::either::Either::{self, Left, Right};
 use extendr_api::prelude::*;
 
 #[derive(Debug, PartialEq)]

--- a/extendr-api/tests/optional/either/either_mock_try_from_robj.rs
+++ b/extendr-api/tests/optional/either/either_mock_try_from_robj.rs
@@ -1,4 +1,3 @@
-use ::either::Either::{self, Left, Right};
 use extendr_api::prelude::*;
 
 #[derive(Debug, PartialEq)]

--- a/tests/extendrtests/src/rust/Cargo.toml
+++ b/tests/extendrtests/src/rust/Cargo.toml
@@ -15,8 +15,6 @@ crate-type = ["staticlib"]
 
 [dependencies]
 extendr-api = { version = "*", features = ["graphics", "ndarray", "either"] }
-ndarray = '0.15'
-either = '1'
 
 [patch.crates-io]
 ## This is configured to work with RStudio features.

--- a/tests/extendrtests/src/rust/Cargo.toml
+++ b/tests/extendrtests/src/rust/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 extendr-api = { version = "*", features = ["graphics", "ndarray", "either"] }
+ndarray = '0.15'
 either = '1'
 
 [patch.crates-io]

--- a/tests/extendrtests/src/rust/src/lib.rs
+++ b/tests/extendrtests/src/rust/src/lib.rs
@@ -2,7 +2,7 @@ use extendr_api::{graphics::*, prelude::*};
 
 mod submodule;
 
-mod ndarray;
+mod optional_ndarray;
 
 mod graphic_device;
 
@@ -355,6 +355,6 @@ extendr_module! {
     fn my_device;
 
     use submodule;
-    use ndarray;
+    use optional_ndarray;
     use optional_either;
 }

--- a/tests/extendrtests/src/rust/src/optional_either.rs
+++ b/tests/extendrtests/src/rust/src/optional_either.rs
@@ -1,5 +1,5 @@
+use ::either::Either::{self, Left, Right};
 use extendr_api::prelude::*;
-use either::Either::{self, Left, Right};
 
 #[extendr(use_try_from = true)]
 fn type_aware_sum(input : Either<Integers, Doubles>) -> Either<Rint, Rfloat> {

--- a/tests/extendrtests/src/rust/src/optional_either.rs
+++ b/tests/extendrtests/src/rust/src/optional_either.rs
@@ -1,4 +1,3 @@
-use ::either::Either::{self, Left, Right};
 use extendr_api::prelude::*;
 
 #[extendr(use_try_from = true)]

--- a/tests/extendrtests/src/rust/src/optional_ndarray.rs
+++ b/tests/extendrtests/src/rust/src/optional_ndarray.rs
@@ -1,3 +1,4 @@
+use ::ndarray::*;
 use extendr_api::prelude::*;
 
 /// Calculate Euclidean distance matrix
@@ -29,5 +30,5 @@ fn euclidean_dist(a: Nullable<ArrayView2<Rfloat>>) -> Nullable<Doubles> {
 extendr_module! {
     fn euclidean_dist;
 
-    mod ndarray;
+    mod optional_ndarray;
 }

--- a/tests/extendrtests/src/rust/src/optional_ndarray.rs
+++ b/tests/extendrtests/src/rust/src/optional_ndarray.rs
@@ -1,4 +1,3 @@
-use ::ndarray::*;
 use extendr_api::prelude::*;
 
 /// Calculate Euclidean distance matrix


### PR DESCRIPTION
This PR reworks how some of the optional features are exposed:
- Modules `optional` and `either` get their docs in order
- Module `robj_nadrray` is renamed to `ndarray` and placed under `optional`
- `ndarray` crate is no longer re-exported
