### PR TITLE
[Help wanted] Adds `r_name` attribute for `#[extendr]` on `impl`-blocks`

### DIFF
--- a/extendr-macros/src/extendr_function.rs
+++ b/extendr-macros/src/extendr_function.rs
@@ -4,7 +4,8 @@ use quote::quote;
 use syn::ItemFn;
 
 /// Generate bindings for a single function.
-pub fn extendr_function(args: Vec<syn::NestedMeta>, mut func: ItemFn) -> TokenStream {
+pub fn extendr_function(args: TokenStream, mut func: ItemFn) -> TokenStream {
+    let args = syn::parse_macro_input!(args as syn::AttributeArgs);
     let mut opts = wrappers::ExtendrOptions::default();
 
     for arg in &args {

--- a/extendr-macros/src/lib.rs
+++ b/extendr-macros/src/lib.rs
@@ -73,10 +73,9 @@ use syn::{parse_macro_input, Item};
 
 #[proc_macro_attribute]
 pub fn extendr(attr: TokenStream, item: TokenStream) -> TokenStream {
-    let args = parse_macro_input!(attr as syn::AttributeArgs);
     match parse_macro_input!(item as Item) {
-        Item::Fn(func) => extendr_function::extendr_function(args, func),
-        Item::Impl(item_impl) => extendr_impl::extendr_impl(item_impl),
+        Item::Fn(func) => extendr_function::extendr_function(attr, func),
+        Item::Impl(item_impl) => extendr_impl::extendr_impl(attr, item_impl),
         other_item => TokenStream::from(quote! {#other_item}),
     }
 }

--- a/extendr-macros/src/wrappers.rs
+++ b/extendr-macros/src/wrappers.rs
@@ -1,8 +1,8 @@
 use quote::{format_ident, quote};
 use syn::{parse_quote, punctuated::Punctuated, Expr, FnArg, ItemFn, Token, Type};
 
-pub const META_PREFIX: &str = "meta__";
-pub const WRAP_PREFIX: &str = "wrap__";
+pub const META_PREFIX: &'static str = "meta__";
+pub const WRAP_PREFIX: &'static str = "wrap__";
 
 #[derive(Debug, Default)]
 pub struct ExtendrOptions {
@@ -37,12 +37,12 @@ pub fn make_function_wrappers(
     let wrap_name = format_ident!("{}{}{}", WRAP_PREFIX, prefix, mod_name);
     let meta_name = format_ident!("{}{}{}", META_PREFIX, prefix, mod_name);
 
-    let rust_name_str = format!("{}", rust_name);
-    let c_name_str = format!("{}", mod_name);
+    let rust_name_str = format!("{rust_name}");
+    let c_name_str = format!("{mod_name}");
     let doc_string = get_doc_string(attrs);
     let return_type_string = get_return_type(sig);
 
-    let panic_str = format!("{} panicked.\0", r_name_str);
+    let panic_str = format!("{r_name_str} panicked.\0");
 
     let inputs = &mut sig.inputs;
     let has_self = matches!(inputs.iter().next(), Some(FnArg::Receiver(_)));


### PR DESCRIPTION
# In-progress: Help Wanted

I've added the ability to write `r_name` in `#[extendr]` for `impl`-blocks.
There are three places where this should incur a change (I think):

* Generated macro around the impl block
* extendr-wrappers
* ???

So far I assume that I've done the mapping I need to do;
However I get this output when I use `Person` after it has been `r_name`'d to `individual`:

```r
> a<-individual$new()
> a$set_name("jason")
Error in a$set_name : object of type 'externalptr' is not subsettable
> a
```

This doesn't happen before, e.g.
```r
> Person$new()->b
> b$set_name("jason")
> b
<pointer: 0x0000021dc3b10b50>
attr(,"class")
[1] "Person"
```

I'm very sure that the `extendr-wrappers` have been altered correctly.
I'll attach them here:
[extendr-wrappers_on_main.txt](https://github.com/extendr/extendr/files/11360077/extendr-wrappers_on_main.txt)
[extendr-wrappers.txt](https://github.com/extendr/extendr/files/11360079/extendr-wrappers.txt)

And for completion, here I attach the "macro expansion" when using `r_name` and without.
[macro_expand_person_no_r_name.txt](https://github.com/extendr/extendr/files/11360088/macro_expand_person_no_r_name.txt)
[macro_expand_person_yes_r_name.txt](https://github.com/extendr/extendr/files/11360089/macro_expand_person_yes_r_name.txt)

Here the only change is this: 
![image](https://user-images.githubusercontent.com/1063624/235324678-61012978-13b2-42f0-8cd2-188b8d3465cb.png)

All suggestions are more than welcome

Fixes #536 