### PR TITLE
[internal] Remove `new_owned` in favour of `Robj::from_sexp`

### DIFF
--- a/extendr-api/src/graphics/mod.rs
+++ b/extendr-api/src/graphics/mod.rs
@@ -702,7 +702,7 @@ impl Device {
 
     /// Screen capture. Returns an integer matrix representing pixels if it is able.
     pub fn capture(&self) -> Robj {
-        unsafe { new_owned(GECap(self.inner())) }
+        unsafe { Robj::from_sexp(GECap(self.inner())) }
     }
 
     /// Draw a bitmap.

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -1026,15 +1026,6 @@ pub trait Attributes: Types + Length {
 
 impl Attributes for Robj {}
 
-#[doc(hidden)]
-#[deprecated = "is exactly like Robj::from_sexp"]
-pub unsafe fn new_owned(sexp: SEXP) -> Robj {
-    single_threaded(|| {
-        ownership::protect(sexp);
-        Robj { inner: sexp }
-    })
-}
-
 /// Compare equality with integer slices.
 impl PartialEq<[i32]> for Robj {
     fn eq(&self, rhs: &[i32]) -> bool {

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -1027,6 +1027,7 @@ pub trait Attributes: Types + Length {
 impl Attributes for Robj {}
 
 #[doc(hidden)]
+#[deprecated = "is exactly like Robj::from_sexp"]
 pub unsafe fn new_owned(sexp: SEXP) -> Robj {
     single_threaded(|| {
         ownership::protect(sexp);

--- a/extendr-api/src/wrapper/externalptr.rs
+++ b/extendr-api/src/wrapper/externalptr.rs
@@ -121,12 +121,12 @@ impl<T: Any + Debug> ExternalPtr<T> {
 
     /// Get the "tag" of an external pointer. This is the type name in the common case.
     pub fn tag(&self) -> Robj {
-        unsafe { new_owned(R_ExternalPtrTag(self.robj.get())) }
+        unsafe { Robj::from_sexp(R_ExternalPtrTag(self.robj.get())) }
     }
 
     /// Get the "protected" field of an external pointer. This is NULL in the common case.
     pub fn protected(&self) -> Robj {
-        unsafe { new_owned(R_ExternalPtrProtected(self.robj.get())) }
+        unsafe { Robj::from_sexp(R_ExternalPtrProtected(self.robj.get())) }
     }
 
     /// Get the "address" field of an external pointer.

--- a/extendr-macros/src/extendr_impl.rs
+++ b/extendr-macros/src/extendr_impl.rs
@@ -165,7 +165,7 @@ pub fn extendr_impl(mut item_impl: ItemImpl) -> TokenStream {
         // Function to free memory for this type.
         extern "C" fn #finalizer_name (sexp: extendr_api::SEXP) {
             unsafe {
-                let robj = extendr_api::new_owned(sexp);
+                let robj = extendr_api::robj::Robj::from_sexp(sexp);
                 if robj.check_external_ptr_type::<#self_ty>() {
                     //eprintln!("finalize {}", #self_ty_name);
                     let ptr = robj.external_ptr_addr::<#self_ty>();

--- a/extendr-macros/src/extendr_module.rs
+++ b/extendr-macros/src/extendr_module.rs
@@ -101,10 +101,10 @@ pub fn extendr_module(item: TokenStream) -> TokenStream {
             unsafe {
                 use extendr_api::robj::*;
                 use extendr_api::GetSexp;
-                let robj = new_owned(use_symbols_sexp);
+                let robj = Robj::from_sexp(use_symbols_sexp);
                 let use_symbols: bool = <bool>::from_robj(&robj).unwrap();
 
-                let robj = new_owned(package_name_sexp);
+                let robj = Robj::from_sexp(package_name_sexp);
                 let package_name: &str = <&str>::from_robj(&robj).unwrap();
 
                 extendr_api::Robj::from(

--- a/extendr-macros/src/wrappers.rs
+++ b/extendr-macros/src/wrappers.rs
@@ -333,13 +333,13 @@ fn translate_to_robj(input: &FnArg) -> syn::Stmt {
             let pat = &pattype.pat.as_ref();
             if let syn::Pat::Ident(ref ident) = pat {
                 let varname = format_ident!("_{}_robj", ident.ident);
-                parse_quote! { let #varname = extendr_api::new_owned(#pat); }
+                parse_quote! { let #varname = extendr_api::robj::Robj::from_sexp(#pat); }
             } else {
                 panic!("expect identifier as arg name")
             }
         }
         FnArg::Receiver(_) => {
-            parse_quote! { let mut _self_robj = extendr_api::new_owned(_self); }
+            parse_quote! { let mut _self_robj = extendr_api::robj::Robj::from_sexp(_self); }
         }
     }
 }


### PR DESCRIPTION
Removing `new_owned`, as

```rust
#[doc(hidden)]
pub unsafe fn new_owned(sexp: SEXP) -> Robj {
    single_threaded(|| {
        ownership::protect(sexp);
        Robj { inner: sexp }
    })
}
```

is a carbon copy of 

```rust
impl Robj {
    pub fn from_sexp(sexp: SEXP) -> Self {
        single_threaded(|| {
            unsafe { ownership::protect(sexp) };
            Robj { inner: sexp }
        })
    }
```

- `new_owned` is an internal (private) function, as it is `doc(hidden)`.
- It doesn't have `new_unowned` variants
