### PR TITLE
Fix win toolchain

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -270,8 +270,8 @@ jobs:
           # When the MSVC target is used, since it's cross-compilation from MSVC
           # to GNU, the doc tests are usually skipped. Adding `-Zdoctest-xcompile`
           # lets the doctests run, which accordingly require the nightly toolchain.
-          - {os: windows-latest, r: 'release', rust-version: 'nightly-msvc', rust-targets: ['x86_64-pc-windows-gnu'], rtools-version: '43', extra-args: ['-Zdoctest-xcompile']}
-          - {os: windows-latest, r: 'oldrel',  rust-version: 'nightly-msvc', rust-targets: ['x86_64-pc-windows-gnu'], rtools-version: '42', extra-args: ['-Zdoctest-xcompile']}
+          - {os: windows-latest, r: 'release', rust-version: 'nightly-2023-04-11-msvc', rust-targets: ['x86_64-pc-windows-gnu'], rtools-version: '43', extra-args: ['-Zdoctest-xcompile']}
+          - {os: windows-latest, r: 'oldrel',  rust-version: 'nightly--msvc', rust-targets: ['x86_64-pc-windows-gnu'], rtools-version: '42', extra-args: ['-Zdoctest-xcompile']}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -271,7 +271,7 @@ jobs:
           # to GNU, the doc tests are usually skipped. Adding `-Zdoctest-xcompile`
           # lets the doctests run, which accordingly require the nightly toolchain.
           - {os: windows-latest, r: 'release', rust-version: 'nightly-2023-04-11-msvc', rust-targets: ['x86_64-pc-windows-gnu'], rtools-version: '43', extra-args: ['-Zdoctest-xcompile']}
-          - {os: windows-latest, r: 'oldrel',  rust-version: 'nightly--msvc', rust-targets: ['x86_64-pc-windows-gnu'], rtools-version: '42', extra-args: ['-Zdoctest-xcompile']}
+          - {os: windows-latest, r: 'oldrel',  rust-version: 'nightly-2023-04-11-msvc', rust-targets: ['x86_64-pc-windows-gnu'], rtools-version: '42', extra-args: ['-Zdoctest-xcompile']}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true


### PR DESCRIPTION
[main extendr tests currently fails latest nightly because cannot install toolchain for 1-2 msvc targets](https://github.com/extendr/extendr/actions/runs/5345995596/jobs/9692375964?pr=562)

When I google and find similar errors. It appears to have been a reoccurring issue the last 5 years in rust.

[one solution which worked when the problem appeared in 2019 was to temporarily fix nightly](https://github.com/rust-lang/rust/issues/57488#issuecomment-453040972)

py-polars and r-polars runs on the same nightly version.

If accepting this PR, I suggest to make ("DO NOT MERGE PR: reverting fix nightly") to monitor when the error goes away again.