### PR TITLE
Integrate `ExternalPtr<T>` and `#[extendr]` for `impl`-blocks

### DIFF
--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -772,6 +772,7 @@ mod tests {
         x
     }
 
+    #[derive(Debug)]
     struct Person {
         pub name: String,
     }

--- a/extendr-api/src/robj/rinternals.rs
+++ b/extendr-api/src/robj/rinternals.rs
@@ -407,6 +407,7 @@ pub trait Rinternals: Types + Conversions {
     /// Check an external pointer tag.
     /// This is used to wrap R objects.
     #[doc(hidden)]
+    #[deprecated]
     fn check_external_ptr_type<T>(&self) -> bool {
         if self.sexptype() == libR_sys::EXTPTRSXP {
             let tag = unsafe { self.external_ptr_tag() };

--- a/extendr-api/src/wrapper/externalptr.rs
+++ b/extendr-api/src/wrapper/externalptr.rs
@@ -122,6 +122,8 @@ impl<T: Any + Debug> ExternalPtr<T> {
             }));
             extern "C" fn finalizer<T>(x: SEXP) {
                 unsafe {
+                    /// Free the `tag` which is the type name
+                    R_SetExternalPtrTag(x, R_NilValue);
                     let ptr = R_ExternalPtrAddr(x) as *mut ExternalData<T>;
 
                     // Convert the pointer to a box and drop it implictly.

--- a/extendr-api/tests/externalptr_tests.rs
+++ b/extendr-api/tests/externalptr_tests.rs
@@ -60,5 +60,8 @@ fn test_externalptr_deref() {
         let extptr = ExternalPtr::new(X { x: 1, y: 2});
         assert_eq!(extptr.x, 1);
         assert_eq!(extptr.y, 2);
+        let mut extptr = extptr;
+        extptr.x = 44;
+        assert_eq!(extptr.x, 44);
     }
 }

--- a/extendr-macros/src/extendr_impl.rs
+++ b/extendr-macros/src/extendr_impl.rs
@@ -141,25 +141,8 @@ pub fn extendr_impl(mut item_impl: ItemImpl) -> TokenStream {
         // Output conversion function for this type.
         impl From<#self_ty> for Robj {
             fn from(value: #self_ty) -> Self {
-                unsafe {
-                    let ptr = Box::into_raw(Box::new(value));
-                    let res = Robj::make_external_ptr(ptr, Robj::from(()));
-                    res.set_attrib(class_symbol(), #self_ty_name).unwrap();
-                    res.register_c_finalizer(Some(#finalizer_name));
-                    res
-                }
-            }
-        }
-
-        // Function to free memory for this type.
-        extern "C" fn #finalizer_name (sexp: extendr_api::SEXP) {
-            unsafe {
-                let robj = extendr_api::robj::Robj::from_sexp(sexp);
-                if robj.check_external_ptr_type::<#self_ty>() {
-                    //eprintln!("finalize {}", #self_ty_name);
-                    let ptr = robj.external_ptr_addr::<#self_ty>();
-                    drop(Box::from_raw(ptr));
-                }
+                let external_ptr = ExternalPtr::new(value);
+                external_ptr.into()
             }
         }
 

--- a/extendr-macros/src/extendr_impl.rs
+++ b/extendr-macros/src/extendr_impl.rs
@@ -5,6 +5,8 @@ use syn::{ItemFn, ItemImpl};
 
 use crate::wrappers;
 
+//TODO: It is now a requirement that these implement `Debug`. 
+
 /// Handle trait implementations.
 ///
 /// Example:
@@ -139,19 +141,6 @@ pub fn extendr_impl(mut item_impl: ItemImpl) -> TokenStream {
         // Output conversion function for this type.
         impl From<#self_ty> for Robj {
             fn from(value: #self_ty) -> Self {
-                unsafe {
-                    let ptr = Box::into_raw(Box::new(value));
-                    let res = Robj::make_external_ptr(ptr, Robj::from(()));
-                    res.set_attrib(class_symbol(), #self_ty_name).unwrap();
-                    res.register_c_finalizer(Some(#finalizer_name));
-                    res
-                }
-            }
-        }
-
-        // Output conversion function for this type.
-        impl<'a> From<&'a #self_ty> for Robj {
-            fn from(value: &'a #self_ty) -> Self {
                 unsafe {
                     let ptr = Box::into_raw(Box::new(value));
                     let res = Robj::make_external_ptr(ptr, Robj::from(()));

--- a/extendr-macros/src/extendr_impl.rs
+++ b/extendr-macros/src/extendr_impl.rs
@@ -5,7 +5,7 @@ use syn::{ItemFn, ItemImpl};
 
 use crate::wrappers;
 
-//TODO: It is now a requirement that these implement `Debug`. 
+//TODO: It is now a requirement that these implement `Debug`.
 
 /// Handle trait implementations.
 ///
@@ -105,8 +105,6 @@ pub fn extendr_impl(mut item_impl: ItemImpl) -> TokenStream {
 
     let meta_name = format_ident!("{}{}", wrappers::META_PREFIX, self_ty_name);
 
-    let finalizer_name = format_ident!("__finalize__{}", self_ty_name);
-
     let expanded = TokenStream::from(quote! {
         // The impl itself copied from the source.
         #item_impl
@@ -141,8 +139,7 @@ pub fn extendr_impl(mut item_impl: ItemImpl) -> TokenStream {
         // Output conversion function for this type.
         impl From<#self_ty> for Robj {
             fn from(value: #self_ty) -> Self {
-                let external_ptr = ExternalPtr::new(value);
-                external_ptr.into()
+                ExternalPtr::new(value).into()
             }
         }
 


### PR DESCRIPTION
# [Help wanted]

Before this PR, `ExternalPtr<T>` and `#[extendr]`-impl were not connected at all.
In fact, it was doubly implemented. **Also**, runtime type-checks between passing R the
`ExternalPtr<T>`s was through strings. R recommends using symbols for the comparisons,
and while we did do that, the symbols are `ownership`-checked, and we were generating
them every time types were passed.

## Progress

* Added `ExternalData<T>` which adds a `TypeId` to what's covered by `ExternalPtr<T>`.
Thus, we have `ExternalPtr<ExternalData<T>>`. By virtue of `repr(C)`, we may extract first
field (here `TypeId`) from an opaque pointer to an unknown `ExternalPtr`. 

We use `addr_of!` because it could be bad to create an intermediate reference (for the pointer) of
a thing that isn't all that valid (`ExternalData<()>`). It is some dark-magic that someone suggested (named @wolvereness).

* Deprecating / Removing `check_external_ptr_type` as it is not a recommended way of doing
reflection, see documentation on `std::any::type_name` for this.

* From now on `#[extendr]`-impl types must be `Debug`. 

* Removed `From<&T> for Robj` as it doesn't make sense to create a `ExternalPtr` from a
reference; We need to have an owning pointer, to even finalize the object to begin with.

* Added static methods on `ExternalPtr`, as the issue is we cannot return references to
local data, and thus instantiating an `ExternalPtr<T>` in say `FromRobj` is not feasible.

## Hurdle

`FromRobj` is not playing nicely; Changing that will increase the foot-print of this PR,
and it is not obvious to me how to change it.



