### PR TITLE
Remove stringly-typed ExternalPtr

### DIFF
--- a/extendr-api/src/wrapper/externalptr.rs
+++ b/extendr-api/src/wrapper/externalptr.rs
@@ -74,6 +74,18 @@ impl<T: Debug + 'static> DerefMut for ExternalPtr<T> {
     }
 }
 
+struct ExternalType {
+    inner: Box<dyn Any>,
+}
+
+impl ExternalType {
+    fn new<T: 'static>(value: T) -> Self {
+        Self {
+            inner: Box::new(value),
+        }
+    }
+}
+
 impl<T: Any + Debug> ExternalPtr<T> {
     /// Construct an external pointer object from any type T.
     /// In this case, the R object owns the data and will drop the Rust object
@@ -82,24 +94,32 @@ impl<T: Any + Debug> ExternalPtr<T> {
     /// An ExternalPtr behaves like a Box except that the information is
     /// tracked by a R object.
     pub fn new(val: T) -> Self {
+        use std::ffi::c_void;
         unsafe {
             // This allocates some memory for our object and moves the object into it.
-            let boxed = Box::new(val);
+            let v = ExternalType::new(val);
 
             // This constructs an external pointer to our boxed data.
             // into_raw() converts the box to a malloced pointer.
-            let robj = Robj::make_external_ptr(Box::into_raw(boxed), r!(()));
+            let v = Box::new(v);
+            let ptr = Box::into_raw(v);
+            let external_ptr = R_MakeExternalPtr(ptr as *mut c_void, R_NilValue, R_NilValue);
 
-            extern "C" fn finalizer<T>(x: SEXP) {
+            // ensure that this is protected
+            let robj = Robj::from_sexp(external_ptr);
+
+            extern "C" fn finalizer<T: 'static>(x: SEXP) {
                 unsafe {
-                    let ptr = R_ExternalPtrAddr(x) as *mut T;
+                    let ptr = R_ExternalPtrAddr(x);
+                    let boxed = Box::from_raw(ptr as *mut ExternalType);
+                    // let boxed_ref = boxed.inner.downcast_ref::<T>().unwrap();
 
                     // Free the `tag`, which is the type-name
                     R_SetExternalPtrTag(x, R_NilValue);
 
                     // Convert the pointer to a box and drop it implictly.
                     // This frees up the memory we have used and calls the "T::drop" method if there is one.
-                    drop(Box::from_raw(ptr));
+                    drop(boxed);
 
                     // Now set the pointer in ExternalPTR to C `NULL`
                     R_ClearExternalPtr(x);
@@ -131,10 +151,10 @@ impl<T: Any + Debug> ExternalPtr<T> {
 
     /// Get the "address" field of an external pointer.
     /// Normally, we will use Deref to do this.
-    pub fn addr<'a>(&self) -> &'a T {
+    pub fn addr(&self) -> &T {
         unsafe {
-            let ptr = R_ExternalPtrAddr(self.robj.get()) as *const T;
-            &*ptr as &'a T
+            let ptr = R_ExternalPtrAddr(self.robj.get()) as *const Box<dyn Any>;
+            (*ptr).downcast_ref().unwrap()
         }
     }
 
@@ -142,8 +162,8 @@ impl<T: Any + Debug> ExternalPtr<T> {
     /// Normally, we will use DerefMut to do this.
     pub fn addr_mut(&mut self) -> &mut T {
         unsafe {
-            let ptr = R_ExternalPtrAddr(self.robj.get()) as *mut T;
-            &mut *ptr as &mut T
+            let ptr = R_ExternalPtrAddr(self.robj.get()) as *mut Box<dyn Any>;
+            (*ptr).downcast_mut().unwrap()
         }
     }
 }
@@ -152,18 +172,23 @@ impl<T: Any + Debug> TryFrom<&Robj> for ExternalPtr<T> {
     type Error = Error;
 
     fn try_from(robj: &Robj) -> Result<Self> {
-        let clone = robj.clone();
-        if clone.rtype() != Rtype::ExternalPtr {
-            Err(Error::ExpectedExternalPtr(clone))
-        } else if clone.check_external_ptr_type::<T>() {
+        if robj.rtype() != Rtype::ExternalPtr {
+            return Err(Error::ExpectedExternalPtr(robj.clone()));
+        }
+        let is_type = unsafe {
+            let external_ptr = R_ExternalPtrAddr(robj.get()) as *mut ExternalType;
+            let is_type = (*external_ptr).inner.downcast_ref::<T>().is_some();
+            is_type
+        };
+        if is_type {
             let res = ExternalPtr::<T> {
-                robj: clone,
+                robj: robj.clone(),
                 marker: std::marker::PhantomData,
             };
             Ok(res)
         } else {
             Err(Error::ExpectedExternalPtrType(
-                clone,
+                robj.clone(),
                 std::any::type_name::<T>().into(),
             ))
         }


### PR DESCRIPTION
Currently, `tag` in `ExternalPtr` is set to a string containing `std::any::type_name`.
This means, that every time an `Robj` is to be interpreted as an `ExternalPtr`, a
string comparison occurs.

R recommends that `tag` is set to an `install("Class name")`, which is a symbol, which is a pointer, and thus pointers are faster to compare than strings.

Proposed is a strategy where what is stored in `ExternalPtr` isn't an owning pointer `T*`, but rather something ressembling `Box<dyn Any>`, which contains type information.
This type information is extracted through `downcast`. 

This is a draft, and I'd like your collaboration in making this better, as I'm struggling to figure out the type-stuff.
