### PR TITLE
Subset of `cargo clippy` fixes

### DIFF
--- a/extendr-api/src/error.rs
+++ b/extendr-api/src/error.rs
@@ -10,7 +10,7 @@ use std::convert::Infallible;
 pub fn unwrap_or_throw<T>(r: std::result::Result<T, &'static str>) -> T {
     match r {
         Err(e) => {
-            throw_r_error(e.to_string());
+            throw_r_error(e);
         }
         Ok(v) => v,
     }

--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -621,7 +621,7 @@ pub fn sxp_to_rtype(sxptype: i32) -> Rtype {
     }
 }
 
-const PRINTF_NO_FMT_CSTRING: &'static [i8] = &[37, 115, 0]; // same as "%s\0"
+const PRINTF_NO_FMT_CSTRING: &[i8] = &[37, 115, 0]; // same as "%s\0"
 #[doc(hidden)]
 pub fn print_r_output<T: Into<Vec<u8>>>(s: T) {
     let cs = CString::new(s).expect("NulError");
@@ -960,8 +960,8 @@ mod tests {
     fn test_na_str() {
         assert_ne!(<&str>::na().as_ptr(), "NA".as_ptr());
         assert_eq!(<&str>::na(), "NA");
-        assert_eq!("NA".is_na(), false);
-        assert_eq!(<&str>::na().is_na(), true);
+        assert!(!"NA".is_na());
+        assert!(<&str>::na().is_na());
     }
 
     #[test]

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -179,7 +179,7 @@ impl From<Error> for Robj {
 }
 impl From<Error> for String {
     fn from(res: Error) -> Self {
-        res.to_string().into()
+        res.to_string()
     }
 }
 
@@ -381,7 +381,7 @@ impl ToVectorValue for u8 {
     }
 
     fn to_raw(&self) -> u8 {
-        *self as u8
+        *self
     }
 }
 
@@ -391,7 +391,7 @@ impl ToVectorValue for &u8 {
     }
 
     fn to_raw(&self) -> u8 {
-        **self as u8
+        **self
     }
 }
 
@@ -808,7 +808,7 @@ mod test {
             let rmat = (1i32..=16).collect_rarray([3, 3]);
             assert!(rmat.is_err());
             let msg = rmat.unwrap_err().to_string();
-            assert!(msg.contains("9"));
+            assert!(msg.contains('9'));
             assert!(msg.contains("dimension"));
         }
     }

--- a/extendr-api/src/thread_safety.rs
+++ b/extendr-api/src/thread_safety.rs
@@ -130,8 +130,8 @@ where
         let x = false;
         let fun = std::mem::transmute(fun_ptr);
         let cleanfun = std::mem::transmute(clean_ptr);
-        let data = std::mem::transmute(&f);
-        let cleandata = std::mem::transmute(&x);
+        let data = &f as *const _ as _;
+        let cleandata = &x as *const _ as _;
         let cont = R_MakeUnwindCont();
         Rf_protect(cont);
 

--- a/extendr-api/src/wrapper/environment.rs
+++ b/extendr-api/src/wrapper/environment.rs
@@ -93,7 +93,7 @@ impl Environment {
     pub fn envflags(&self) -> i32 {
         unsafe {
             let sexp = self.robj.get();
-            ENVFLAGS(sexp) as i32
+            ENVFLAGS(sexp)
         }
     }
 

--- a/extendr-api/src/wrapper/pairlist.rs
+++ b/extendr-api/src/wrapper/pairlist.rs
@@ -49,7 +49,7 @@ impl Pairlist {
             let res = Pairlist {
                 robj: Robj::from_sexp(res),
             };
-            Rf_unprotect(num_protects as i32);
+            Rf_unprotect(num_protects);
             res
         })
     }

--- a/extendr-api/tests/altrep_tests.rs
+++ b/extendr-api/tests/altrep_tests.rs
@@ -67,7 +67,7 @@ fn test_altreal() {
 
         impl AltrepImpl for MyCompactRealRange {
             fn length(&self) -> usize {
-                self.len as usize
+                self.len
             }
         }
 
@@ -121,7 +121,7 @@ fn test_altlogical() {
 
         impl AltrepImpl for IsEven {
             fn length(&self) -> usize {
-                self.len as usize
+                self.len
             }
         }
 
@@ -186,7 +186,7 @@ fn test_altcomplex() {
 
         impl AltrepImpl for MyCompactComplexRange {
             fn length(&self) -> usize {
-                self.len as usize
+                self.len
             }
         }
 
@@ -216,7 +216,7 @@ fn test_altstring() {
 
         impl AltrepImpl for StringInts {
             fn length(&self) -> usize {
-                self.len as usize
+                self.len
             }
         }
 

--- a/extendr-api/tests/from_iterator_tests.rs
+++ b/extendr-api/tests/from_iterator_tests.rs
@@ -11,7 +11,6 @@ fn protect_lim2(n: i32) -> List {
     let n = n as usize;
 
     (0..n)
-        .into_iter()
         .map(|xi| ExternalPtr::new(PlzBreak(xi as i32)))
         .collect::<List>()
 }
@@ -20,7 +19,6 @@ fn protect_lim2(n: i32) -> List {
 fn prot_strs(n: i32) -> Strings {
     let n = n as usize;
     (0..n)
-        .into_iter()
         .map(|_| Rstr::from_string("val"))
         .collect::<Strings>()
 }

--- a/extendr-api/tests/na_tests.rs
+++ b/extendr-api/tests/na_tests.rs
@@ -12,8 +12,8 @@ fn test_float_na_is_na() {
 fn test_float_from_bits_is_na() {
     test! {
         let na_bits = 0x7ff00000u64 << 32 | 1954;
-        let na_r = Rfloat::new(unsafe {std::mem::transmute(na_bits)});
-        let na_f64 : f64 = unsafe {std::mem::transmute(na_bits)};
+        let na_r = Rfloat::new(f64::from_bits(na_bits));
+        let na_f64 = f64::from_bits(na_bits);
         assert!(na_r.is_na());
         assert!(na_f64.is_na());
     }

--- a/extendr-api/tests/scalar_tests.rs
+++ b/extendr-api/tests/scalar_tests.rs
@@ -11,10 +11,10 @@ fn test_rint() {
     assert_eq!(-a, Rint::from(-20));
     assert_eq!(!a, Rint::from(-21));
 
-    assert_eq!(&a + b, Rint::from(30));
-    assert_eq!(&a - b, Rint::from(10));
-    assert_eq!(&a * b, Rint::from(200));
-    assert_eq!(&a / b, Rint::from(2));
+    assert_eq!(a + b, Rint::from(30));
+    assert_eq!(a - b, Rint::from(10));
+    assert_eq!(a * b, Rint::from(200));
+    assert_eq!(a / b, Rint::from(2));
     assert_eq!(-&a, Rint::from(-20));
     assert_eq!(!&a, Rint::from(-21));
 
@@ -167,10 +167,10 @@ fn test_rfloat() {
         assert_eq!(a / b, Rfloat::from(2.));
         assert_eq!(-a, Rfloat::from(-20.));
 
-        assert_eq!(&a + b, Rfloat::from(30.));
-        assert_eq!(&a - b, Rfloat::from(10.));
-        assert_eq!(&a * b, Rfloat::from(200.));
-        assert_eq!(&a / b, Rfloat::from(2.));
+        assert_eq!(a + b, Rfloat::from(30.));
+        assert_eq!(a - b, Rfloat::from(10.));
+        assert_eq!(a * b, Rfloat::from(200.));
+        assert_eq!(a / b, Rfloat::from(2.));
         assert_eq!(-&a, Rfloat::from(-20.));
 
         assert!(Rfloat::na().is_na());

--- a/extendr-macros/src/wrappers.rs
+++ b/extendr-macros/src/wrappers.rs
@@ -246,7 +246,7 @@ pub fn translate_formal(input: &FnArg, self_ty: Option<&syn::Type>) -> FnArg {
         // function argument.
         FnArg::Typed(ref pattype) => {
             let pat = &pattype.pat.as_ref();
-            return parse_quote! { #pat : extendr_api::SEXP };
+            parse_quote! { #pat : extendr_api::SEXP }
         }
         // &self
         FnArg::Receiver(ref reciever) => {
@@ -256,7 +256,7 @@ pub fn translate_formal(input: &FnArg, self_ty: Option<&syn::Type>) -> FnArg {
             if self_ty.is_none() {
                 panic!("found &self in non-impl function - have you missed the #[extendr] before the impl?");
             }
-            return parse_quote! { _self : extendr_api::SEXP };
+            parse_quote! { _self : extendr_api::SEXP }
         }
     }
 }
@@ -275,13 +275,13 @@ fn translate_meta_arg(input: &mut FnArg, self_ty: Option<&syn::Type>) -> Expr {
             } else {
                 quote!(None)
             };
-            return parse_quote! {
+            parse_quote! {
                 extendr_api::metadata::Arg {
                     name: #name_string,
                     arg_type: #type_string,
                     default: #default
                 }
-            };
+            }
         }
         // &self
         FnArg::Receiver(ref reciever) => {
@@ -292,13 +292,13 @@ fn translate_meta_arg(input: &mut FnArg, self_ty: Option<&syn::Type>) -> Expr {
                 panic!("found &self in non-impl function - have you missed the #[extendr] before the impl?");
             }
             let type_string = type_name(self_ty.unwrap());
-            return parse_quote! {
+            parse_quote! {
                 extendr_api::metadata::Arg {
                     name: "self",
                     arg_type: #type_string,
                     default: None
                 }
-            };
+            }
         }
     }
 }


### PR DESCRIPTION
Again, with a new version of Rust, comes many new clippy/rustc lints.
I've gone through some of them, and I propose we merge these.

There are more, meaning `cargo clippy` won't be successful with this PR, but
these make sense in my opinion.
