### PR TITLE
Make `Rfloat`, `Rint`, and friends `ToVectorValue`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - [**either**] `TryFrom<&Robj> for Either<T, R>` and `From<Either<T, R>> for Robj` if `T` and `R` are themselves implement these traits. This unblocks scenarios like accepting any numeric vector from R via `Either<Integers, Doubles>` without extra memory allocation [[#480]](https://github.com/extendr/extendr/pull/480)
 - `PartialOrd` trait implementation for `Rfloat`, `Rint` and `Rbool`. `Rfloat` and `Rint` gained `min()` and `max()` methods [[#573]](https://github.com/extendr/extendr/pull/573)
+- Added `ToVectorValue` for `Rfloat`, `Rint` and `Rbool` [[#593]](https://github.com/extendr/extendr/pull/593)
+- Added `TryFrom<_>` on `Vec<_>` for `Integers` (`i32`), `Complexes` (`c64`), `Doubles` (`f64`), and `Logicals` (`bool` / `i32`). [[#593]](https://github.com/extendr/extendr/pull/593)
+
 
 ### Fixed
 

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -300,52 +300,52 @@ impl_real_tvv!(f32);
 macro_rules! impl_synonym_type {
     ($type: ty, $synonym_type: ty) => {
         impl ToVectorValue for $type {
-    fn sexptype() -> SEXPTYPE {
-        <f64 as ToVectorValue>::sexptype()
-    }
+            fn sexptype() -> SEXPTYPE {
+                <f64 as ToVectorValue>::sexptype()
+            }
 
-    fn to_real(&self) -> f64
-    where
-        Self: Sized,
-    {
+            fn to_real(&self) -> f64
+            where
+                Self: Sized,
+            {
                 <$synonym_type as ToVectorValue>::to_real(&self.inner())
-    }
+            }
 
-    fn to_complex(&self) -> Rcomplex
-    where
-        Self: Sized,
-    {
+            fn to_complex(&self) -> Rcomplex
+            where
+                Self: Sized,
+            {
                 <$synonym_type as ToVectorValue>::to_complex(&self.inner())
-    }
+            }
 
-    fn to_integer(&self) -> i32
-    where
-        Self: Sized,
-    {
+            fn to_integer(&self) -> i32
+            where
+                Self: Sized,
+            {
                 <$synonym_type as ToVectorValue>::to_integer(&self.inner())
-    }
+            }
 
-    fn to_logical(&self) -> i32
-    where
-        Self: Sized,
-    {
+            fn to_logical(&self) -> i32
+            where
+                Self: Sized,
+            {
                 <$synonym_type as ToVectorValue>::to_logical(&self.inner())
-    }
+            }
 
-    fn to_raw(&self) -> u8
-    where
-        Self: Sized,
-    {
+            fn to_raw(&self) -> u8
+            where
+                Self: Sized,
+            {
                 <$synonym_type as ToVectorValue>::to_raw(&self.inner())
-    }
+            }
 
-    fn to_sexp(&self) -> SEXP
-    where
-        Self: Sized,
-    {
+            fn to_sexp(&self) -> SEXP
+            where
+                Self: Sized,
+            {
                 <$synonym_type as ToVectorValue>::to_sexp(&self.inner())
-    }
-}
+            }
+        }
     };
 }
 impl_synonym_type!(Rfloat, f64);
@@ -816,7 +816,6 @@ impl From<Vec<Rstr>> for Robj {
         Strings::from_values(val.into_iter()).into()
     }
 }
-
 
 #[cfg(test)]
 mod test {

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -297,7 +297,9 @@ macro_rules! impl_real_tvv {
 impl_real_tvv!(f64);
 impl_real_tvv!(f32);
 
-impl ToVectorValue for Rfloat {
+macro_rules! impl_synonym_type {
+    ($type: ty, $synonym_type: ty) => {
+        impl ToVectorValue for $type {
     fn sexptype() -> SEXPTYPE {
         <f64 as ToVectorValue>::sexptype()
     }
@@ -306,44 +308,48 @@ impl ToVectorValue for Rfloat {
     where
         Self: Sized,
     {
-        <f64 as ToVectorValue>::to_real(&self.inner())
+                <$synonym_type as ToVectorValue>::to_real(&self.inner())
     }
 
     fn to_complex(&self) -> Rcomplex
     where
         Self: Sized,
     {
-        <f64 as ToVectorValue>::to_complex(&self.inner())
+                <$synonym_type as ToVectorValue>::to_complex(&self.inner())
     }
 
     fn to_integer(&self) -> i32
     where
         Self: Sized,
     {
-        <f64 as ToVectorValue>::to_integer(&self.inner())
+                <$synonym_type as ToVectorValue>::to_integer(&self.inner())
     }
 
     fn to_logical(&self) -> i32
     where
         Self: Sized,
     {
-        <f64 as ToVectorValue>::to_logical(&self.inner())
+                <$synonym_type as ToVectorValue>::to_logical(&self.inner())
     }
 
     fn to_raw(&self) -> u8
     where
         Self: Sized,
     {
-        <f64 as ToVectorValue>::to_raw(&self.inner())
+                <$synonym_type as ToVectorValue>::to_raw(&self.inner())
     }
 
     fn to_sexp(&self) -> SEXP
     where
         Self: Sized,
     {
-        <f64 as ToVectorValue>::to_sexp(&self.inner())
+                <$synonym_type as ToVectorValue>::to_sexp(&self.inner())
     }
 }
+    };
+}
+impl_synonym_type!(Rfloat, f64);
+impl_synonym_type!(Rint, i32);
 
 // Since these types might exceeds the max or min of R's 32bit integer, we need
 // to return as REALSXP
@@ -811,12 +817,6 @@ impl From<Vec<Rstr>> for Robj {
     }
 }
 
-impl From<Vec<Rint>> for Robj {
-    /// Convert a vector of Rint into integers.
-    fn from(val: Vec<Rint>) -> Self {
-        Integers::from_values(val.into_iter()).into()
-    }
-}
 
 #[cfg(test)]
 mod test {

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -349,7 +349,9 @@ macro_rules! impl_synonym_type {
     };
 }
 impl_synonym_type!(Rfloat, f64);
+impl_synonym_type!(&Rfloat, f64);
 impl_synonym_type!(Rint, i32);
+impl_synonym_type!(&Rint, i32);
 
 // Since these types might exceeds the max or min of R's 32bit integer, we need
 // to return as REALSXP

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -297,6 +297,37 @@ macro_rules! impl_real_tvv {
 impl_real_tvv!(f64);
 impl_real_tvv!(f32);
 
+//TODO: It could be an idea to make this a attribute macro for users,
+// if they wish to specialise their own types as representable in R.
+
+/// Generates a [`ToVectorValue`] for a type, by inheriting the properties
+/// of another type's [`ToVectorValue`]'s implementation.
+/// 
+/// This is meant to be used for wrappers of types that may be represented
+/// in R. The marshalling rules for this is represented in `ToVectorValue`,
+/// and this macro merely co-opts 
+/// 
+/// Arguments:
+/// 
+/// * `$type`         - Target type
+/// * `$synonym_type` - A type that has a `ToVectorValue`-impl, and an `inner`-method. 
+/// 
+/// Requirements: `$type` must have an `inner`-method to extract the
+/// wrapped value. It suffices that `$type` implements `Scalar<T>`.
+/// 
+/// Example usage:
+/// 
+/// ```ignore
+/// impl_synonym_type(Rint, i32);
+/// ```
+/// 
+/// The example here implements
+/// 
+/// `impl ToVectorValue for Rint`,
+/// 
+/// this entails that `Rint` would be stored in `R` exactly
+/// as `i32`. 
+/// 
 macro_rules! impl_synonym_type {
     ($type: ty, $synonym_type: ty) => {
         impl ToVectorValue for $type {

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -297,6 +297,54 @@ macro_rules! impl_real_tvv {
 impl_real_tvv!(f64);
 impl_real_tvv!(f32);
 
+impl ToVectorValue for Rfloat {
+    fn sexptype() -> SEXPTYPE {
+        <f64 as ToVectorValue>::sexptype()
+    }
+
+    fn to_real(&self) -> f64
+    where
+        Self: Sized,
+    {
+        <f64 as ToVectorValue>::to_real(&self.inner())
+    }
+
+    fn to_complex(&self) -> Rcomplex
+    where
+        Self: Sized,
+    {
+        <f64 as ToVectorValue>::to_complex(&self.inner())
+    }
+
+    fn to_integer(&self) -> i32
+    where
+        Self: Sized,
+    {
+        <f64 as ToVectorValue>::to_integer(&self.inner())
+    }
+
+    fn to_logical(&self) -> i32
+    where
+        Self: Sized,
+    {
+        <f64 as ToVectorValue>::to_logical(&self.inner())
+    }
+
+    fn to_raw(&self) -> u8
+    where
+        Self: Sized,
+    {
+        <f64 as ToVectorValue>::to_raw(&self.inner())
+    }
+
+    fn to_sexp(&self) -> SEXP
+    where
+        Self: Sized,
+    {
+        <f64 as ToVectorValue>::to_sexp(&self.inner())
+    }
+}
+
 // Since these types might exceeds the max or min of R's 32bit integer, we need
 // to return as REALSXP
 impl_real_tvv!(i64);
@@ -767,13 +815,6 @@ impl From<Vec<Rint>> for Robj {
     /// Convert a vector of Rint into integers.
     fn from(val: Vec<Rint>) -> Self {
         Integers::from_values(val.into_iter()).into()
-    }
-}
-
-impl From<Vec<Rfloat>> for Robj {
-    /// Convert a vector of Rfloat into doubles.
-    fn from(val: Vec<Rfloat>) -> Self {
-        Doubles::from_values(val.into_iter()).into()
     }
 }
 

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -302,32 +302,32 @@ impl_real_tvv!(f32);
 
 /// Generates a [`ToVectorValue`] for a type, by inheriting the properties
 /// of another type's [`ToVectorValue`]'s implementation.
-/// 
+///
 /// This is meant to be used for wrappers of types that may be represented
 /// in R. The marshalling rules for this is represented in `ToVectorValue`,
-/// and this macro merely co-opts 
-/// 
+/// and this macro merely co-opts
+///
 /// Arguments:
-/// 
+///
 /// * `$type`         - Target type
-/// * `$synonym_type` - A type that has a `ToVectorValue`-impl, and an `inner`-method. 
-/// 
+/// * `$synonym_type` - A type that has a `ToVectorValue`-impl, and an `inner`-method.
+///
 /// Requirements: `$type` must have an `inner`-method to extract the
 /// wrapped value. It suffices that `$type` implements `Scalar<T>`.
-/// 
+///
 /// Example usage:
-/// 
+///
 /// ```ignore
 /// impl_synonym_type(Rint, i32);
 /// ```
-/// 
+///
 /// The example here implements
-/// 
+///
 /// `impl ToVectorValue for Rint`,
-/// 
+///
 /// this entails that `Rint` would be stored in `R` exactly
-/// as `i32`. 
-/// 
+/// as `i32`.
+///
 macro_rules! impl_synonym_type {
     ($type: ty, $synonym_type: ty) => {
         impl ToVectorValue for $type {

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -301,7 +301,7 @@ macro_rules! impl_synonym_type {
     ($type: ty, $synonym_type: ty) => {
         impl ToVectorValue for $type {
             fn sexptype() -> SEXPTYPE {
-                <f64 as ToVectorValue>::sexptype()
+                <$synonym_type as ToVectorValue>::sexptype()
             }
 
             fn to_real(&self) -> f64
@@ -822,6 +822,21 @@ impl From<Vec<Rstr>> for Robj {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn test_vec_rint_to_robj() {
+        test! {
+            let int_vec = vec![3,4,0,-2];
+            let int_vec_robj: Robj = int_vec.clone().into();
+            // unsafe { libR_sys::Rf_PrintValue(int_vec_robj.get())}
+            assert_eq!(int_vec_robj.as_integer_slice().unwrap(), &int_vec);
+
+            let rint_vec = vec![Rint::new(3), Rint::new(4), Rint::new(0), Rint::new(-2)];
+            let rint_vec_robj: Robj = rint_vec.into();
+            // unsafe { libR_sys::Rf_PrintValue(rint_vec_robj.get())}
+            assert_eq!(rint_vec_robj.as_integer_slice().unwrap(), &int_vec);
+        }
+    }
 
     #[test]
     fn test_collect_rarray_matrix() {

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -2,6 +2,8 @@ use super::*;
 use crate::scalar::Scalar;
 use crate::single_threaded;
 
+mod repeat_into_robj;
+
 pub(crate) fn str_to_character(s: &str) -> SEXP {
     unsafe {
         if s.is_na() {
@@ -296,93 +298,6 @@ macro_rules! impl_real_tvv {
 
 impl_real_tvv!(f64);
 impl_real_tvv!(f32);
-
-//TODO: It could be an idea to make this a attribute macro for users,
-// if they wish to specialise their own types as representable in R.
-
-/// Generates a [`ToVectorValue`] for a type, by inheriting the properties
-/// of another type's [`ToVectorValue`]'s implementation.
-///
-/// This is meant to be used for wrappers of types that may be represented
-/// in R. The marshalling rules for this is represented in `ToVectorValue`,
-/// and this macro merely co-opts
-///
-/// Arguments:
-///
-/// * `$type`         - Target type
-/// * `$synonym_type` - A type that has a `ToVectorValue`-impl, and an `inner`-method.
-///
-/// Requirements: `$type` must have an `inner`-method to extract the
-/// wrapped value. It suffices that `$type` implements `Scalar<T>`.
-///
-/// Example usage:
-///
-/// ```ignore
-/// impl_synonym_type(Rint, i32);
-/// ```
-///
-/// The example here implements
-///
-/// `impl ToVectorValue for Rint`,
-///
-/// this entails that `Rint` would be stored in `R` exactly
-/// as `i32`.
-///
-macro_rules! impl_synonym_type {
-    ($type: ty, $synonym_type: ty) => {
-        impl ToVectorValue for $type {
-            fn sexptype() -> SEXPTYPE {
-                <$synonym_type as ToVectorValue>::sexptype()
-            }
-
-            fn to_real(&self) -> f64
-            where
-                Self: Sized,
-            {
-                <$synonym_type as ToVectorValue>::to_real(&self.inner())
-            }
-
-            fn to_complex(&self) -> Rcomplex
-            where
-                Self: Sized,
-            {
-                <$synonym_type as ToVectorValue>::to_complex(&self.inner())
-            }
-
-            fn to_integer(&self) -> i32
-            where
-                Self: Sized,
-            {
-                <$synonym_type as ToVectorValue>::to_integer(&self.inner())
-            }
-
-            fn to_logical(&self) -> i32
-            where
-                Self: Sized,
-            {
-                <$synonym_type as ToVectorValue>::to_logical(&self.inner())
-            }
-
-            fn to_raw(&self) -> u8
-            where
-                Self: Sized,
-            {
-                <$synonym_type as ToVectorValue>::to_raw(&self.inner())
-            }
-
-            fn to_sexp(&self) -> SEXP
-            where
-                Self: Sized,
-            {
-                <$synonym_type as ToVectorValue>::to_sexp(&self.inner())
-            }
-        }
-    };
-}
-impl_synonym_type!(Rfloat, f64);
-impl_synonym_type!(&Rfloat, f64);
-impl_synonym_type!(Rint, i32);
-impl_synonym_type!(&Rint, i32);
 
 // Since these types might exceeds the max or min of R's 32bit integer, we need
 // to return as REALSXP

--- a/extendr-api/src/robj/into_robj/repeat_into_robj.rs
+++ b/extendr-api/src/robj/into_robj/repeat_into_robj.rs
@@ -1,0 +1,88 @@
+use super::*;
+
+//TODO: It could be an idea to make this a attribute macro for users,
+// if they wish to specialise their own types as representable in R.
+
+/// Generates a [`ToVectorValue`] for a type, by inheriting the properties
+/// of another type's [`ToVectorValue`]'s implementation.
+///
+/// This is meant to be used for wrappers of types that may be represented
+/// in R. The marshalling rules for this is represented in `ToVectorValue`,
+/// and this macro merely co-opts
+///
+/// Arguments:
+///
+/// * `$type`         - Target type
+/// * `$synonym_type` - A type that has a `ToVectorValue`-impl, and an `inner`-method.
+///
+/// Requirements: `$type` must have an `inner`-method to extract the
+/// wrapped value. It suffices that `$type` implements `Scalar<T>`.
+///
+/// Example usage:
+///
+/// ```ignore
+/// impl_synonym_type(Rint, i32);
+/// ```
+///
+/// The example here implements
+///
+/// `impl ToVectorValue for Rint`,
+///
+/// this entails that `Rint` would be stored in `R` exactly
+/// as `i32`.
+///
+macro_rules! impl_synonym_type {
+    ($type: ty, $synonym_type: ty) => {
+        impl ToVectorValue for $type {
+            fn sexptype() -> SEXPTYPE {
+                <$synonym_type as ToVectorValue>::sexptype()
+            }
+
+            fn to_real(&self) -> f64
+            where
+                Self: Sized,
+            {
+                <$synonym_type as ToVectorValue>::to_real(&self.inner())
+            }
+
+            fn to_complex(&self) -> Rcomplex
+            where
+                Self: Sized,
+            {
+                <$synonym_type as ToVectorValue>::to_complex(&self.inner())
+            }
+
+            fn to_integer(&self) -> i32
+            where
+                Self: Sized,
+            {
+                <$synonym_type as ToVectorValue>::to_integer(&self.inner())
+            }
+
+            fn to_logical(&self) -> i32
+            where
+                Self: Sized,
+            {
+                <$synonym_type as ToVectorValue>::to_logical(&self.inner())
+            }
+
+            fn to_raw(&self) -> u8
+            where
+                Self: Sized,
+            {
+                <$synonym_type as ToVectorValue>::to_raw(&self.inner())
+            }
+
+            fn to_sexp(&self) -> SEXP
+            where
+                Self: Sized,
+            {
+                <$synonym_type as ToVectorValue>::to_sexp(&self.inner())
+            }
+        }
+    };
+}
+impl_synonym_type!(Rfloat, f64);
+impl_synonym_type!(&Rfloat, f64);
+impl_synonym_type!(Rint, i32);
+impl_synonym_type!(&Rint, i32);

--- a/extendr-api/src/scalar/macros.rs
+++ b/extendr-api/src/scalar/macros.rs
@@ -544,61 +544,6 @@ macro_rules! gen_from_primitive {
     };
 }
 
-/// Generates an implementation of type conversion Traits from a scalar type
-///
-/// This macro requires the following arguments:
-///
-/// * `$type`      - The Type the unary operator Trait is implemented for
-/// * `$type_prim` - The primitive Rust scalar type that corresponds to `$type`
-///
-/// Example Usage:
-///
-/// ```ignore
-/// gen_from_scalar!(Rint, i32);
-/// ```
-///
-/// The 'example usage' implements the following trait definitions:
-///
-/// - `From<Rint> for Option<i32>`
-/// - `From<Rint> for Robj`
-macro_rules! gen_from_scalar {
-    ($type : tt, $type_prim : tt) => {
-        // The 'example usage' expands to...
-        //
-        // impl From<Rint> for Option<i32> {
-        //     fn from(v: Rint) -> Self {
-        //         if v.is_na() {
-        //             None
-        //         } else {
-        //             Some(v.0)
-        //         }
-        //     }
-        // }
-        impl From<$type> for Option<$type_prim> {
-            fn from(v: $type) -> Self {
-                if v.is_na() {
-                    None
-                } else {
-                    Some(v.0)
-                }
-            }
-        }
-
-        // The 'example usage' expands to...
-        //
-        // impl From<Rint> for Robj {
-        //     fn from(value: Rint) -> Self {
-        //         Robj::from(value.0)
-        //     }
-        // }
-        impl From<$type> for Robj {
-            fn from(value: $type) -> Self {
-                Robj::from(value.0)
-            }
-        }
-    };
-}
-
 /// Generates an implementation of a number of Traits for the specified Type
 ///
 /// This macro requires the following arguments:
@@ -888,7 +833,6 @@ macro_rules! gen_sum_iter {
 pub(in crate::scalar) use gen_binop;
 pub(in crate::scalar) use gen_binopassign;
 pub(in crate::scalar) use gen_from_primitive;
-pub(in crate::scalar) use gen_from_scalar;
 pub(in crate::scalar) use gen_partial_ord;
 pub(in crate::scalar) use gen_sum_iter;
 pub(in crate::scalar) use gen_trait_impl;

--- a/extendr-api/src/scalar/rfloat.rs
+++ b/extendr-api/src/scalar/rfloat.rs
@@ -88,7 +88,17 @@ impl Rfloat {
 // Check that underlying `f64` is `NA_real_`.
 gen_trait_impl!(Rfloat, f64, |x: &Rfloat| x.inner().is_na(), f64::na());
 gen_from_primitive!(Rfloat, f64);
-gen_from_scalar!(Rfloat, f64);
+
+impl From<Rfloat> for Option<f64> {
+    fn from(v: Rfloat) -> Self {
+        if v.is_na() {
+            None
+        } else {
+            Some(v.0)
+        }
+    }
+}
+
 gen_sum_iter!(Rfloat);
 gen_partial_ord!(Rfloat, f64);
 

--- a/extendr-api/src/scalar/rint.rs
+++ b/extendr-api/src/scalar/rint.rs
@@ -66,7 +66,17 @@ impl Rint {
 
 gen_trait_impl!(Rint, i32, |x: &Rint| x.0 == i32::MIN, i32::MIN);
 gen_from_primitive!(Rint, i32);
-gen_from_scalar!(Rint, i32);
+
+impl From<Rint> for Option<i32> {
+    fn from(v: Rint) -> Self {
+        if v.is_na() {
+            None
+        } else {
+            Some(v.0)
+        }
+    }
+}
+
 gen_sum_iter!(Rint);
 gen_partial_ord!(Rint, i32);
 

--- a/extendr-api/src/wrapper/complexes.rs
+++ b/extendr-api/src/wrapper/complexes.rs
@@ -78,3 +78,13 @@ impl std::fmt::Debug for Complexes {
         }
     }
 }
+
+impl TryFrom<Vec<c64>> for Complexes {
+    type Error = Error;
+
+    fn try_from(value: Vec<c64>) -> std::result::Result<Self, Self::Error> {
+        Ok(Self {
+            robj: <Robj>::try_from(value)?,
+        })
+    }
+}

--- a/extendr-api/src/wrapper/complexes.rs
+++ b/extendr-api/src/wrapper/complexes.rs
@@ -88,3 +88,18 @@ impl TryFrom<Vec<c64>> for Complexes {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_try_from_vec_c64_conversion() {
+        test! {
+            let vec = vec![c64::new(0., 0.), c64::new(1., 1.), c64::new(0., 1.)];
+            let vec_rob: Complexes = vec.clone().try_into().unwrap();
+            let vec_rob_slice: &[c64] = vec_rob.robj.as_typed_slice().unwrap();
+            assert_eq!(vec_rob_slice, vec.as_slice());
+        }
+    }
+}

--- a/extendr-api/src/wrapper/doubles.rs
+++ b/extendr-api/src/wrapper/doubles.rs
@@ -90,3 +90,15 @@ impl std::fmt::Debug for Doubles {
         }
     }
 }
+
+// TODO: Include Rfloat as well..
+
+impl TryFrom<Vec<f64>> for Doubles {
+    type Error = Error;
+
+    fn try_from(value: Vec<f64>) -> std::result::Result<Self, Self::Error> {
+        Ok(Self {
+            robj: <Robj>::try_from(value)?,
+        })
+    }
+}

--- a/extendr-api/src/wrapper/doubles.rs
+++ b/extendr-api/src/wrapper/doubles.rs
@@ -100,6 +100,7 @@ impl TryFrom<Vec<f64>> for Doubles {
         })
     }
 }
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/extendr-api/src/wrapper/doubles.rs
+++ b/extendr-api/src/wrapper/doubles.rs
@@ -91,8 +91,6 @@ impl std::fmt::Debug for Doubles {
     }
 }
 
-// TODO: Include Rfloat as well..
-
 impl TryFrom<Vec<f64>> for Doubles {
     type Error = Error;
 

--- a/extendr-api/src/wrapper/doubles.rs
+++ b/extendr-api/src/wrapper/doubles.rs
@@ -100,3 +100,17 @@ impl TryFrom<Vec<f64>> for Doubles {
         })
     }
 }
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_vec_f64_doubles_conversion() {
+        test! {
+            let test_vec = vec![0., 1., std::f64::consts::PI, -1.];
+            let test_doubles: Doubles = test_vec.clone().try_into().unwrap();
+            let test_doubles_slice = test_doubles.robj.as_real_slice().unwrap();
+            assert_eq!(test_doubles_slice, test_vec);
+        }
+    }
+}

--- a/extendr-api/src/wrapper/integers.rs
+++ b/extendr-api/src/wrapper/integers.rs
@@ -155,3 +155,13 @@ impl std::fmt::Debug for Integers {
         }
     }
 }
+
+impl TryFrom<Vec<i32>> for Integers {
+    type Error = Error;
+
+    fn try_from(value: Vec<i32>) -> std::result::Result<Self, Self::Error> {
+        Ok(Self {
+            robj: <Robj>::try_from(value)?,
+        })
+    }
+}

--- a/extendr-api/src/wrapper/integers.rs
+++ b/extendr-api/src/wrapper/integers.rs
@@ -50,6 +50,57 @@ impl Integers {
     }
 }
 
+// TODO: this should be a trait.
+impl Integers {
+    pub fn set_elt(&mut self, index: usize, val: Rint) {
+        unsafe {
+            SET_INTEGER_ELT(self.get(), index as R_xlen_t, val.inner());
+        }
+    }
+}
+
+impl Deref for Integers {
+    type Target = [Rint];
+
+    /// Treat Integers as if it is a slice, like `Vec<Rint>`
+    fn deref(&self) -> &Self::Target {
+        unsafe {
+            let ptr = DATAPTR_RO(self.get()) as *const Rint;
+            std::slice::from_raw_parts(ptr, self.len())
+        }
+    }
+}
+
+impl DerefMut for Integers {
+    /// Treat Integers as if it is a mutable slice, like `Vec<Rint>`
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe {
+            let ptr = DATAPTR(self.get()) as *mut Rint;
+            std::slice::from_raw_parts_mut(ptr, self.len())
+        }
+    }
+}
+
+impl std::fmt::Debug for Integers {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.len() == 1 {
+            write!(f, "{:?}", self.elt(0))
+        } else {
+            f.debug_list().entries(self.iter()).finish()
+        }
+    }
+}
+
+impl TryFrom<Vec<i32>> for Integers {
+    type Error = Error;
+
+    fn try_from(value: Vec<i32>) -> std::result::Result<Self, Self::Error> {
+        Ok(Self {
+            robj: <Robj>::try_from(value)?,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::prelude::*;
@@ -113,55 +164,14 @@ mod tests {
             assert_eq!(vec.len(), 10);
         }
     }
-}
 
-// TODO: this should be a trait.
-impl Integers {
-    pub fn set_elt(&mut self, index: usize, val: Rint) {
-        unsafe {
-            SET_INTEGER_ELT(self.get(), index as R_xlen_t, val.inner());
+    #[test]
+    fn test_vec_i32_integers_conversion() {
+        test! {
+            let int_vec = vec![3,4,0,-2];
+            let int_vec_robj: Robj = int_vec.clone().try_into().unwrap();
+            // unsafe { libR_sys::Rf_PrintValue(rint_vec_robj.get())}
+            assert_eq!(int_vec_robj.as_integer_slice().unwrap(), &int_vec);
         }
-    }
-}
-
-impl Deref for Integers {
-    type Target = [Rint];
-
-    /// Treat Integers as if it is a slice, like `Vec<Rint>`
-    fn deref(&self) -> &Self::Target {
-        unsafe {
-            let ptr = DATAPTR_RO(self.get()) as *const Rint;
-            std::slice::from_raw_parts(ptr, self.len())
-        }
-    }
-}
-
-impl DerefMut for Integers {
-    /// Treat Integers as if it is a mutable slice, like `Vec<Rint>`
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        unsafe {
-            let ptr = DATAPTR(self.get()) as *mut Rint;
-            std::slice::from_raw_parts_mut(ptr, self.len())
-        }
-    }
-}
-
-impl std::fmt::Debug for Integers {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.len() == 1 {
-            write!(f, "{:?}", self.elt(0))
-        } else {
-            f.debug_list().entries(self.iter()).finish()
-        }
-    }
-}
-
-impl TryFrom<Vec<i32>> for Integers {
-    type Error = Error;
-
-    fn try_from(value: Vec<i32>) -> std::result::Result<Self, Self::Error> {
-        Ok(Self {
-            robj: <Robj>::try_from(value)?,
-        })
     }
 }

--- a/extendr-api/src/wrapper/logicals.rs
+++ b/extendr-api/src/wrapper/logicals.rs
@@ -156,26 +156,6 @@ mod tests {
         }
     }
 
-    // #[test]
-    // fn test_vec_i32_logicals_conversion() {
-    //     test! {
-    //         // Only valid i32 are 0, 1 and i32:MIN.
-    //         let minus: Result<Logicals> = vec![-1].try_into();
-    //         dbg!(&minus);
-    //         // // assert!(minus.is_err());
-    //         let minus: Result<Logicals> = vec![-1, -24].try_into();
-    //         dbg!(&minus);
-    //         assert!(minus.is_err());
-    //         let without_na_vec = vec![0, 1, 1, 1, 0];
-    //         let without_na: Logicals = without_na_vec.clone().try_into().unwrap();
-    //         assert_eq!(without_na.robj.as_integer_slice().unwrap(), &without_na_vec);
-    //         let with_na_vec = vec![0, 1, 1, 1, i32::MIN, i32::MIN];
-    //         let with_na: Logicals = with_na_vec.clone().try_into().unwrap();
-    //         assert!(with_na[4].is_na());
-    //         assert!(with_na[5].is_na());
-    //     }
-    // }
-
     #[test]
     fn test_vec_bool_logicals_conversion() {
         test! {

--- a/extendr-api/src/wrapper/logicals.rs
+++ b/extendr-api/src/wrapper/logicals.rs
@@ -92,20 +92,6 @@ impl TryFrom<Vec<bool>> for Logicals {
     }
 }
 
-// region: TODO after test `test_vec_i32_logicals_conversion` is resolved
-
-// impl TryFrom<Vec<i32>> for Logicals {
-//     type Error = Error;
-
-//     fn try_from(value: Vec<i32>) -> std::result::Result<Self, Self::Error> {
-//         Ok(Self {
-//             robj: <Robj>::try_from(value)?,
-//         })
-//     }
-// }
-
-// endregion
-
 #[cfg(test)]
 mod tests {
     use crate::prelude::*;

--- a/extendr-api/src/wrapper/logicals.rs
+++ b/extendr-api/src/wrapper/logicals.rs
@@ -146,3 +146,23 @@ impl std::fmt::Debug for Logicals {
         }
     }
 }
+
+impl TryFrom<Vec<i32>> for Logicals {
+    type Error = Error;
+
+    fn try_from(value: Vec<i32>) -> std::result::Result<Self, Self::Error> {
+        Ok(Self {
+            robj: <Robj>::try_from(value)?,
+        })
+    }
+}
+
+impl TryFrom<Vec<bool>> for Logicals {
+    type Error = Error;
+
+    fn try_from(value: Vec<bool>) -> std::result::Result<Self, Self::Error> {
+        Ok(Self {
+            robj: <Robj>::try_from(value)?,
+        })
+    }
+}

--- a/extendr-api/src/wrapper/logicals.rs
+++ b/extendr-api/src/wrapper/logicals.rs
@@ -92,7 +92,6 @@ impl TryFrom<Vec<bool>> for Logicals {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use crate::prelude::*;

--- a/extendr-api/src/wrapper/matrix.rs
+++ b/extendr-api/src/wrapper/matrix.rs
@@ -361,41 +361,60 @@ impl<T, D> Deref for RArray<T, D> {
     }
 }
 
-#[test]
-fn matrix_ops() {
-    test! {
-        let vector = RColumn::new_column(3, |r| [1., 2., 3.][r]);
-        let robj = r!(vector);
-        assert_eq!(robj.is_vector(), true);
-        assert_eq!(robj.nrows(), 3);
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-        let vector2 : RColumn<f64> = robj.as_column().ok_or("expected array")?;
-        assert_eq!(vector2.data().len(), 3);
-        assert_eq!(vector2.nrows(), 3);
+    #[test]
+    fn matrix_ops() {
+        test! {
+            let vector = RColumn::new_column(3, |r| [1., 2., 3.][r]);
+            let robj = r!(vector);
+            assert_eq!(robj.is_vector(), true);
+            assert_eq!(robj.nrows(), 3);
 
-        let matrix = RMatrix::new_matrix(3, 2, |r, c| [
-            [1., 2., 3.],
-            [4., 5., 6.]][c][r]);
-        let robj = r!(matrix);
-        assert_eq!(robj.is_matrix(), true);
-        assert_eq!(robj.nrows(), 3);
-        assert_eq!(robj.ncols(), 2);
-        let matrix2 : RMatrix<f64> = robj.as_matrix().ok_or("expected matrix")?;
-        assert_eq!(matrix2.data().len(), 6);
-        assert_eq!(matrix2.nrows(), 3);
-        assert_eq!(matrix2.ncols(), 2);
+            let vector2 : RColumn<f64> = robj.as_column().ok_or("expected array")?;
+            assert_eq!(vector2.data().len(), 3);
+            assert_eq!(vector2.nrows(), 3);
 
-        let array = RMatrix3D::new_matrix3d(2, 2, 2, |r, c, m| [
-            [[1., 2.],  [3., 4.]],
-            [[5.,  6.], [7., 8.]]][m][c][r]);
-        let robj = r!(array);
-        assert_eq!(robj.is_array(), true);
-        assert_eq!(robj.nrows(), 2);
-        assert_eq!(robj.ncols(), 2);
-        let array2 : RMatrix3D<f64> = robj.as_matrix3d().ok_or("expected matrix3d")?;
-        assert_eq!(array2.data().len(), 8);
-        assert_eq!(array2.nrows(), 2);
-        assert_eq!(array2.ncols(), 2);
-        assert_eq!(array2.nsub(), 2);
+            let matrix = RMatrix::new_matrix(3, 2, |r, c| [
+                [1., 2., 3.],
+                [4., 5., 6.]][c][r]);
+            let robj = r!(matrix);
+            assert_eq!(robj.is_matrix(), true);
+            assert_eq!(robj.nrows(), 3);
+            assert_eq!(robj.ncols(), 2);
+            let matrix2 : RMatrix<f64> = robj.as_matrix().ok_or("expected matrix")?;
+            assert_eq!(matrix2.data().len(), 6);
+            assert_eq!(matrix2.nrows(), 3);
+            assert_eq!(matrix2.ncols(), 2);
+
+            let array = RMatrix3D::new_matrix3d(2, 2, 2, |r, c, m| [
+                [[1., 2.],  [3., 4.]],
+                [[5.,  6.], [7., 8.]]][m][c][r]);
+            let robj = r!(array);
+            assert_eq!(robj.is_array(), true);
+            assert_eq!(robj.nrows(), 2);
+            assert_eq!(robj.ncols(), 2);
+            let array2 : RMatrix3D<f64> = robj.as_matrix3d().ok_or("expected matrix3d")?;
+            assert_eq!(array2.data().len(), 8);
+            assert_eq!(array2.nrows(), 2);
+            assert_eq!(array2.ncols(), 2);
+            assert_eq!(array2.nsub(), 2);
+        }
+    }
+
+    #[test]
+    fn test_from_vec_doubles_to_matrix() {
+        let res: Vec<Doubles> = vec![
+            vec![17.0, 23.0, 4.0, 10.0, 11.0].try_into().unwrap(),
+            vec![24.0, 5.0, 6.0, 12.0, 18.0].try_into().unwrap(),
+            vec![1.0, 7.0, 13.0, 19.0, 25.0].try_into().unwrap(),
+            vec![8.0, 14.0, 20.0, 21.0, 2.0].try_into().unwrap(),
+            vec![15.0, 16.0, 22.0, 3.0, 9.0].try_into().unwrap(),
+        ];
+        let (n_x, n_y) = (5, 5);
+
+        RMatrix::new_matrix(n_x, n_y, |r, c| res[r][c]);
     }
 }

--- a/extendr-api/src/wrapper/matrix.rs
+++ b/extendr-api/src/wrapper/matrix.rs
@@ -406,6 +406,10 @@ mod tests {
 
     #[test]
     fn test_from_vec_doubles_to_matrix() {
+        test! {
+            // R: pracma::magic(5) -> x
+            //    x[1:5**2]
+            // Thus `res` is a list of col-vectors.
         let res: Vec<Doubles> = vec![
             vec![17.0, 23.0, 4.0, 10.0, 11.0].try_into().unwrap(),
             vec![24.0, 5.0, 6.0, 12.0, 18.0].try_into().unwrap(),
@@ -414,7 +418,9 @@ mod tests {
             vec![15.0, 16.0, 22.0, 3.0, 9.0].try_into().unwrap(),
         ];
         let (n_x, n_y) = (5, 5);
+            let matrix = RMatrix::new_matrix(n_x, n_y, |r, c| res[c][r]);
 
-        RMatrix::new_matrix(n_x, n_y, |r, c| res[r][c]);
+            }
+
     }
 }

--- a/extendr-api/src/wrapper/matrix.rs
+++ b/extendr-api/src/wrapper/matrix.rs
@@ -407,9 +407,9 @@ mod tests {
     #[test]
     fn test_from_vec_doubles_to_matrix() {
         test! {
-            // R: pracma::magic(5) -> x
-            //    x[1:5**2]
-            // Thus `res` is a list of col-vectors.
+        // R: pracma::magic(5) -> x
+        //    x[1:5**2]
+        // Thus `res` is a list of col-vectors.
         let res: Vec<Doubles> = vec![
             vec![17.0, 23.0, 4.0, 10.0, 11.0].try_into().unwrap(),
             vec![24.0, 5.0, 6.0, 12.0, 18.0].try_into().unwrap(),
@@ -418,9 +418,8 @@ mod tests {
             vec![15.0, 16.0, 22.0, 3.0, 9.0].try_into().unwrap(),
         ];
         let (n_x, n_y) = (5, 5);
-            let matrix = RMatrix::new_matrix(n_x, n_y, |r, c| res[c][r]);
+        let matrix = RMatrix::new_matrix(n_x, n_y, |r, c| res[c][r]);
 
-            }
-
+        }
     }
 }


### PR DESCRIPTION
Fixes #592

This PR does two things:

- Makes `Rints`, `&Rints`, `Rfloat`, and `&Rfloat`  as `ToVectorValue`, as these are wrapped Rust types
that are safe to assume would translate to R. Moreover `Rbool` and `&Rbool` were already `ToVectorValue`,
so it could have been a slight oversight

- We are increasingly promoting `Integers`, `Logicals`, `Doubles`, and `Complexes` as the better way
to extract vectors from R. Thus to make these more easier to work with, I've added `TryFrom<Vec<RustNative>>` for all of them. This was previously accomplished with `from_values`,
but I think these are intuitive interface for these as well.
