### PR TITLE
Update syn crate to version 2

### DIFF
--- a/extendr-macros/Cargo.toml
+++ b/extendr-macros/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "Mossa Merhi Reimert <mossa@sund.ku.dk>",
     "Claus O. Wilke <wilke@austin.utexas.edu>",
     "Hiroaki Yutani",
-    "Ilia A. Kosenkov <ilia.kosenkov@outlook.com>"
+    "Ilia A. Kosenkov <ilia.kosenkov@outlook.com>",
 ]
 edition = "2021"
 description = "Generate bindings from R to Rust."
@@ -18,7 +18,7 @@ repository = "https://github.com/extendr/extendr"
 proc_macro = true
 
 [dependencies]
-syn = { version = "1.0.22", features = ["full", "extra-traits"] }
+syn = { version = "2.0", features = ["full", "extra-traits"] }
 quote = "1.0.6"
 proc-macro2 = { version = "1.0" }
 

--- a/extendr-macros/src/extendr_function.rs
+++ b/extendr-macros/src/extendr_function.rs
@@ -4,12 +4,7 @@ use quote::quote;
 use syn::{meta::ParseNestedMeta, ItemFn, Lit, LitBool};
 
 /// Generate bindings for a single function.
-pub fn extendr_function(args: Vec<syn::NestedMeta>, mut func: ItemFn) -> TokenStream {
-    let mut opts = wrappers::ExtendrOptions::default();
-
-    for arg in &args {
-        parse_options(&mut opts, arg);
-    }
+pub fn extendr_function(mut func: ItemFn, opts: &wrappers::ExtendrOptions) -> TokenStream {
     let mut wrappers: Vec<ItemFn> = Vec::new();
     wrappers::make_function_wrappers(opts, &mut wrappers, "", &func.attrs, &mut func.sig, None);
 
@@ -20,51 +15,29 @@ pub fn extendr_function(args: Vec<syn::NestedMeta>, mut func: ItemFn) -> TokenSt
     })
 }
 
-/// Parse a set of attribute arguments for `#[extendr(opts...)]`
-///
-/// Supported options:
-///
-/// - `use_try_from = bool` which uses `TryFrom<Robj>` for argument conversions.
-/// - `r_name = "name"` which specifies the name of the wrapper on the R-side.
-/// - `use_rng = bool` ensures the RNG-state is pulled and pushed
-///
-pub fn parse_options(opts: &mut wrappers::ExtendrOptions, arg: &syn::NestedMeta) {
-    use syn::{Lit, LitBool, Meta, MetaNameValue, NestedMeta};
+impl wrappers::ExtendrOptions {
+    /// Parse a set of attribute arguments for `#[extendr(opts...)]`
+    ///
+    /// Supported options:
+    ///
+    /// - `use_try_from = bool` which uses `TryFrom<Robj>` for argument conversions.
+    /// - `r_name = "name"` which specifies the name of the wrapper on the R-side.
+    /// - `use_rng = bool` ensures the RNG-state is pulled and pushed
+    ///
+    pub fn parse(&mut self, meta: ParseNestedMeta) -> syn::parse::Result<()> {
+        fn help_message() -> ! {
+            panic!("expected #[extendr(use_try_from = bool, r_name = \"name\", mod_name = \"r_mod_name\", use_rng = bool)]");
+        }
 
-    fn help_message() -> ! {
-        panic!("expected #[extendr(use_try_from = bool, r_name = \"name\", mod_name = \"r_mod_name\", use_rng = bool)]");
-    }
+        let value = match meta.value() {
+            Ok(value) => value,
+            Err(_) => help_message(),
+        };
 
-    match arg {
-        NestedMeta::Meta(Meta::NameValue(MetaNameValue {
-            ref path,
-            eq_token: _,
-            lit,
-        })) => {
-            if path.is_ident("use_try_from") {
-                if let Lit::Bool(LitBool { value, .. }) = lit {
-                    opts.use_try_from = *value;
-                } else {
-                    help_message();
-                }
-            } else if path.is_ident("r_name") {
-                if let Lit::Str(litstr) = lit {
-                    opts.r_name = Some(litstr.value());
-                } else {
-                    help_message();
-                }
-            } else if path.is_ident("mod_name") {
-                if let Lit::Str(litstr) = lit {
-                    opts.mod_name = Some(litstr.value());
-                } else {
-                    help_message();
-                }
-            } else if path.is_ident("use_rng") {
-                if let Lit::Bool(LitBool { value, .. }) = lit {
-                    opts.use_rng = *value;
-                } else {
-                    help_message();
-                }
+        if meta.path.is_ident("use_try_from") {
+            if let Ok(LitBool { value, .. }) = value.parse() {
+                self.use_try_from = value;
+                Ok(())
             } else {
                 help_message();
             }
@@ -78,6 +51,13 @@ pub fn parse_options(opts: &mut wrappers::ExtendrOptions, arg: &syn::NestedMeta)
         } else if meta.path.is_ident("mod_name") {
             if let Ok(Lit::Str(litstr)) = value.parse() {
                 self.mod_name = Some(litstr.value());
+                Ok(())
+            } else {
+                help_message();
+            }
+        } else if meta.path.is_ident("use_rng") {
+            if let Ok(LitBool { value, .. }) = value.parse() {
+                self.use_rng = value;
                 Ok(())
             } else {
                 help_message();

--- a/extendr-macros/src/extendr_function.rs
+++ b/extendr-macros/src/extendr_function.rs
@@ -1,18 +1,12 @@
 use crate::wrappers;
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::ItemFn;
+use syn::{meta::ParseNestedMeta, ItemFn, Lit, LitBool};
 
 /// Generate bindings for a single function.
-pub fn extendr_function(args: Vec<syn::NestedMeta>, mut func: ItemFn) -> TokenStream {
-    let mut opts = wrappers::ExtendrOptions::default();
-
-    for arg in &args {
-        parse_options(&mut opts, arg);
-    }
-
+pub fn extendr_function(mut func: ItemFn, opts: &wrappers::ExtendrOptions) -> TokenStream {
     let mut wrappers: Vec<ItemFn> = Vec::new();
-    wrappers::make_function_wrappers(&opts, &mut wrappers, "", &func.attrs, &mut func.sig, None);
+    wrappers::make_function_wrappers(opts, &mut wrappers, "", &func.attrs, &mut func.sig, None);
 
     TokenStream::from(quote! {
         #func
@@ -21,42 +15,41 @@ pub fn extendr_function(args: Vec<syn::NestedMeta>, mut func: ItemFn) -> TokenSt
     })
 }
 
-/// Parse a set of attribute arguments for #[extendr(opts...)]
-pub fn parse_options(opts: &mut wrappers::ExtendrOptions, arg: &syn::NestedMeta) {
-    use syn::{Lit, LitBool, Meta, MetaNameValue, NestedMeta};
+impl wrappers::ExtendrOptions {
+    /// Parse a set of attribute arguments for #[extendr(opts...)]
+    pub fn parse(&mut self, meta: ParseNestedMeta) -> syn::parse::Result<()> {
+        fn help_message() -> ! {
+            panic!("expected #[extendr(use_try_from=bool, r_name=\"name\")]");
+        }
 
-    fn help_message() -> ! {
-        panic!("expected #[extendr(use_try_from=bool, r_name=\"name\")]");
-    }
+        let value = match meta.value() {
+            Ok(value) => value,
+            Err(_) => help_message(),
+        };
 
-    match arg {
-        NestedMeta::Meta(Meta::NameValue(MetaNameValue {
-            ref path,
-            eq_token: _,
-            lit,
-        })) => {
-            if path.is_ident("use_try_from") {
-                if let Lit::Bool(LitBool { value, .. }) = lit {
-                    opts.use_try_from = *value;
-                } else {
-                    help_message();
-                }
-            } else if path.is_ident("r_name") {
-                if let Lit::Str(litstr) = lit {
-                    opts.r_name = Some(litstr.value());
-                } else {
-                    help_message();
-                }
-            } else if path.is_ident("mod_name") {
-                if let Lit::Str(litstr) = lit {
-                    opts.mod_name = Some(litstr.value());
-                } else {
-                    help_message();
-                }
+        if meta.path.is_ident("use_try_from") {
+            if let Ok(LitBool { value, .. }) = value.parse() {
+                self.use_try_from = value;
+                Ok(())
             } else {
                 help_message();
             }
+        } else if meta.path.is_ident("r_name") {
+            if let Ok(Lit::Str(litstr)) = value.parse() {
+                self.r_name = Some(litstr.value());
+                Ok(())
+            } else {
+                help_message();
+            }
+        } else if meta.path.is_ident("mod_name") {
+            if let Ok(Lit::Str(litstr)) = value.parse() {
+                self.mod_name = Some(litstr.value());
+                Ok(())
+            } else {
+                help_message();
+            }
+        } else {
+            help_message();
         }
-        _ => help_message(),
     }
 }

--- a/extendr-macros/src/extendr_impl.rs
+++ b/extendr-macros/src/extendr_impl.rs
@@ -83,7 +83,7 @@ pub fn extendr_impl(mut item_impl: ItemImpl) -> TokenStream {
     // ```
     let mut wrappers: Vec<ItemFn> = Vec::new();
     for impl_item in &mut item_impl.items {
-        if let syn::ImplItem::Method(ref mut method) = impl_item {
+        if let syn::ImplItem::Fn(ref mut method) = impl_item {
             method_meta_names.push(format_ident!(
                 "{}{}__{}",
                 wrappers::META_PREFIX,

--- a/extendr-macros/src/lib.rs
+++ b/extendr-macros/src/lib.rs
@@ -73,9 +73,13 @@ use syn::{parse_macro_input, Item};
 
 #[proc_macro_attribute]
 pub fn extendr(attr: TokenStream, item: TokenStream) -> TokenStream {
-    let args = parse_macro_input!(attr as syn::AttributeArgs);
+    let mut opts = wrappers::ExtendrOptions::default();
+
+    let extendr_opts_parser = syn::meta::parser(|meta| opts.parse(meta));
+    parse_macro_input!(attr with extendr_opts_parser);
+
     match parse_macro_input!(item as Item) {
-        Item::Fn(func) => extendr_function::extendr_function(args, func),
+        Item::Fn(func) => extendr_function::extendr_function(func, &opts),
         Item::Impl(item_impl) => extendr_impl::extendr_impl(item_impl),
         other_item => TokenStream::from(quote! {#other_item}),
     }

--- a/extendr-macros/src/wrappers.rs
+++ b/extendr-macros/src/wrappers.rs
@@ -171,7 +171,7 @@ pub fn make_function_wrappers(
 pub fn get_doc_string(attrs: &[syn::Attribute]) -> String {
     let mut res = String::new();
     for attr in attrs {
-        if let Some(id) = attr.path.get_ident() {
+        if let Some(id) = attr.path().get_ident() {
             if *id != "doc" {
                 continue;
             }

--- a/extendr-macros/src/wrappers.rs
+++ b/extendr-macros/src/wrappers.rs
@@ -1,5 +1,5 @@
 use proc_macro2::Ident;
-use quote::{format_ident, quote, ToTokens};
+use quote::{format_ident, quote};
 use syn::{parse_quote, punctuated::Punctuated, Expr, ExprLit, FnArg, ItemFn, Token, Type};
 
 pub const META_PREFIX: &str = "meta__";
@@ -175,27 +175,18 @@ pub fn get_doc_string(attrs: &[syn::Attribute]) -> String {
             continue;
         }
 
-        let _ = attr.parse_nested_meta(|meta| {
-            let value = match meta.value() {
-                Ok(value) => value,
-                Err(_) => return Err(meta.error("Failed to get value")),
-            };
-
-            if let Ok(syn::Meta::NameValue(syn::MetaNameValue { value, .. })) = value.parse() {
-                if let Expr::Lit(ExprLit {
-                    lit: syn::Lit::Str(litstr),
-                    ..
-                }) = value
-                {
-                    if !res.is_empty() {
-                        res.push('\n');
-                    }
-                    res.push_str(&litstr.value());
+        if let syn::Meta::NameValue(ref nv) = attr.meta {
+            if let Expr::Lit(ExprLit {
+                lit: syn::Lit::Str(ref litstr),
+                ..
+            }) = nv.value
+            {
+                if !res.is_empty() {
+                    res.push('\n');
                 }
+                res.push_str(&litstr.value());
             }
-
-            Ok(())
-        });
+        }
     }
     res
 }


### PR DESCRIPTION
Disclaimer: I don't intend to merge this because it would conflicts with several ongoing pull requests. The main purpose of this is is to show how updating is possible, and (the second purpose is to train myself).

As discussed in https://github.com/extendr/extendr/pull/574, extendr seems to have some motivation to update the syn crate. Here's some code and references:

* [Release note of Syn 2.0](https://github.com/dtolnay/syn/releases/tag/2.0.0)
* [`syn::parse`](https://docs.rs/syn/latest/syn/parse/index.html)
* [`syn::meta::parser`](https://docs.rs/syn/latest/syn/meta/fn.parser.html)
* [`syn::Attribute`](https://docs.rs/syn/latest/syn/struct.Attribute.html)
* [When to choose `Attribute::parse_nested_meta` or `syn::meta::parser`](https://docs.rs/syn/latest/syn/meta/struct.ParseNestedMeta.html#examples)

Sorry for no explanations about the changes. I might write some in future if I get some time.