### PR TITLE
ci: check msrv

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -30,4 +30,4 @@ jobs:
         with:
           crate: cargo-msrv
       - name: Verify minimum rust version
-        run: cargo-msrv verify
+        run: cargo-msrv --path extendr-api/ verify

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -1,0 +1,33 @@
+name: Check MSRV
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "**.rs"
+      - "**/Cargo.toml"
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "**.rs"
+      - "**/Cargo.toml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test-min-rust-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: baptiste0928/cargo-install@v2
+        with:
+          crate: cargo-msrv
+      - name: Verify minimum rust version
+        run: cargo-msrv verify

--- a/extendr-api/Cargo.toml
+++ b/extendr-api/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2021"
 description = "Safe and user friendly bindings to the R programming language."
 license = "MIT"
 repository = "https://github.com/extendr/extendr"
+rust-version = "1.60"
 
 [dependencies]
 libR-sys = "0.5.0"


### PR DESCRIPTION
Use cargo-msrv to guarantee the minimum Rust version supported.
https://crates.io/crates/cargo-msrv