### PR TITLE
Return featureful iterator from `Robj`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 - [**either**] `TryFrom<&Robj> for Either<T, R>` and `From<Either<T, R>> for Robj` if `T` and `R` are themselves implement these traits. This unblocks scenarios like accepting any numeric vector from R via `Either<Integers, Doubles>` without extra memory allocation [[#480]](https://github.com/extendr/extendr/pull/480)
 - `PartialOrd` trait implementation for `Rfloat`, `Rint` and `Rbool`. `Rfloat` and `Rint` gained `min()` and `max()` methods [[#573]](https://github.com/extendr/extendr/pull/573)
-- Iterators from `Robj` now implements `DoubleEndedIterator` and `ExactSizeIterator`
-etc. allowing for more combinators to be used [[#591]](https://github.com/extendr/extendr/pull/591)
+- Iterators from `Robj` now implements `DoubleEndedIterator` and `ExactSizeIterator` allowing for more combinators to be used
+    [[#591]](https://github.com/extendr/extendr/pull/591)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@
 
 - [**either**] `TryFrom<&Robj> for Either<T, R>` and `From<Either<T, R>> for Robj` if `T` and `R` are themselves implement these traits. This unblocks scenarios like accepting any numeric vector from R via `Either<Integers, Doubles>` without extra memory allocation [[#480]](https://github.com/extendr/extendr/pull/480)
 - `PartialOrd` trait implementation for `Rfloat`, `Rint` and `Rbool`. `Rfloat` and `Rint` gained `min()` and `max()` methods [[#573]](https://github.com/extendr/extendr/pull/573)
-- Iterators from `Robj` now returns `std::slice::Iter` / `std::slice::IterMut`,
-which implements `DoubleEndedIterator`, `ExactSizeIterator`, `FusedIterator`,
+- Iterators from `Robj` now implements `DoubleEndedIterator` and `ExactSizeIterator`
 etc. allowing for more combinators to be used [[#591]](https://github.com/extendr/extendr/pull/591)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - [**either**] `TryFrom<&Robj> for Either<T, R>` and `From<Either<T, R>> for Robj` if `T` and `R` are themselves implement these traits. This unblocks scenarios like accepting any numeric vector from R via `Either<Integers, Doubles>` without extra memory allocation [[#480]](https://github.com/extendr/extendr/pull/480)
 - `PartialOrd` trait implementation for `Rfloat`, `Rint` and `Rbool`. `Rfloat` and `Rint` gained `min()` and `max()` methods [[#573]](https://github.com/extendr/extendr/pull/573)
+- Iterators from `Robj` now returns `std::slice::Iter` / `std::slice::IterMut`,
+which implements `DoubleEndedIterator`, `ExactSizeIterator`, `FusedIterator`,
+etc. allowing for more combinators to be used [[#591]](https://github.com/extendr/extendr/pull/591)
 
 ### Fixed
 

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -426,7 +426,7 @@ impl Robj {
     ///     assert_eq!(num_na, 1);
     /// }
     /// ```
-    pub fn as_logical_iter(&self) -> Option<impl Iterator<Item = &Rbool>> {
+    pub fn as_logical_iter(&self) -> Option<std::slice::Iter<Rbool>> {
         self.as_logical_slice().map(|slice| slice.iter())
     }
 
@@ -465,7 +465,7 @@ impl Robj {
     ///     assert_eq!(tot, 6.);
     /// }
     /// ```
-    pub fn as_real_iter(&self) -> Option<impl Iterator<Item = &f64>> {
+    pub fn as_real_iter(&self) -> Option<std::slice::Iter<f64>> {
         self.as_real_slice().map(|slice| slice.iter())
     }
 

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -426,7 +426,7 @@ impl Robj {
     ///     assert_eq!(num_na, 1);
     /// }
     /// ```
-    pub fn as_logical_iter(&self) -> Option<std::slice::Iter<Rbool>> {
+    pub fn as_logical_iter(&self) -> Option<impl Iterator<Item = &Rbool> + DoubleEndedIterator + ExactSizeIterator> {
         self.as_logical_slice().map(|slice| slice.iter())
     }
 

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -426,7 +426,9 @@ impl Robj {
     ///     assert_eq!(num_na, 1);
     /// }
     /// ```
-    pub fn as_logical_iter(&self) -> Option<impl Iterator<Item = &Rbool> + DoubleEndedIterator + ExactSizeIterator> {
+    pub fn as_logical_iter(
+        &self,
+    ) -> Option<impl Iterator<Item = &Rbool> + DoubleEndedIterator + ExactSizeIterator> {
         self.as_logical_slice().map(|slice| slice.iter())
     }
 
@@ -465,7 +467,9 @@ impl Robj {
     ///     assert_eq!(tot, 6.);
     /// }
     /// ```
-    pub fn as_real_iter(&self) -> Option<std::slice::Iter<f64>> {
+    pub fn as_real_iter(
+        &self,
+    ) -> Option<impl Iterator<Item = &f64> + DoubleEndedIterator + ExactSizeIterator> {
         self.as_real_slice().map(|slice| slice.iter())
     }
 

--- a/extendr-api/src/robj/tests.rs
+++ b/extendr-api/src/robj/tests.rs
@@ -342,12 +342,14 @@ fn input_iterator_test() {
 
         let src: &[i32] = &[1, 2, 3];
         let robj = Robj::from(src);
-        let iter = <Integers>::from_robj(&robj).unwrap().iter();
+        let iter = <Integers>::from_robj(&robj).unwrap();
+        let iter = iter.iter();
         assert_eq!(iter.collect::<Vec<_>>(), src);
 
         let src: &[f64] = &[1., 2., 3.];
         let robj = Robj::from(src);
-        let iter = <Doubles>::from_robj(&robj).unwrap().iter();
+        let iter = <Doubles>::from_robj(&robj).unwrap();
+        let iter = iter.iter();
         assert_eq!(iter.collect::<Vec<_>>(), src);
 
         /*

--- a/extendr-api/src/wrapper/integers.rs
+++ b/extendr-api/src/wrapper/integers.rs
@@ -116,7 +116,7 @@ mod tests {
 
     #[test]
     fn test_various_iter_methods() {
-        test!{
+        test! {
             let a: Integers = (0..2).map(|z| Rint::from(z)).collect();
             let b = <[Rint]>::iter(&a);
             let c: Integers = b.rev().copied().collect();

--- a/extendr-api/src/wrapper/integers.rs
+++ b/extendr-api/src/wrapper/integers.rs
@@ -113,6 +113,16 @@ mod tests {
             assert_eq!(vec.len(), 10);
         }
     }
+
+    #[test]
+    fn test_various_iter_methods() {
+        test!{
+            let a: Integers = (0..2).map(|z| Rint::from(z)).collect();
+            let b = <[Rint]>::iter(&a);
+            let c: Integers = b.rev().copied().collect();
+            let d = a.iter().rev();
+        }
+    }
 }
 
 // TODO: this should be a trait.

--- a/extendr-api/src/wrapper/macros.rs
+++ b/extendr-api/src/wrapper/macros.rs
@@ -104,11 +104,11 @@ macro_rules! gen_vector_wrapper_impl {
             paste::paste!{
                 #[doc = "Return an iterator for a " $doc_name " object."]
                 #[doc = "Forces ALTREP objects to manifest."]
-                pub fn iter(&self) -> impl Iterator<Item = $scalar_type> {
+                pub fn iter(&self) -> std::iter::Cloned<std::slice::Iter<$scalar_type>> {
                     self.as_robj().as_typed_slice().unwrap().iter().cloned()
                 }
             }
-
+            //TODO: pass the underlying slice IterMut
             paste::paste!{
                 #[doc = "Return a writable iterator for a " $doc_name " object."]
                 #[doc = "Forces ALTREP objects to manifest."]

--- a/extendr-api/src/wrapper/macros.rs
+++ b/extendr-api/src/wrapper/macros.rs
@@ -108,11 +108,11 @@ macro_rules! gen_vector_wrapper_impl {
                     self.as_robj().as_typed_slice().unwrap().iter().cloned()
                 }
             }
-            //TODO: pass the underlying slice IterMut
+            
             paste::paste!{
                 #[doc = "Return a writable iterator for a " $doc_name " object."]
                 #[doc = "Forces ALTREP objects to manifest."]
-                pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut $scalar_type> {
+                pub fn iter_mut(&mut self) -> std::slice::IterMut<$scalar_type> {
                     self.as_robj_mut().as_typed_slice_mut().unwrap().iter_mut()
                 }
             }

--- a/extendr-api/src/wrapper/macros.rs
+++ b/extendr-api/src/wrapper/macros.rs
@@ -108,7 +108,7 @@ macro_rules! gen_vector_wrapper_impl {
                     self.as_robj().as_typed_slice().unwrap().iter().cloned()
                 }
             }
-            
+
             paste::paste!{
                 #[doc = "Return a writable iterator for a " $doc_name " object."]
                 #[doc = "Forces ALTREP objects to manifest."]

--- a/extendr-api/src/wrapper/macros.rs
+++ b/extendr-api/src/wrapper/macros.rs
@@ -104,7 +104,7 @@ macro_rules! gen_vector_wrapper_impl {
             paste::paste!{
                 #[doc = "Return an iterator for a " $doc_name " object."]
                 #[doc = "Forces ALTREP objects to manifest."]
-                pub fn iter(&self) -> std::iter::Cloned<std::slice::Iter<$scalar_type>> {
+                pub fn iter(&self) -> impl Iterator<Item = $scalar_type> + DoubleEndedIterator + ExactSizeIterator {
                     self.as_robj().as_typed_slice().unwrap().iter().cloned()
                 }
             }
@@ -112,7 +112,7 @@ macro_rules! gen_vector_wrapper_impl {
             paste::paste!{
                 #[doc = "Return a writable iterator for a " $doc_name " object."]
                 #[doc = "Forces ALTREP objects to manifest."]
-                pub fn iter_mut(&mut self) -> std::slice::IterMut<$scalar_type> {
+                pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut $scalar_type> + DoubleEndedIterator + ExactSizeIterator  {
                     self.as_robj_mut().as_typed_slice_mut().unwrap().iter_mut()
                 }
             }

--- a/extendr-api/src/wrapper/strings.rs
+++ b/extendr-api/src/wrapper/strings.rs
@@ -88,7 +88,7 @@ impl Strings {
     }
 
     /// Get an iterator for this string vector.
-    pub fn iter(&self) -> impl Iterator<Item = &Rstr> {
+    pub fn iter(&self) -> std::slice::Iter<Rstr> {
         self.as_slice().iter()
     }
 

--- a/extendr-api/src/wrapper/strings.rs
+++ b/extendr-api/src/wrapper/strings.rs
@@ -88,7 +88,7 @@ impl Strings {
     }
 
     /// Get an iterator for this string vector.
-    pub fn iter(&self) -> std::slice::Iter<Rstr> {
+    pub fn iter(&self) -> impl Iterator<Item = &Rstr> + DoubleEndedIterator + ExactSizeIterator {
         self.as_slice().iter()
     }
 


### PR DESCRIPTION
Essentially, the issue is

```rust
let a: Integers = (0..2).map(|z| Rint::from(z)).collect();
let b = <[Rint]>::iter(&a);
let c: Integers = b.rev().copied().collect();
```
But this line fails:
```rust
let d = a.iter().rev();
```

I believe this is because we use `impl Iterator<Item = &TYPE>`,
which means trait impls on the underlying slice-iterator aren't passed on.
This can be remedied by using `std::slice::Iter` as a return type instead.

Motivated by a discussion in discord by @daniellga, as seen in #590.

Fixes #590 