### PR TITLE
Add `[T; N]` for `Robj`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - [**either**] `TryFrom<&Robj> for Either<T, R>` and `From<Either<T, R>> for Robj` if `T` and `R` are themselves implement these traits. This unblocks scenarios like accepting any numeric vector from R via `Either<Integers, Doubles>` without extra memory allocation [[#480]](https://github.com/extendr/extendr/pull/480)
 - `PartialOrd` trait implementation for `Rfloat`, `Rint` and `Rbool`. `Rfloat` and `Rint` gained `min()` and `max()` methods [[#573]](https://github.com/extendr/extendr/pull/573)
+- Added `[T; N]` conversions to `Robj` [[#594]](https://github.com/extendr/extendr/pull/594/)
 
 ### Fixed
 

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -663,23 +663,6 @@ where
     }
 }
 
-// We would love to do a blanket IntoIterator impl.
-// But the matching rules would clash with the above.
-macro_rules! impl_from_iter {
-    ($t: ty) => {
-        impl<'a, T> From<$t> for Robj
-        where
-            Self: 'a,
-            T: Clone + 'a,
-            T: ToVectorValue,
-        {
-            fn from(val: $t) -> Self {
-                val.iter().cloned().collect_robj()
-            }
-        }
-    };
-}
-
 macro_rules! impl_from_into_iter {
     ($t: ty) => {
         impl<'a, T> From<$t> for Robj
@@ -751,8 +734,19 @@ where
     }
 }
 
-impl_from_iter! {Vec<T>}
-impl_from_iter! {&Vec<T>}
+impl<T: ToVectorValue + Clone> From<&Vec<T>> for Robj {
+    fn from(value: &Vec<T>) -> Self {
+        let len = value.len();
+        fixed_size_collect(value.iter().cloned(), len)
+    }
+}
+
+impl<T: ToVectorValue> From<Vec<T>> for Robj {
+    fn from(value: Vec<T>) -> Self {
+        let len = value.len();
+        fixed_size_collect(value.into_iter(), len)
+    }
+}
 
 impl_from_into_iter! {&'a [T]}
 

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -721,26 +721,16 @@ macro_rules! impl_from_as_iterator {
 //     }
 // } //
 
-// Template constants are still unstable in rust.
-impl_from_iter! {[T; 1]}
-impl_from_iter! {[T; 2]}
-impl_from_iter! {[T; 3]}
-impl_from_iter! {[T; 4]}
-impl_from_iter! {[T; 5]}
-impl_from_iter! {[T; 6]}
-impl_from_iter! {[T; 7]}
-impl_from_iter! {[T; 8]}
-impl_from_iter! {[T; 9]}
-impl_from_iter! {[T; 10]}
-impl_from_iter! {[T; 11]}
-impl_from_iter! {[T; 12]}
-impl_from_iter! {[T; 13]}
-impl_from_iter! {[T; 14]}
-impl_from_iter! {[T; 15]}
-impl_from_iter! {[T; 16]}
-impl_from_iter! {[T; 17]}
-impl_from_iter! {[T; 18]}
-impl_from_iter! {[T; 19]}
+impl<'a, T, const N: usize> From<[T; N]> for Robj
+where
+    Self: 'a,
+    T: ToVectorValue,
+{
+    fn from(val: [T; N]) -> Self {
+        fixed_size_collect(val.into_iter(), N)
+    }
+}
+
 impl_from_iter! {Vec<T>}
 impl_from_iter! {&Vec<T>}
 

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -731,6 +731,26 @@ where
     }
 }
 
+impl<'a, T, const N: usize> From<&'a [T; N]> for Robj
+where
+    Self: 'a,
+    &'a T: ToVectorValue + 'a,
+{
+    fn from(val: &'a [T; N]) -> Self {
+        fixed_size_collect(val.into_iter(), N)
+    }
+}
+
+impl<'a, T, const N: usize> From<&'a mut [T; N]> for Robj
+where
+    Self: 'a,
+    &'a mut T: ToVectorValue + 'a,
+{
+    fn from(val: &'a mut [T; N]) -> Self {
+        fixed_size_collect(val.into_iter(), N)
+    }
+}
+
 impl_from_iter! {Vec<T>}
 impl_from_iter! {&Vec<T>}
 

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -663,21 +663,6 @@ where
     }
 }
 
-macro_rules! impl_from_into_iter {
-    ($t: ty) => {
-        impl<'a, T> From<$t> for Robj
-        where
-            Self: 'a,
-            T: 'a,
-            &'a T: ToVectorValue,
-        {
-            fn from(val: $t) -> Self {
-                val.into_iter().collect_robj()
-            }
-        }
-    };
-}
-
 macro_rules! impl_from_as_iterator {
     ($t: ty) => {
         impl<T> From<$t> for Robj
@@ -748,7 +733,16 @@ impl<T: ToVectorValue> From<Vec<T>> for Robj {
     }
 }
 
-impl_from_into_iter! {&'a [T]}
+impl<'a, T> From<&'a [T]> for Robj
+where
+    Self: 'a,
+    T: 'a,
+    &'a T: ToVectorValue,
+{
+    fn from(val: &'a [T]) -> Self {
+        val.into_iter().collect_robj()
+    }
+}
 
 impl_from_as_iterator! {Range<T>}
 impl_from_as_iterator! {RangeInclusive<T>}


### PR DESCRIPTION
Rust added support for `[T; N]`, but we haven't taken advantage of it yet.

Previous attempts got scope creeped, thus this time we'll stick with a very small PR for now.
