### PR TITLE
ci: add dependabot.yml for rust and github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: daily
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily


### PR DESCRIPTION
I think we can automate the updating of dependencies.

However, a MSRV checking workflow may be needed to keep Rust versions compatible.
So please merge #569 first.