### PR TITLE
Add `...` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- `Ellipsis` type and matching `#[ellipsis]` parameter attribute to enable support for `...` in function signatures [[#578]](https://github.com/extendr/extendr/pull/578)
 - [**either**] `TryFrom<&Robj> for Either<T, R>` and `From<Either<T, R>> for Robj` if `T` and `R` are themselves implement these traits. This unblocks scenarios like accepting any numeric vector from R via `Either<Integers, Doubles>` without extra memory allocation [[#480]](https://github.com/extendr/extendr/pull/480)
 - `PartialOrd` trait implementation for `Rfloat`, `Rint` and `Rbool`. `Rfloat` and `Rint` gained `min()` and `max()` methods [[#573]](https://github.com/extendr/extendr/pull/573)
 

--- a/extendr-api/src/metadata.rs
+++ b/extendr-api/src/metadata.rs
@@ -6,12 +6,19 @@ use crate::robj::IntoRobj;
 use crate::*;
 use std::io::Write;
 
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub enum ArgModifier {
+    None,
+    Default(&'static str),
+    Ellipsis,
+}
+
 /// Metadata function argument.
 #[derive(Debug, PartialEq)]
 pub struct Arg {
     pub name: &'static str,
     pub arg_type: &'static str,
-    pub default: Option<&'static str>,
+    pub modifier: ArgModifier,
 }
 
 /// Metadata function.
@@ -69,7 +76,11 @@ impl From<&Arg> for RArg {
     fn from(arg: &Arg) -> Self {
         Self {
             name: sanitize_identifier(arg.name),
-            default: arg.default,
+            default: if let ArgModifier::Default(default) = arg.modifier {
+                Some(default)
+            } else {
+                None
+            },
         }
     }
 }

--- a/extendr-api/src/metadata.rs
+++ b/extendr-api/src/metadata.rs
@@ -6,10 +6,14 @@ use crate::robj::IntoRobj;
 use crate::*;
 use std::io::Write;
 
+/// Argument modifier.
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum ArgModifier {
+    /// No modifier applied.
     None,
+    /// Default value is set via `#[default = "<value>"]`.
     Default(&'static str),
+    /// Argument is marked as `...` using `#[ellipsis]`.
     Ellipsis,
 }
 

--- a/extendr-api/src/metadata.rs
+++ b/extendr-api/src/metadata.rs
@@ -53,6 +53,7 @@ pub struct Metadata {
 struct RArg {
     name: String,
     default: Option<&'static str>,
+    is_ellipsis: bool,
 }
 
 impl RArg {
@@ -61,13 +62,25 @@ impl RArg {
     }
 
     fn to_actual_arg(&self) -> String {
-        self.name.clone()
+        if self.is_ellipsis {
+            "environment()".to_string()
+        } else {
+            self.name.clone()
+        }
     }
 
     fn to_formal_arg(&self) -> String {
-        match self.default {
-            Some(default_val) => format!("{} = {}", self.name, default_val),
-            None => self.name.clone(),
+        match self {
+            Self {
+                default: Some(default_val),
+                ..
+            } => {
+                format!("{} = {}", self.name, default_val)
+            }
+            Self {
+                is_ellipsis: true, ..
+            } => "...".to_string(),
+            _ => self.name.clone(),
         }
     }
 }
@@ -81,6 +94,7 @@ impl From<&Arg> for RArg {
             } else {
                 None
             },
+            is_ellipsis: matches!(arg.modifier, ArgModifier::Ellipsis),
         }
     }
 }

--- a/extendr-api/src/prelude.rs
+++ b/extendr-api/src/prelude.rs
@@ -55,9 +55,9 @@ pub use super::thread_safety::{
 };
 
 pub use super::wrapper::{
-    Complexes, Dataframe, Doubles, EnvIter, Environment, Expressions, ExternalPtr, FromList,
-    Function, Integers, IntoDataFrameRow, Language, List, ListIter, Logicals, Nullable, Pairlist,
-    Primitive, Promise, Raw, Rstr, Strings, Symbol,
+    Complexes, Dataframe, Doubles, Ellipsis, EnvIter, Environment, Expressions, ExternalPtr,
+    FromList, Function, Integers, IntoDataFrameRow, Language, List, ListIter, Logicals, Nullable,
+    Pairlist, Primitive, Promise, Raw, Rstr, Strings, Symbol,
 };
 
 pub use extendr_macros::{call, extendr, extendr_module, pairlist, IntoDataFrameRow, Rraw, R};

--- a/extendr-api/src/wrapper/ellipsis.rs
+++ b/extendr-api/src/wrapper/ellipsis.rs
@@ -1,0 +1,6 @@
+use crate::Robj;
+
+#[derive(PartialEq, Clone)]
+pub struct Ellipsis {
+    pub(crate) robj: Robj,
+}

--- a/extendr-api/src/wrapper/ellipsis.rs
+++ b/extendr-api/src/wrapper/ellipsis.rs
@@ -1,12 +1,28 @@
 use crate::prelude::*;
-use crate::{Error, Robj, Rtype, Types};
+use crate::{Error, R_NilValue, Robj, Rtype, Types, SEXP};
 
 #[derive(PartialEq, Clone)]
 pub struct Ellipsis {
     pub(crate) robj: Robj,
 }
 
-impl Ellipsis {}
+impl Ellipsis {
+    pub fn iter(&self) -> EllipsisIter {
+        unsafe {
+            EllipsisIter {
+                robj: Some(&self.robj),
+                list_elem: self.robj.get(),
+            }
+        }
+    }
+
+    pub fn collect_values(&self) -> Result<Vec<Robj>> {
+        self.iter()
+            .filter_map(|x| <Promise as TryFrom<&Robj>>::try_from(&x).ok())
+            .map(|p| p.eval())
+            .collect()
+    }
+}
 
 impl<'a> TryFrom<&'a Robj> for Ellipsis {
     type Error = Error;
@@ -15,7 +31,7 @@ impl<'a> TryFrom<&'a Robj> for Ellipsis {
         match robj.rtype() {
             Rtype::Dot => Ok(Self { robj: robj.clone() }),
             Rtype::Environment => try_from_env(robj),
-            _ => Err(Error::Other("Placeholder".into())),
+            tp => Err(Error::Other(format!("Got {:?}", tp))),
         }
     }
 }
@@ -28,4 +44,43 @@ fn try_from_env(env: &Robj) -> Result<Ellipsis> {
                 .ok_or(Error::Other("Ellipsis missing".into()))
         })
         .and_then(|(_, v)| <Ellipsis as TryFrom<&Robj>>::try_from(&v))
+}
+
+#[derive(Clone)]
+pub struct EllipsisIter<'a> {
+    pub(crate) robj: Option<&'a Robj>,
+    pub(crate) list_elem: SEXP,
+}
+
+impl<'a> Default for EllipsisIter<'a> {
+    fn default() -> Self {
+        EllipsisIter::new()
+    }
+}
+
+impl<'a> EllipsisIter<'a> {
+    pub fn new() -> Self {
+        unsafe {
+            Self {
+                robj: None,
+                list_elem: R_NilValue,
+            }
+        }
+    }
+}
+
+impl<'a> Iterator for EllipsisIter<'a> {
+    type Item = Robj;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        unsafe {
+            if self.robj.is_none() || self.list_elem == R_NilValue {
+                return None;
+            }
+
+            let elem = libR_sys::CAR(self.list_elem);
+            self.list_elem = libR_sys::CDR(self.list_elem);
+            Some(Robj::from_sexp(elem))
+        }
+    }
 }

--- a/extendr-api/src/wrapper/ellipsis.rs
+++ b/extendr-api/src/wrapper/ellipsis.rs
@@ -1,6 +1,31 @@
-use crate::Robj;
+use crate::prelude::*;
+use crate::{Error, Robj, Rtype, Types};
 
 #[derive(PartialEq, Clone)]
 pub struct Ellipsis {
     pub(crate) robj: Robj,
+}
+
+impl Ellipsis {}
+
+impl<'a> TryFrom<&'a Robj> for Ellipsis {
+    type Error = Error;
+
+    fn try_from(robj: &'a Robj) -> std::result::Result<Self, Self::Error> {
+        match robj.rtype() {
+            Rtype::Dot => Ok(Self { robj: robj.clone() }),
+            Rtype::Environment => try_from_env(robj),
+            _ => Err(Error::Other("Placeholder".into())),
+        }
+    }
+}
+
+fn try_from_env(env: &Robj) -> Result<Ellipsis> {
+    <Environment as TryFrom<&Robj>>::try_from(env)
+        .and_then(|e| {
+            e.iter()
+                .find(|(k, _)| *k == "...")
+                .ok_or(Error::Other("Ellipsis missing".into()))
+        })
+        .and_then(|(_, v)| <Ellipsis as TryFrom<&Robj>>::try_from(&v))
 }

--- a/extendr-api/src/wrapper/ellipsis.rs
+++ b/extendr-api/src/wrapper/ellipsis.rs
@@ -1,3 +1,4 @@
+use crate::list::KeyValue;
 use crate::prelude::*;
 use crate::{Error, R_NilValue, Robj, Rtype, Types, SEXP};
 
@@ -10,6 +11,16 @@ pub struct Ellipsis {
 pub struct EllipsisValue {
     pub name: Option<String>,
     pub value: Robj,
+}
+
+impl KeyValue for EllipsisValue {
+    fn key(&self) -> String {
+        self.name.clone().unwrap_or("".to_string())
+    }
+
+    fn value(self) -> Robj {
+        self.value
+    }
 }
 
 impl Ellipsis {

--- a/extendr-api/src/wrapper/ellipsis.rs
+++ b/extendr-api/src/wrapper/ellipsis.rs
@@ -8,8 +8,8 @@ pub struct Ellipsis {
 
 #[derive(PartialEq, Clone, Debug)]
 pub struct EllipsisValue {
-    pub(crate) name: Option<String>,
-    pub(crate) value: Robj,
+    pub name: Option<String>,
+    pub value: Robj,
 }
 
 impl Ellipsis {
@@ -136,6 +136,14 @@ impl TryFrom<&Robj> for EllipsisItemValue {
         } else {
             <Promise as TryFrom<&Robj>>::try_from(value).map(EllipsisItemValue::Promise)
         }
+    }
+}
+
+impl TryFrom<Robj> for EllipsisItemValue {
+    type Error = Error;
+
+    fn try_from(value: Robj) -> std::result::Result<Self, Self::Error> {
+        <EllipsisItemValue as TryFrom<&Robj>>::try_from(&value)
     }
 }
 

--- a/extendr-api/src/wrapper/ellipsis.rs
+++ b/extendr-api/src/wrapper/ellipsis.rs
@@ -6,11 +6,21 @@ pub struct Ellipsis {
     pub(crate) robj: Robj,
 }
 
+#[derive(PartialEq, Clone, Debug)]
+pub struct EllipsisValue {
+    pub(crate) name: Option<String>,
+    pub(crate) value: Robj,
+}
+
 impl Ellipsis {
+    pub(crate) fn new() -> Ellipsis {
+        Self { robj: ().into() }
+    }
+
     pub fn iter(&self) -> EllipsisIter {
         unsafe {
             EllipsisIter {
-                robj: Some(&self.robj),
+                robj: self.robj.clone(),
                 list_elem: self.robj.get(),
             }
         }
@@ -18,9 +28,41 @@ impl Ellipsis {
 
     pub fn collect_values(&self) -> Result<Vec<Robj>> {
         self.iter()
-            .filter_map(|x| <Promise as TryFrom<&Robj>>::try_from(&x).ok())
+            .filter_map(|x| x.value.to_promise())
             .map(|p| p.eval())
             .collect()
+    }
+
+    pub fn values(&self) -> Result<Vec<EllipsisValue>> {
+        let values = self
+            .iter()
+            .map(|x| (x.name, x.value.to_promise()))
+            .collect::<Vec<_>>();
+
+        let n = values.len() - 1;
+
+        values
+            .iter()
+            .enumerate()
+            .filter_map(|(i, (name, value))| {
+                if let Some(prom) = value {
+                    Some(prom.eval().map(|value| EllipsisValue {
+                        name: name.clone().map(|nm| nm.as_str().to_string()),
+                        value,
+                    }))
+                } else {
+                    if i == n {
+                        None
+                    } else {
+                        let name = name
+                            .clone()
+                            .map(|nm| format!("`{}`", nm.as_str()))
+                            .unwrap_or_else(|| format!("[{}] element", i));
+                        Some(Err(Error::Other(format!("Missing value for {}", name))))
+                    }
+                }
+            })
+            .collect::<Result<Vec<_>>>()
     }
 }
 
@@ -31,7 +73,8 @@ impl<'a> TryFrom<&'a Robj> for Ellipsis {
         match robj.rtype() {
             Rtype::Dot => Ok(Self { robj: robj.clone() }),
             Rtype::Environment => try_from_env(robj),
-            tp => Err(Error::Other(format!("Got {:?}", tp))),
+            Rtype::Symbol if robj.is_missing_arg() => Ok(Ellipsis::new()),
+            tp => Err(Error::Other(format!("Got {:?}: {:?}", tp, robj))),
         }
     }
 }
@@ -47,40 +90,79 @@ fn try_from_env(env: &Robj) -> Result<Ellipsis> {
 }
 
 #[derive(Clone)]
-pub struct EllipsisIter<'a> {
-    pub(crate) robj: Option<&'a Robj>,
-    pub(crate) list_elem: SEXP,
+pub struct EllipsisIter {
+    robj: Robj,
+    list_elem: SEXP,
 }
 
-impl<'a> Default for EllipsisIter<'a> {
+impl Default for EllipsisIter {
     fn default() -> Self {
         EllipsisIter::new()
     }
 }
 
-impl<'a> EllipsisIter<'a> {
+impl EllipsisIter {
     pub fn new() -> Self {
         unsafe {
             Self {
-                robj: None,
+                robj: ().into(),
                 list_elem: R_NilValue,
             }
         }
     }
 }
 
-impl<'a> Iterator for EllipsisIter<'a> {
-    type Item = Robj;
+#[derive(Clone, PartialEq, Debug)]
+pub enum EllipsisItemValue {
+    Promise(Promise),
+    MissingArg,
+}
+
+impl EllipsisItemValue {
+    pub fn to_promise(self) -> Option<Promise> {
+        match self {
+            EllipsisItemValue::Promise(p) => Some(p),
+            _ => None,
+        }
+    }
+}
+
+impl TryFrom<&Robj> for EllipsisItemValue {
+    type Error = Error;
+
+    fn try_from(value: &Robj) -> std::result::Result<Self, Self::Error> {
+        if value.is_missing_arg() {
+            Ok(EllipsisItemValue::MissingArg)
+        } else {
+            <Promise as TryFrom<&Robj>>::try_from(value).map(EllipsisItemValue::Promise)
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct EllipsisIterItem {
+    pub name: Option<Symbol>,
+    pub value: EllipsisItemValue,
+}
+
+impl Iterator for EllipsisIter {
+    type Item = EllipsisIterItem;
 
     fn next(&mut self) -> Option<Self::Item> {
         unsafe {
-            if self.robj.is_none() || self.list_elem == R_NilValue {
+            if self.robj.is_null() || self.list_elem == R_NilValue {
                 return None;
             }
 
+            let tag = libR_sys::TAG(self.list_elem);
             let elem = libR_sys::CAR(self.list_elem);
             self.list_elem = libR_sys::CDR(self.list_elem);
-            Some(Robj::from_sexp(elem))
+            Some(EllipsisIterItem {
+                name: <Symbol as TryFrom<&Robj>>::try_from(&Robj::from_sexp(tag)).ok(),
+                value: (&Robj::from_sexp(elem))
+                    .try_into()
+                    .expect("Should not happen"),
+            })
         }
     }
 }

--- a/extendr-api/src/wrapper/ellipsis.rs
+++ b/extendr-api/src/wrapper/ellipsis.rs
@@ -1,8 +1,8 @@
 /*!
 Enables support for `...` parameters in R functions.
 `Ellipsis` can be used as a regular extendr-function argument. At most one `Ellipsis` is allowed per function,
-and it requires `#[ellipsis]` attribute in front of it in the signature.
-When encountered, `#[ellipsis]` attribute transforms parameter name into `...` on R side and captures current `environment()`.
+and it requires the `#[ellipsis]` attribute in front of it in the signature.
+When encountered, `#[ellipsis]` attribute transforms the parameter name into `...` on R side and captures current `environment()`.
 
 `Ellipsis` can be iterated over to obtain `EllipsisItemValue` objects, each representing a (potentially named) argument captured by `...`.
 `EllipsisItemValue` contains either a `Promise` that can be evaluated for value, or MissingArg, marking a missing argument in `...`.

--- a/extendr-api/src/wrapper/ellipsis.rs
+++ b/extendr-api/src/wrapper/ellipsis.rs
@@ -23,6 +23,16 @@ impl KeyValue for EllipsisValue {
     }
 }
 
+impl<'a> KeyValue for &'a EllipsisValue {
+    fn key(&self) -> String {
+        self.name.clone().unwrap_or("".to_string())
+    }
+
+    fn value(self) -> Robj {
+        self.value.clone()
+    }
+}
+
 impl Ellipsis {
     pub(crate) fn new() -> Ellipsis {
         Self { robj: ().into() }
@@ -35,13 +45,6 @@ impl Ellipsis {
                 list_elem: self.robj.get(),
             }
         }
-    }
-
-    pub fn collect_values(&self) -> Result<Vec<Robj>> {
-        self.iter()
-            .filter_map(|x| x.value.to_promise())
-            .map(|p| p.eval())
-            .collect()
     }
 
     pub fn values(&self) -> Result<Vec<EllipsisValue>> {

--- a/extendr-api/src/wrapper/mod.rs
+++ b/extendr-api/src/wrapper/mod.rs
@@ -9,6 +9,7 @@ pub mod altrep;
 pub mod complexes;
 pub mod dataframe;
 pub mod doubles;
+pub mod ellipsis;
 pub mod environment;
 pub mod expr;
 pub mod externalptr;
@@ -37,6 +38,7 @@ pub use altrep::{
 pub use complexes::Complexes;
 pub use dataframe::{Dataframe, IntoDataFrameRow};
 pub use doubles::Doubles;
+pub use ellipsis::Ellipsis;
 pub use environment::{EnvIter, Environment};
 pub use expr::Expressions;
 pub use externalptr::ExternalPtr;

--- a/extendr-api/tests/extendr_macro.rs
+++ b/extendr-api/tests/extendr_macro.rs
@@ -212,7 +212,7 @@ fn test_metadata() {
 }
 
 #[extendr(use_try_from = true)]
-fn test_ellipsis(#[ellipsis] val: Ellipsis) {}
+fn test_ellipsis(#[ellipsis] _val: Ellipsis) {}
 
 #[test]
 fn test_metadata_ellipsis() {
@@ -222,7 +222,7 @@ fn test_metadata_ellipsis() {
     meta__test_ellipsis(&mut funcs);
 
     let args = vec![Arg {
-        name: "val",
+        name: "_val",
         arg_type: "Ellipsis",
         modifier: ArgModifier::Ellipsis,
     }];

--- a/extendr-api/tests/extendr_macro.rs
+++ b/extendr-api/tests/extendr_macro.rs
@@ -1,3 +1,4 @@
+use extendr_api::metadata::ArgModifier;
 use extendr_api::prelude::*;
 
 #[extendr(use_try_from = true)]
@@ -192,7 +193,7 @@ fn test_metadata() {
     let args = vec![Arg {
         name: "val",
         arg_type: "Robj",
-        default: Some("NULL"),
+        modifier: ArgModifier::None,
     }];
 
     assert_eq!(

--- a/extendr-api/tests/extendr_macro.rs
+++ b/extendr-api/tests/extendr_macro.rs
@@ -193,7 +193,7 @@ fn test_metadata() {
     let args = vec![Arg {
         name: "val",
         arg_type: "Robj",
-        modifier: ArgModifier::None,
+        modifier: ArgModifier::Default("NULL"),
     }];
 
     assert_eq!(

--- a/extendr-api/tests/extendr_macro.rs
+++ b/extendr-api/tests/extendr_macro.rs
@@ -210,3 +210,22 @@ fn test_metadata() {
         }
     );
 }
+
+#[extendr(use_try_from = true)]
+fn test_ellipsis(#[ellipsis] val: Ellipsis) {}
+
+#[test]
+fn test_metadata_ellipsis() {
+    use extendr_api::metadata::Arg;
+    use extendr_api::metadata::Func;
+    let mut funcs: Vec<Func> = Vec::new();
+    meta__test_ellipsis(&mut funcs);
+
+    let args = vec![Arg {
+        name: "val",
+        arg_type: "Ellipsis",
+        modifier: ArgModifier::Ellipsis,
+    }];
+
+    assert_eq!(funcs[0].args, args);
+}

--- a/extendr-macros/src/extendr_module.rs
+++ b/extendr-macros/src/extendr_module.rs
@@ -70,8 +70,8 @@ pub fn extendr_module(item: TokenStream) -> TokenStream {
                 mod_name: #make_module_wrappers_name_string,
                 r_name: #make_module_wrappers_name_string,
                 args: vec![
-                    extendr_api::metadata::Arg { name: "use_symbols", arg_type: "bool", default: None },
-                    extendr_api::metadata::Arg { name: "package_name", arg_type: "&str", default: None },
+                    extendr_api::metadata::Arg { name: "use_symbols", arg_type: "bool", modifier: extendr_api::metadata::ArgModifier::None },
+                    extendr_api::metadata::Arg { name: "package_name", arg_type: "&str", modifier: extendr_api::metadata::ArgModifier::None  },
                     ],
                 return_type: "String",
                 func_ptr: #wrap_make_module_wrappers as * const u8,

--- a/extendr-macros/src/wrappers.rs
+++ b/extendr-macros/src/wrappers.rs
@@ -332,7 +332,7 @@ fn translate_actual(opts: &ExtendrOptions, input: &FnArg) -> Option<Expr> {
                 let varname = format_ident!("_{}_robj", ident.ident);
                 if opts.use_try_from {
                     Some(parse_quote! {
-                        #varname.try_into()?
+                        (&#varname).try_into()?
                     })
                 } else {
                     Some(parse_quote! { <#ty>::from_robj(&#varname)? })

--- a/tests/extendrtests/.gitignore
+++ b/tests/extendrtests/.gitignore
@@ -40,3 +40,4 @@ vignettes/*.pdf
 
 # check dir
 check/
+/.vscode/settings.json

--- a/tests/extendrtests/DESCRIPTION
+++ b/tests/extendrtests/DESCRIPTION
@@ -25,4 +25,4 @@ Suggests:
     testthat,
     vctrs,
     lobstr
-Config/rextendr/version: 0.3.0
+Config/rextendr/version: 0.3.1.9000

--- a/tests/extendrtests/R/extendr-wrappers.R
+++ b/tests/extendrtests/R/extendr-wrappers.R
@@ -145,6 +145,8 @@ MyClass$restore_from_robj <- function(robj) .Call(wrap__MyClass__restore_from_ro
 
 MyClass$get_default_value <- function(x = 42) .Call(wrap__MyClass__get_default_value, x)
 
+MyClass$process_dots <- function(...) .Call(wrap__MyClass__process_dots, environment())
+
 #' @rdname MyClass
 #' @usage NULL
 #' @export

--- a/tests/extendrtests/R/extendr-wrappers.R
+++ b/tests/extendrtests/R/extendr-wrappers.R
@@ -77,6 +77,8 @@ add_5_if_not_null <- function(x) .Call(wrap__add_5_if_not_null, x)
 #' @export
 my_device <- function(welcome_message) invisible(.Call(wrap__my_device, welcome_message))
 
+collect_dots <- function(x, ..., y) .Call(wrap__collect_dots, x, environment(), y)
+
 #' Return string `"Hello world!"` to R.
 #' @export
 hello_submodule <- function() .Call(wrap__hello_submodule)

--- a/tests/extendrtests/man/MyClass.Rd
+++ b/tests/extendrtests/man/MyClass.Rd
@@ -6,7 +6,7 @@
 \alias{$.MyClass}
 \title{Class for testing (exported)}
 \format{
-An object of class \code{environment} of length 6.
+An object of class \code{environment} of length 7.
 }
 \usage{
 MyClass

--- a/tests/extendrtests/src/rust/src/lib.rs
+++ b/tests/extendrtests/src/rust/src/lib.rs
@@ -257,6 +257,17 @@ impl MyClass {
     fn get_default_value(#[default = "42"] x: i32) -> i32 {
         x
     }
+
+    fn process_dots(#[ellipsis] dots: Ellipsis) -> Result<List> {
+        let dots = dots.values()?;
+        let has_names = dots.iter().any(|v| v.name.is_some());
+
+        if has_names {
+            Ok(List::from_pairs(dots.into_iter()))
+        } else {
+            Ok(List::from_values(dots.into_iter().map(|v| v.value)))
+        }
+    }
 }
 
 // Class for testing special names

--- a/tests/extendrtests/src/rust/src/lib.rs
+++ b/tests/extendrtests/src/rust/src/lib.rs
@@ -309,6 +309,20 @@ fn my_device(welcome_message: String) {
     device_driver.create_device::<graphic_device::MyDevice>(device_descriptor, "my device");
 }
 
+#[extendr(use_try_from = true)]
+fn collect_dots(x: Robj, #[ellipsis] dots: Ellipsis, y: Robj) -> Result<List> {
+    let dots = dots.values()?;
+    let has_names = dots.iter().any(|v| v.name.is_some());
+
+    let dots = if has_names {
+        List::from_pairs(dots.into_iter())
+    } else {
+        List::from_values(dots.into_iter().map(|v| v.value))
+    };
+
+    Ok(list!(x = x, dots = dots, y = y))
+}
+
 // Macro to generate exports
 extendr_module! {
     mod extendrtests;
@@ -357,6 +371,8 @@ extendr_module! {
     impl MyClassUnexported;
 
     fn my_device;
+
+    fn collect_dots;
 
     use submodule;
     use optional_ndarray;

--- a/tests/extendrtests/tests/testthat/test-dots.R
+++ b/tests/extendrtests/tests/testthat/test-dots.R
@@ -1,0 +1,28 @@
+test_that("Dots collect reamaining unnamed values", {
+  result <- collect_dots(x = 42, y = "y", 1, 2, 3, 4, 5)
+  expected <- list(x = 42, dots = list(1, 2, 3, 4, 5), y = "y")
+  expect_equal(result, expected)
+})
+
+test_that("Dots collect reamaining partially-named values", {
+  result <- collect_dots(x = 42, y = "y", 1, 2, q = 3, 4, p = 5)
+  expected <- list(x = 42, dots = list(1, 2, q = 3, 4, p = 5), y = "y")
+  expect_equal(result, expected)
+})
+
+test_that("Dots allow trailing comma", {
+  result <- collect_dots(x = 42, y = "y", )
+  expected <- list(x = 42, dots = list(), y = "y")
+  expect_equal(result, expected)
+})
+
+test_that("Dots allow values and trailing comma", {
+  result <- collect_dots(x = 42, y = "y", 1, 2, 3, )
+  expected <- list(x = 42, dots = list(1, 2, 3), y = "y")
+  expect_equal(result, expected)
+})
+
+test_that("Dots throw if missing value in the middle", {
+  expect_error(collect_dots(x = 42, y = "y", 1, 2, , 3))
+})
+

--- a/tests/extendrtests/tests/testthat/test-dots.R
+++ b/tests/extendrtests/tests/testthat/test-dots.R
@@ -26,3 +26,9 @@ test_that("Dots throw if missing value in the middle", {
   expect_error(collect_dots(x = 42, y = "y", 1, 2, , 3))
 })
 
+test_that("Dots in class method", {
+  class <- MyClass$new()
+  result <- class$process_dots(x = 42, y = "y", 1, 2, 3, 4, 5,)
+  expected <- list(x = 42, y = "y", 1, 2, 3, 4, 5)
+  expect_equal(result, expected)
+})


### PR DESCRIPTION
- Add support for `...` parameters in `extendr`-functions.
  - Introduce `Ellipsis` type that lazily consumes `...`
  - Allow iterating over raw values (either `Promise` or `missing_arg`)
  - Allow quickly collecting all values by evaluating `Promise`s, with at most one allowed trailing missing arg (`rlang::list2`-style)
- Implement conversion from `Robj` in two steps:
  - If `Robj` is `Environment`, try searching for `...` element in the environment and then
    - If `...` is `missing_arg`, return empty `Ellipsis` (case when nothing is captured by `...`)
    - If `...` is `DOTSXP`, capture it in `Ellipsis`
- Add `#[ellipsis]` attribute to signal wrapper generator to rename parameter & capture `environment()`
- Fix incorrect conversion when `use_try_from = true`:  `TryFrom<Robj>` was used instead of `TryFrom<&Robj>`, which is the preferred one

Closes #576 