### PR TITLE
[internal] Function-version of `test!` 

### DIFF
--- a/extendr-engine/src/lib.rs
+++ b/extendr-engine/src/lib.rs
@@ -63,7 +63,7 @@ pub fn end_r() {
 }
 
 /// Ensures that an embedded R instance is present when evaluating
-/// `f`. 
+/// `f`.
 pub fn with_r(f: impl FnOnce()) {
     start_r();
     f();

--- a/extendr-engine/src/lib.rs
+++ b/extendr-engine/src/lib.rs
@@ -62,6 +62,8 @@ pub fn end_r() {
     }
 }
 
+/// Ensures that an embedded R instance is present when evaluating
+/// `f`. 
 pub fn with_r(f: impl FnOnce()) {
     start_r();
     f();

--- a/extendr-engine/src/lib.rs
+++ b/extendr-engine/src/lib.rs
@@ -62,6 +62,13 @@ pub fn end_r() {
     }
 }
 
+pub fn with_r(f: impl FnOnce()) {
+    start_r();
+    f();
+    // For compatibility with `test!` in `extendr-api/src/rmacros.rs`, there
+    // is no `end_r()` call here.
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Adding `with_r` a function-version of `test!`. 

- This function doesn't allow the use of `?` inside of tests like `test!` does;
- It's not a macro, thus rust-analyzer, `cargo fmt`, and other tools behave nicely with it

Please see #598 for tests where `with_r` has replaced many `test!` cases. 

There are many other issues and many things to dwell on, but for now, let's take a look at this.