### PR TITLE
Remove `[workspace]` from `extendrtests`

### DIFF
--- a/tests/extendrtests/src/rust/Cargo.toml
+++ b/tests/extendrtests/src/rust/Cargo.toml
@@ -1,5 +1,3 @@
-[workspace]
-
 [package]
 name = "extendrtests"
 version = "0.2.1"


### PR DESCRIPTION
I see no reason to have `extendrtests` be a workspace.
