### PR TITLE
[internal] Shutdown R after tests

### DIFF
--- a/extendr-engine/Cargo.toml
+++ b/extendr-engine/Cargo.toml
@@ -16,6 +16,7 @@ repository = "https://github.com/extendr/extendr"
 
 [dependencies]
 libR-sys = "0.6.0"
+ctor = "0.2.4"
 
 [features]
 default = []

--- a/extendr-engine/src/lib.rs
+++ b/extendr-engine/src/lib.rs
@@ -53,7 +53,7 @@ pub fn start_r() {
 
 /// Close down the R interpreter. Note you won't be able to
 /// Restart it, so use with care or not at all.
-pub fn end_r() {
+fn end_r() {
     unsafe {
         //Rf_endEmbeddedR(0);
         R_RunExitFinalizers();

--- a/extendr-engine/src/lib.rs
+++ b/extendr-engine/src/lib.rs
@@ -71,6 +71,13 @@ pub fn with_r(f: impl FnOnce()) {
     // is no `end_r()` call here.
 }
 
+#[ctor::dtor]
+fn shutdown_r() {
+    if START_R.is_completed() {
+        end_r();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
`extendr-engine` never enacts the `end_r` function. This means that we never see the consequences of the finalizers for `ExternalPtr`, or for `ALTREP`. 

Also, if our tests make temporary directories/files through R those are never cleaned properly.

The only lean way to do this I found is with `ctor`, a crate that provides a way to add "init function" for a library; In this case, we use the "shutdown" for a library, i.e. `dtor`.

This is a draft for now, as it may uncover unforseen bugs. 