### PR TITLE
`ExternalPtr` clean-up type-name

### DIFF
--- a/extendr-api/src/wrapper/altrep.rs
+++ b/extendr-api/src/wrapper/altrep.rs
@@ -496,9 +496,9 @@ impl Altrep {
             }
 
             let ptr: *mut StateType = Box::into_raw(Box::new(state));
-            let tag = r!(());
-            let prot = r!(());
-            let state = R_MakeExternalPtr(ptr as *mut c_void, tag.get(), prot.get());
+            let tag = R_NilValue;
+            let prot = R_NilValue;
+            let state = R_MakeExternalPtr(ptr as *mut c_void, tag, prot);
             R_RegisterCFinalizer(state, Some(finalizer::<StateType>));
 
             let class_ptr = R_altrep_class_t { ptr: class.get() };

--- a/extendr-api/src/wrapper/externalptr.rs
+++ b/extendr-api/src/wrapper/externalptr.rs
@@ -93,10 +93,12 @@ impl<T: Any + Debug> ExternalPtr<T> {
             extern "C" fn finalizer<T>(x: SEXP) {
                 unsafe {
                     let ptr = R_ExternalPtrAddr(x) as *mut T;
+                    let externalptr_box = Box::from_raw(ptr);
+                    R_SetExternalPtrTag(x, R_NilValue);
 
                     // Convert the pointer to a box and drop it implictly.
                     // This frees up the memory we have used and calls the "T::drop" method if there is one.
-                    drop(Box::from_raw(ptr));
+                    drop(externalptr_box)
                 }
             }
 

--- a/extendr-api/src/wrapper/externalptr.rs
+++ b/extendr-api/src/wrapper/externalptr.rs
@@ -93,12 +93,13 @@ impl<T: Any + Debug> ExternalPtr<T> {
             extern "C" fn finalizer<T>(x: SEXP) {
                 unsafe {
                     let ptr = R_ExternalPtrAddr(x) as *mut T;
-                    let externalptr_box = Box::from_raw(ptr);
+
+                    // Free the `tag`, which is the type-name
                     R_SetExternalPtrTag(x, R_NilValue);
 
                     // Convert the pointer to a box and drop it implictly.
                     // This frees up the memory we have used and calls the "T::drop" method if there is one.
-                    drop(externalptr_box)
+                    drop(Box::from_raw(ptr));
                 }
             }
 

--- a/extendr-api/src/wrapper/externalptr.rs
+++ b/extendr-api/src/wrapper/externalptr.rs
@@ -100,6 +100,9 @@ impl<T: Any + Debug> ExternalPtr<T> {
                     // Convert the pointer to a box and drop it implictly.
                     // This frees up the memory we have used and calls the "T::drop" method if there is one.
                     drop(Box::from_raw(ptr));
+
+                    // Now set the pointer in ExternalPTR to C `NULL`
+                    R_ClearExternalPtr(x);
                 }
             }
 


### PR DESCRIPTION
Great care is taken to deallocate the Rust object from `ExternalPtr`, but what about `tag` and `prot`?

- Using `r(())` we get `R_NilValue` that is protected by `ownership`-module.

But this is convoluted.

- `ExternalPtr` protects values,
`tag` and `prot`, so they need to
be "released" to unprotected.

