### PR TITLE
ExternalPtr are no longer stringly typed

### DIFF
--- a/extendr-api/src/wrapper/altrep.rs
+++ b/extendr-api/src/wrapper/altrep.rs
@@ -496,9 +496,9 @@ impl Altrep {
             }
 
             let ptr: *mut StateType = Box::into_raw(Box::new(state));
-            let tag = r!(());
-            let prot = r!(());
-            let state = R_MakeExternalPtr(ptr as *mut c_void, tag.get(), prot.get());
+            let tag = R_NilValue;
+            let prot = R_NilValue;
+            let state = R_MakeExternalPtr(ptr as *mut c_void, tag, prot);
             R_RegisterCFinalizer(state, Some(finalizer::<StateType>));
 
             let class_ptr = R_altrep_class_t { ptr: class.get() };

--- a/extendr-api/src/wrapper/externalptr.rs
+++ b/extendr-api/src/wrapper/externalptr.rs
@@ -135,7 +135,8 @@ impl<T: Any + Debug> ExternalPtr<T> {
     pub fn addr(&self) -> &T {
         unsafe {
             let ptr = R_ExternalPtrAddr(self.robj.get()) as *const Box<dyn Any>;
-            ptr.as_ref().unwrap().downcast_ref().unwrap()
+            let ptr_ref: &Box<dyn Any> = ptr.as_ref().unwrap();
+            ptr_ref.downcast_ref().unwrap()
         }
     }
 
@@ -144,7 +145,8 @@ impl<T: Any + Debug> ExternalPtr<T> {
     pub fn addr_mut(&mut self) -> &mut T {
         unsafe {
             let ptr = R_ExternalPtrAddr(self.robj.get()) as *mut Box<dyn Any>;
-            ptr.as_mut().unwrap().downcast_mut().unwrap()
+            let ref_mut_ptr: &mut Box<dyn Any> = ptr.as_mut().unwrap();
+            ref_mut_ptr.downcast_mut().unwrap()
         }
     }
 }
@@ -158,8 +160,8 @@ impl<T: Any + Debug> TryFrom<&Robj> for ExternalPtr<T> {
         }
         let is_type = unsafe {
             let external_ptr = R_ExternalPtrAddr(robj.get()) as *mut Box<dyn Any>;
-            let is_type = external_ptr.as_ref().unwrap().downcast_ref::<T>().is_some();
-            is_type
+            let is_type: &Box<dyn Any> = external_ptr.as_ref().unwrap();
+            is_type.downcast_ref::<T>().is_some()
         };
         if is_type {
             let res = ExternalPtr::<T> {

--- a/extendr-api/src/wrapper/externalptr.rs
+++ b/extendr-api/src/wrapper/externalptr.rs
@@ -74,6 +74,18 @@ impl<T: Debug + 'static> DerefMut for ExternalPtr<T> {
     }
 }
 
+struct ExternalType {
+    inner: Box<dyn Any>,
+}
+
+impl ExternalType {
+    fn new<T: 'static>(value: T) -> Self {
+        Self {
+            inner: Box::new(value),
+        }
+    }
+}
+
 impl<T: Any + Debug> ExternalPtr<T> {
     /// Construct an external pointer object from any type T.
     /// In this case, the R object owns the data and will drop the Rust object
@@ -82,24 +94,32 @@ impl<T: Any + Debug> ExternalPtr<T> {
     /// An ExternalPtr behaves like a Box except that the information is
     /// tracked by a R object.
     pub fn new(val: T) -> Self {
+        use std::ffi::c_void;
         unsafe {
             // This allocates some memory for our object and moves the object into it.
-            let boxed = Box::new(val);
+            let v = ExternalType::new(val);
 
             // This constructs an external pointer to our boxed data.
             // into_raw() converts the box to a malloced pointer.
-            let robj = Robj::make_external_ptr(Box::into_raw(boxed), r!(()));
+            let v = Box::new(v);
+            let ptr = Box::into_raw(v);
+            let external_ptr = R_MakeExternalPtr(ptr as *mut c_void, R_NilValue, R_NilValue);
 
-            extern "C" fn finalizer<T>(x: SEXP) {
+            // ensure that this is protected
+            let robj = Robj::from_sexp(external_ptr);
+
+            extern "C" fn finalizer<T: 'static>(x: SEXP) {
                 unsafe {
-                    let ptr = R_ExternalPtrAddr(x) as *mut T;
+                    let ptr = R_ExternalPtrAddr(x);
+                    let boxed = Box::from_raw(ptr as *mut ExternalType);
+                    // let boxed_ref = boxed.inner.downcast_ref::<T>().unwrap();
 
                     // Free the `tag`, which is the type-name
                     R_SetExternalPtrTag(x, R_NilValue);
 
                     // Convert the pointer to a box and drop it implictly.
                     // This frees up the memory we have used and calls the "T::drop" method if there is one.
-                    drop(Box::from_raw(ptr));
+                    drop(boxed);
 
                     // Now set the pointer in ExternalPTR to C `NULL`
                     R_ClearExternalPtr(x);
@@ -131,10 +151,10 @@ impl<T: Any + Debug> ExternalPtr<T> {
 
     /// Get the "address" field of an external pointer.
     /// Normally, we will use Deref to do this.
-    pub fn addr<'a>(&self) -> &'a T {
+    pub fn addr(&self) -> &T {
         unsafe {
-            let ptr = R_ExternalPtrAddr(self.robj.get()) as *const T;
-            &*ptr as &'a T
+            let ptr = R_ExternalPtrAddr(self.robj.get()) as *const Box<dyn Any>;
+            (*ptr).downcast_ref().unwrap()
         }
     }
 
@@ -142,8 +162,8 @@ impl<T: Any + Debug> ExternalPtr<T> {
     /// Normally, we will use DerefMut to do this.
     pub fn addr_mut(&mut self) -> &mut T {
         unsafe {
-            let ptr = R_ExternalPtrAddr(self.robj.get()) as *mut T;
-            &mut *ptr as &mut T
+            let ptr = R_ExternalPtrAddr(self.robj.get()) as *mut Box<dyn Any>;
+            (*ptr).downcast_mut().unwrap()
         }
     }
 }
@@ -152,18 +172,23 @@ impl<T: Any + Debug> TryFrom<&Robj> for ExternalPtr<T> {
     type Error = Error;
 
     fn try_from(robj: &Robj) -> Result<Self> {
-        let clone = robj.clone();
-        if clone.rtype() != Rtype::ExternalPtr {
-            Err(Error::ExpectedExternalPtr(clone))
-        } else if clone.check_external_ptr_type::<T>() {
+        if robj.rtype() != Rtype::ExternalPtr {
+            return Err(Error::ExpectedExternalPtr(robj.clone()));
+        }
+        let is_type = unsafe {
+            let external_ptr = R_ExternalPtrAddr(robj.get()) as *mut ExternalType;
+            let is_type = (*external_ptr).inner.downcast_ref::<T>().is_some();
+            is_type
+        };
+        if is_type {
             let res = ExternalPtr::<T> {
-                robj: clone,
+                robj: robj.clone(),
                 marker: std::marker::PhantomData,
             };
             Ok(res)
         } else {
             Err(Error::ExpectedExternalPtrType(
-                clone,
+                robj.clone(),
                 std::any::type_name::<T>().into(),
             ))
         }

--- a/extendr-api/src/wrapper/externalptr.rs
+++ b/extendr-api/src/wrapper/externalptr.rs
@@ -93,10 +93,12 @@ impl<T: Any + Debug> ExternalPtr<T> {
             extern "C" fn finalizer<T>(x: SEXP) {
                 unsafe {
                     let ptr = R_ExternalPtrAddr(x) as *mut T;
+                    let externalptr_box = Box::from_raw(ptr);
+                    R_SetExternalPtrTag(x, R_NilValue);
 
                     // Convert the pointer to a box and drop it implictly.
                     // This frees up the memory we have used and calls the "T::drop" method if there is one.
-                    drop(Box::from_raw(ptr));
+                    drop(externalptr_box)
                 }
             }
 

--- a/extendr-api/src/wrapper/externalptr.rs
+++ b/extendr-api/src/wrapper/externalptr.rs
@@ -136,7 +136,8 @@ impl<T: Any + Debug> ExternalPtr<T> {
         unsafe {
             let ptr = R_ExternalPtrAddr(self.robj.get()) as *const Box<dyn Any>;
             let ptr_ref: &Box<dyn Any> = ptr.as_ref().unwrap();
-            ptr_ref.downcast_ref().unwrap()
+            let ptr_ref_downcast: &Box<T> = ptr_ref.downcast_ref().unwrap();
+            ptr_ref_downcast
         }
     }
 
@@ -146,7 +147,8 @@ impl<T: Any + Debug> ExternalPtr<T> {
         unsafe {
             let ptr = R_ExternalPtrAddr(self.robj.get()) as *mut Box<dyn Any>;
             let ref_mut_ptr: &mut Box<dyn Any> = ptr.as_mut().unwrap();
-            ref_mut_ptr.downcast_mut().unwrap()
+            let ref_mut_ptr_downcast: &mut Box<T> = ref_mut_ptr.downcast_mut().unwrap();
+            ref_mut_ptr_downcast
         }
     }
 }
@@ -161,7 +163,8 @@ impl<T: Any + Debug> TryFrom<&Robj> for ExternalPtr<T> {
         let is_type = unsafe {
             let external_ptr = R_ExternalPtrAddr(robj.get()) as *mut Box<dyn Any>;
             let is_type: &Box<dyn Any> = external_ptr.as_ref().unwrap();
-            is_type.downcast_ref::<T>().is_some()
+            let is_type: Option<&Box<T>> = is_type.downcast_ref();
+            is_type.is_some()
         };
         if is_type {
             let res = ExternalPtr::<T> {

--- a/extendr-api/src/wrapper/externalptr.rs
+++ b/extendr-api/src/wrapper/externalptr.rs
@@ -93,12 +93,13 @@ impl<T: Any + Debug> ExternalPtr<T> {
             extern "C" fn finalizer<T>(x: SEXP) {
                 unsafe {
                     let ptr = R_ExternalPtrAddr(x) as *mut T;
-                    let externalptr_box = Box::from_raw(ptr);
+
+                    // Free the `tag`, which is the type-name
                     R_SetExternalPtrTag(x, R_NilValue);
 
                     // Convert the pointer to a box and drop it implictly.
                     // This frees up the memory we have used and calls the "T::drop" method if there is one.
-                    drop(externalptr_box)
+                    drop(Box::from_raw(ptr));
                 }
             }
 

--- a/extendr-api/src/wrapper/externalptr.rs
+++ b/extendr-api/src/wrapper/externalptr.rs
@@ -135,7 +135,7 @@ impl<T: Any + Debug> ExternalPtr<T> {
     pub fn addr(&self) -> &T {
         unsafe {
             let ptr = R_ExternalPtrAddr(self.robj.get()) as *const Box<dyn Any>;
-            let ptr_ref: &Box<dyn Any> = ptr.as_ref().unwrap();
+            let ptr_ref = &*ptr;
             let ptr_ref_downcast = ptr_ref.downcast_ref::<T>().unwrap();
             ptr_ref_downcast
         }
@@ -146,9 +146,9 @@ impl<T: Any + Debug> ExternalPtr<T> {
     pub fn addr_mut(&mut self) -> &mut T {
         unsafe {
             let ptr = R_ExternalPtrAddr(self.robj.get()) as *mut Box<dyn Any>;
-            let ref_mut_ptr: &mut Box<dyn Any> = ptr.as_mut().unwrap();
-            let ref_mut_ptr_downcast: &mut Box<T> = ref_mut_ptr.downcast_mut().unwrap();
-            ref_mut_ptr_downcast.as_mut()
+            let ptr_ref = &mut *ptr;
+            let ptr_ref_downcast = ptr_ref.downcast_mut::<T>().unwrap();
+            ptr_ref_downcast
         }
     }
 }

--- a/extendr-api/src/wrapper/externalptr.rs
+++ b/extendr-api/src/wrapper/externalptr.rs
@@ -111,15 +111,9 @@ impl<T: Any + Debug> ExternalPtr<T> {
             extern "C" fn finalizer<T: 'static>(x: SEXP) {
                 unsafe {
                     let ptr = R_ExternalPtrAddr(x);
-                    let boxed = Box::from_raw(ptr as *mut ExternalType);
-                    // let boxed_ref = boxed.inner.downcast_ref::<T>().unwrap();
-
-                    // Free the `tag`, which is the type-name
-                    R_SetExternalPtrTag(x, R_NilValue);
-
                     // Convert the pointer to a box and drop it implictly.
                     // This frees up the memory we have used and calls the "T::drop" method if there is one.
-                    drop(boxed);
+                    drop(Box::from_raw(ptr as *mut ExternalType));
 
                     // Now set the pointer in ExternalPTR to C `NULL`
                     R_ClearExternalPtr(x);

--- a/extendr-api/src/wrapper/externalptr.rs
+++ b/extendr-api/src/wrapper/externalptr.rs
@@ -136,7 +136,7 @@ impl<T: Any + Debug> ExternalPtr<T> {
         unsafe {
             let ptr = R_ExternalPtrAddr(self.robj.get()) as *const Box<dyn Any>;
             let ptr_ref: &Box<dyn Any> = ptr.as_ref().unwrap();
-            let ptr_ref_downcast: &Box<T> = ptr_ref.downcast_ref().unwrap();
+            let ptr_ref_downcast = ptr_ref.downcast_ref::<T>().unwrap();
             ptr_ref_downcast
         }
     }
@@ -148,7 +148,7 @@ impl<T: Any + Debug> ExternalPtr<T> {
             let ptr = R_ExternalPtrAddr(self.robj.get()) as *mut Box<dyn Any>;
             let ref_mut_ptr: &mut Box<dyn Any> = ptr.as_mut().unwrap();
             let ref_mut_ptr_downcast: &mut Box<T> = ref_mut_ptr.downcast_mut().unwrap();
-            ref_mut_ptr_downcast
+            ref_mut_ptr_downcast.as_mut()
         }
     }
 }
@@ -163,7 +163,7 @@ impl<T: Any + Debug> TryFrom<&Robj> for ExternalPtr<T> {
         let is_type = unsafe {
             let external_ptr = R_ExternalPtrAddr(robj.get()) as *mut Box<dyn Any>;
             let is_type: &Box<dyn Any> = external_ptr.as_ref().unwrap();
-            let is_type: Option<&Box<T>> = is_type.downcast_ref();
+            let is_type = is_type.downcast_ref::<T>();
             is_type.is_some()
         };
         if is_type {

--- a/extendr-api/src/wrapper/externalptr.rs
+++ b/extendr-api/src/wrapper/externalptr.rs
@@ -100,6 +100,9 @@ impl<T: Any + Debug> ExternalPtr<T> {
                     // Convert the pointer to a box and drop it implictly.
                     // This frees up the memory we have used and calls the "T::drop" method if there is one.
                     drop(Box::from_raw(ptr));
+
+                    // Now set the pointer in ExternalPTR to C `NULL`
+                    R_ClearExternalPtr(x);
                 }
             }
 

--- a/extendr-api/src/wrapper/externalptr.rs
+++ b/extendr-api/src/wrapper/externalptr.rs
@@ -101,8 +101,7 @@ impl<T: Any + Debug> ExternalPtr<T> {
 
             // This constructs an external pointer to our boxed data.
             // into_raw() converts the box to a malloced pointer.
-            let v = Box::new(v);
-            let ptr = Box::into_raw(v);
+            let ptr = Box::into_raw(Box::new(v));
             let external_ptr = R_MakeExternalPtr(ptr as *mut c_void, R_NilValue, R_NilValue);
 
             // ensure that this is protected

--- a/extendr-api/tests/externalptr_tests.rs
+++ b/extendr-api/tests/externalptr_tests.rs
@@ -60,5 +60,8 @@ fn test_externalptr_deref() {
         let extptr = ExternalPtr::new(X { x: 1, y: 2});
         assert_eq!(extptr.x, 1);
         assert_eq!(extptr.y, 2);
+        let mut extptr = extptr;
+        extptr.x = 66;
+        assert_eq!(extptr.x, 66);
     }
 }


### PR DESCRIPTION
Currently, `tag` in `ExternalPtr` is set to a string containing `std::any::type_name`.
This means, that every time an `Robj` is to be interpreted as an `ExternalPtr`, a
string comparison occurs.

R recommends that `tag` is set to an `install("Class name")`, which is a symbol, which is a pointer, and thus pointers are faster to compare than strings.

Proposed is a strategy where what is stored in `ExternalPtr` isn't an owning pointer `T*`, but rather something ressembling `Box<dyn Any>`, which contains type information.
This type information is extracted through `downcast`. 

This is a draft, and I'd like your collaboration in making this better, as I'm struggling to figure out the type-stuff.
