### PR TITLE
Update `extendrtests` with latest project files from `rextendr`

### DIFF
--- a/tests/extendrtests/extendrtests.Rproj
+++ b/tests/extendrtests/extendrtests.Rproj
@@ -1,7 +1,7 @@
 Version: 1.0
 
-RestoreWorkspace: Default
-SaveWorkspace: Default
+RestoreWorkspace: No
+SaveWorkspace: No
 AlwaysSaveHistory: Default
 
 EnableCodeIndexing: Yes
@@ -10,7 +10,11 @@ NumSpacesForTab: 2
 Encoding: UTF-8
 
 RnwWeave: knitr
-LaTeX: pdfLaTeX
+LaTeX: XeLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+LineEndingConversion: Posix
 
 BuildType: Package
 PackageUseDevtools: Yes

--- a/tests/extendrtests/src/Makevars
+++ b/tests/extendrtests/src/Makevars
@@ -1,5 +1,5 @@
 TARGET_DIR = ./rust/target
-LIBDIR = $(TARGET_DIR)/debug
+LIBDIR = $(TARGET_DIR)/release
 STATLIB = $(LIBDIR)/libextendrtests.a
 PKG_LIBS = -L$(LIBDIR) -lextendrtests
 
@@ -7,8 +7,21 @@ all: C_clean
 
 $(SHLIB): $(STATLIB)
 
+CARGOTMP = $(CURDIR)/.cargo
+
 $(STATLIB):
-	cargo build --lib --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) --color=always
+	# In some environments, ~/.cargo/bin might not be included in PATH, so we need
+	# to set it here to ensure cargo can be invoked. It is appended to PATH and
+	# therefore is only used if cargo is absent from the user's PATH.
+	if [ "$(NOT_CRAN)" != "true" ]; then \
+		export CARGO_HOME=$(CARGOTMP); \
+	fi && \
+		export PATH="$(PATH):$(HOME)/.cargo/bin" && \
+		cargo build --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+	if [ "$(NOT_CRAN)" != "true" ]; then \
+		rm -Rf $(CARGOTMP) && \
+		rm -Rf $(LIBDIR)/build; \
+	fi
 
 C_clean:
 	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)

--- a/tests/extendrtests/src/Makevars
+++ b/tests/extendrtests/src/Makevars
@@ -1,5 +1,5 @@
 TARGET_DIR = ./rust/target
-LIBDIR = $(TARGET_DIR)/release
+LIBDIR = $(TARGET_DIR)/debug
 STATLIB = $(LIBDIR)/libextendrtests.a
 PKG_LIBS = -L$(LIBDIR) -lextendrtests
 
@@ -17,7 +17,7 @@ $(STATLIB):
 		export CARGO_HOME=$(CARGOTMP); \
 	fi && \
 		export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-		cargo build --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+		cargo build --lib --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)  --color-always
 	if [ "$(NOT_CRAN)" != "true" ]; then \
 		rm -Rf $(CARGOTMP) && \
 		rm -Rf $(LIBDIR)/build; \

--- a/tests/extendrtests/src/Makevars
+++ b/tests/extendrtests/src/Makevars
@@ -17,7 +17,7 @@ $(STATLIB):
 		export CARGO_HOME=$(CARGOTMP); \
 	fi && \
 		export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-		cargo build --lib --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)  --color-always
+		cargo build --lib --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)  --color=always
 	if [ "$(NOT_CRAN)" != "true" ]; then \
 		rm -Rf $(CARGOTMP) && \
 		rm -Rf $(LIBDIR)/build; \

--- a/tests/extendrtests/src/Makevars.win
+++ b/tests/extendrtests/src/Makevars.win
@@ -27,7 +27,7 @@ $(STATLIB):
 	fi && \
 		export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
 		export LIBRARY_PATH="$${LIBRARY_PATH};$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \
-		cargo build --target=$(TARGET) --lib --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) --color-always
+		cargo build --target=$(TARGET) --lib --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) --color=always
 	if [ "$(NOT_CRAN)" != "true" ]; then \
 		rm -Rf $(CARGOTMP) && \
 		rm -Rf $(LIBDIR)/build; \

--- a/tests/extendrtests/src/Makevars.win
+++ b/tests/extendrtests/src/Makevars.win
@@ -1,17 +1,17 @@
 TARGET = $(subst 64,x86_64,$(subst 32,i686,$(WIN)))-pc-windows-gnu
 
 TARGET_DIR = ./rust/target
-LIBDIR = $(TARGET_DIR)/$(TARGET)/debug
-STATLIB = $(LIBDIR)/lextendrtest.a
+LIBDIR = $(TARGET_DIR)/$(TARGET)/release
+STATLIB = $(LIBDIR)/libextendrtests.a
 PKG_LIBS = -L$(LIBDIR) -lextendrtests -lws2_32 -ladvapi32 -luserenv -lbcrypt
 
 all: C_clean
 
 $(SHLIB): $(STATLIB)
 
+CARGOTMP = $(CURDIR)/.cargo
+
 $(STATLIB):
-	# Note: on the GitHub Actions CI, the tests pass without this tweak because
-	#       the same setup is already done in the CI.
 	mkdir -p $(TARGET_DIR)/libgcc_mock
 	# `rustc` adds `-lgcc_eh` flags to the compiler, but Rtools' GCC doesn't have
 	# `libgcc_eh` due to the compilation settings. So, in order to please the
@@ -22,9 +22,16 @@ $(STATLIB):
 	touch $(TARGET_DIR)/libgcc_mock/libgcc_eh.a
 
 	# CARGO_LINKER is provided in Makevars.ucrt for R >= 4.2
-	export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
+	if [ "$(NOT_CRAN)" != "true" ]; then \
+		export CARGO_HOME=$(CARGOTMP); \
+	fi && \
+		export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
 		export LIBRARY_PATH="$${LIBRARY_PATH};$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \
-		cargo build --target=$(TARGET) --lib --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) --color=always
+		cargo build --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+	if [ "$(NOT_CRAN)" != "true" ]; then \
+		rm -Rf $(CARGOTMP) && \
+		rm -Rf $(LIBDIR)/build; \
+	fi
 
 C_clean:
 	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)

--- a/tests/extendrtests/src/Makevars.win
+++ b/tests/extendrtests/src/Makevars.win
@@ -1,7 +1,7 @@
 TARGET = $(subst 64,x86_64,$(subst 32,i686,$(WIN)))-pc-windows-gnu
 
 TARGET_DIR = ./rust/target
-LIBDIR = $(TARGET_DIR)/$(TARGET)/release
+LIBDIR = $(TARGET_DIR)/$(TARGET)/debug
 STATLIB = $(LIBDIR)/libextendrtests.a
 PKG_LIBS = -L$(LIBDIR) -lextendrtests -lws2_32 -ladvapi32 -luserenv -lbcrypt
 
@@ -27,7 +27,7 @@ $(STATLIB):
 	fi && \
 		export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
 		export LIBRARY_PATH="$${LIBRARY_PATH};$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \
-		cargo build --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+		cargo build --target=$(TARGET) --lib --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) --color-always
 	if [ "$(NOT_CRAN)" != "true" ]; then \
 		rm -Rf $(CARGOTMP) && \
 		rm -Rf $(LIBDIR)/build; \

--- a/tests/extendrtests/src/entrypoint.c
+++ b/tests/extendrtests/src/entrypoint.c
@@ -1,8 +1,8 @@
-// We need to forward routine registration from C to Rust 
+// We need to forward routine registration from C to Rust
 // to avoid the linker removing the static library.
 
 void R_init_extendrtests_extendr(void *dll);
 
 void R_init_extendrtests(void *dll) {
-  R_init_extendrtests_extendr(dll);
+    R_init_extendrtests_extendr(dll);
 }

--- a/tests/extendrtests/src/extendrtests-win.def
+++ b/tests/extendrtests/src/extendrtests-win.def
@@ -1,0 +1,2 @@
+EXPORTS
+R_init_extendrtests

--- a/tests/extendrtests/src/rust/Cargo.toml
+++ b/tests/extendrtests/src/rust/Cargo.toml
@@ -11,7 +11,7 @@ authors = [
 edition = "2021"
 
 [lib]
-crate-type = ["staticlib"]
+name = 'extendrtests'
 
 [dependencies]
 extendr-api = { version = "*", features = ["graphics", "ndarray", "either"] }


### PR DESCRIPTION
I'm currently unable to build `extendrtests`;

The error I'm receiving is this:
```
  error: failed to load source for dependency `extendr-api`
   
   Caused by:
     Unable to update C:\Users\minin\extendr\extendr-api
   
   Caused by:
     failed to read `C:\Users\minin\extendr\extendr-api\Cargo.toml`
   
   Caused by:
     The system cannot find the path specified. (os error 3)
```

Incidentally, I tried to update the project files, as I'm able to: Create a package, then use `rextendr::use_extendr()` and successfully build the resulting package.

There are some changes here. But none of them seem particularly altering anything;
This PR is just for consistency. 