### PR TITLE
`Rarray` rebuild

### DIFF
--- a/extendr-api/src/error.rs
+++ b/extendr-api/src/error.rs
@@ -62,8 +62,7 @@ pub enum Error {
 
     ExpectedScalar(Robj),
     ExpectedVector(Robj),
-    ExpectedMatrix(Robj),
-    ExpectedMatrix3D(Robj),
+    ExpectedArray(Robj),
     ExpectedNumeric(Robj),
     ExpectedAltrep(Robj),
     ExpectedDataframe(Robj),
@@ -136,8 +135,7 @@ impl std::fmt::Display for Error {
 
             Error::ExpectedScalar(robj) => write!(f, "Expected Scalar, got {:?}", robj.rtype()),
             Error::ExpectedVector(robj) => write!(f, "Expected Vector, got {:?}", robj.rtype()),
-            Error::ExpectedMatrix(robj) => write!(f, "Expected Matrix, got {:?}", robj.rtype()),
-            Error::ExpectedMatrix3D(robj) => write!(f, "Expected Matrix3D, got {:?}", robj.rtype()),
+            Error::ExpectedArray(robj) => write!(f, "Expected Array, got {:?}", robj.rtype()),
             Error::ExpectedNumeric(robj) => write!(f, "Expected Numeric, got {:?}", robj.rtype()),
             Error::ExpectedAltrep(robj) => write!(f, "Expected Altrep, got {:?}", robj.rtype()),
             Error::ExpectedDataframe(robj) => {

--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -763,12 +763,12 @@ mod tests {
     // }
 
     #[extendr]
-    pub fn symbol(x: Symbol) -> Symbol {
+    pub fn matrix(x: RMatrix<i32>) -> RMatrix<i32> {
         x
     }
 
     #[extendr]
-    pub fn matrix(x: RMatrix<f64>) -> RMatrix<f64> {
+    pub fn symbol(x: Symbol) -> Symbol {
         x
     }
 
@@ -925,10 +925,9 @@ mod tests {
                 assert_eq!(Robj::from_sexp(wrap__symbol(robj.get())), robj);
 
                 // #[extendr]
-                // pub fn matrix(x: Matrix<&[f64]>) -> Matrix<&[f64]> { x }
+                // pub fn matrix(x: RMatrix<i32>) -> RMatrix<i32> { x }
 
-                let m = RMatrix::new_matrix(1, 2, |r, c| if r == c {1.0} else {0.});
-                let robj = r!(m);
+                let robj = r!(RMatrix::from_slice(&[1,2,3,4,5,6], [2,3]));
                 assert_eq!(Robj::from_sexp(wrap__matrix(robj.get())), robj);
             }
         }

--- a/extendr-api/src/prelude.rs
+++ b/extendr-api/src/prelude.rs
@@ -38,12 +38,12 @@ pub use crate::{
 
 pub use super::wrapper::{
     AltComplexImpl, AltIntegerImpl, AltLogicalImpl, AltRawImpl, AltRealImpl, AltStringImpl, Altrep,
-    AltrepImpl, RArray, RArray3D, RColumn, RMatrix,
+    AltrepImpl, RArray, RMatrix,
 };
 
 pub use super::wrapper::s4::S4;
 
-pub use super::wrapper::{Conversions, MatrixConversions};
+pub use super::wrapper::Conversions;
 
 pub use super::robj::{
     AsStrIter, Attributes, Eval, GetSexp, IntoRobj, Length, Operators, Rinternals, Robj,

--- a/extendr-api/src/prelude.rs
+++ b/extendr-api/src/prelude.rs
@@ -38,7 +38,7 @@ pub use crate::{
 
 pub use super::wrapper::{
     AltComplexImpl, AltIntegerImpl, AltLogicalImpl, AltRawImpl, AltRealImpl, AltStringImpl, Altrep,
-    AltrepImpl, RArray, RColumn, RMatrix, RMatrix3D,
+    AltrepImpl, RArray, RArray3D, RColumn, RMatrix,
 };
 
 pub use super::wrapper::s4::S4;

--- a/extendr-api/src/robj/from_robj.rs
+++ b/extendr-api/src/robj/from_robj.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::wrapper::matrix::MatrixConversions;
+use crate::wrapper::array::MatrixConversions;
 
 /// Trait used for incomming parameter conversion.
 pub trait FromRobj<'a>: Sized {
@@ -278,12 +278,12 @@ where
 }
 
 // Matrix input parameters.
-impl<'a, T: 'a> FromRobj<'a> for RMatrix3D<T>
+impl<'a, T: 'a> FromRobj<'a> for RArray3D<T>
 where
     Robj: AsTypedSlice<'a, T>,
 {
     fn from_robj(robj: &'a Robj) -> std::result::Result<Self, &'static str> {
-        match robj.as_matrix3d() {
+        match robj.as_array3d() {
             Some(x) => Ok(x),
             _ => Err("Expected a matrix."),
         }

--- a/extendr-api/src/robj/from_robj.rs
+++ b/extendr-api/src/robj/from_robj.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::wrapper::array::MatrixConversions;
 
 /// Trait used for incomming parameter conversion.
 pub trait FromRobj<'a>: Sized {
@@ -264,27 +263,14 @@ where
     }
 }
 
-// Matrix input parameters.
-impl<'a, T: 'a> FromRobj<'a> for RArray<T, [usize; 2]>
+// RMatrix input parameters.
+impl<'a, T: 'a> FromRobj<'a> for RMatrix<T>
 where
     Robj: AsTypedSlice<'a, T>,
 {
     fn from_robj(robj: &'a Robj) -> std::result::Result<Self, &'static str> {
-        match robj.as_matrix() {
-            Some(x) => Ok(x),
-            _ => Err("Expected a matrix."),
-        }
-    }
-}
-
-// Matrix input parameters.
-impl<'a, T: 'a> FromRobj<'a> for RArray3D<T>
-where
-    Robj: AsTypedSlice<'a, T>,
-{
-    fn from_robj(robj: &'a Robj) -> std::result::Result<Self, &'static str> {
-        match robj.as_array3d() {
-            Some(x) => Ok(x),
+        match RArray::try_from(robj) {
+            Ok(x) => Ok(x),
             _ => Err("Expected a matrix."),
         }
     }

--- a/extendr-api/src/wrapper/array.rs
+++ b/extendr-api/src/wrapper/array.rs
@@ -1,27 +1,22 @@
 //! Wrappers for matrices with deferred arithmetic.
 
+use super::scalar::Scalar;
 use super::*;
-use crate::robj::GetSexp;
-use crate::scalar::Scalar;
-use std::ops::{Index, IndexMut};
+use std::{
+    marker::PhantomData,
+    ops::{Index, IndexMut},
+};
 
 /// Wrapper for creating and using matrices and arrays.
 ///
 /// ```
 /// use extendr_api::prelude::*;
 /// test! {
-///     let matrix = RMatrix::new_matrix(3, 2, |r, c| [
-///         [1., 2., 3.],
-///          [4., 5., 6.]][c][r]);
+///     let matrix = RArray::from_slice([1,2,3,4,5,6], [3, 2]);
 ///     let robj = r!(matrix);
 ///     assert_eq!(robj.is_matrix(), true);
 ///     assert_eq!(robj.nrows(), 3);
 ///     assert_eq!(robj.ncols(), 2);
-///
-///     let matrix2 : RMatrix<f64> = robj.as_matrix().ok_or("error")?;
-///     assert_eq!(matrix2.data().len(), 6);
-///     assert_eq!(matrix2.nrows(), 3);
-///     assert_eq!(matrix2.ncols(), 2);
 /// }
 /// ```
 #[derive(Debug, PartialEq)]
@@ -29,16 +24,174 @@ pub struct RArray<T, D> {
     /// Owning Robj (probably should be a Pin).
     robj: Robj,
 
-    /// Slice of the data references the Robj.
-    data: *mut T,
-
     /// Dimensions of the array.
     dim: D,
+
+    phantom: PhantomData<T>,
 }
 
-pub type RColumn<T> = RArray<T, [usize; 1]>;
 pub type RMatrix<T> = RArray<T, [usize; 2]>;
-pub type RArray3D<T> = RArray<T, [usize; 3]>;
+
+impl<'a, T, D> RArray<T, D>
+where
+    Robj: AsTypedSlice<'a, T>,
+    Self: 'a,
+{
+    // Make a new RArray type.
+    // This function doesn't insert a dim attribute to the Robj.
+    pub(crate) fn new(robj: Robj, dim: D) -> Self {
+        Self {
+            robj,
+            dim,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Get the underlying data from this RArray.
+    pub fn data(&'a self) -> &'a [T] {
+        self.robj.as_typed_slice().unwrap()
+    }
+
+    /// Get the dimensions for this array.
+    pub fn dim(&self) -> &D {
+        &self.dim
+    }
+
+    /// Make a new RArray type.
+    /// This function inserts a dim attribute to the Robj.
+    pub fn from_slice<P>(slice: P, dims: D) -> Result<Self>
+    where
+        P: AsRef<[T]>,
+        T: ToVectorValue + Clone + 'a,
+        D: AsRef<[usize]> + Clone,
+    {
+        let dims_ref = dims.as_ref();
+        let slice_ref = slice.as_ref();
+        let robj = slice_ref.iter().cloned().collect_robj();
+
+        let prod = dims_ref.iter().product::<usize>();
+        if prod != robj.len() {
+            return Err(Error::Other(format!(
+                "The vector length ({}) does not match the length implied by the dimensions ({})",
+                slice_ref.len(),
+                prod
+            )));
+        }
+
+        let robj = robj
+            .set_attrib(
+                wrapper::symbol::dim_symbol(),
+                dims_ref.iter().collect_robj(),
+            )
+            .unwrap();
+
+        Ok(Self {
+            robj,
+            dim: dims,
+            phantom: PhantomData,
+        })
+    }
+
+    /// Make a new RArray type.
+    /// This function inserts a dim attribute to the Robj.
+    /// # Safety
+    /// The caller must ensure that the product of the dimensions is equal to the slice length.
+    pub unsafe fn from_slice_unchecked<P>(slice: P, dims: D) -> Result<Self>
+    where
+        P: AsRef<[T]>,
+        T: ToVectorValue + Clone + 'a,
+        D: AsRef<[usize]> + Clone,
+    {
+        let dims_ref = dims.as_ref();
+        let robj = slice.as_ref().iter().cloned().collect_robj();
+
+        let robj = robj
+            .set_attrib(
+                wrapper::symbol::dim_symbol(),
+                dims_ref.iter().collect_robj(),
+            )
+            .unwrap();
+
+        Ok(Self {
+            robj,
+            dim: dims,
+            phantom: PhantomData,
+        })
+    }
+}
+
+impl<T, D> From<RArray<T, D>> for Robj {
+    fn from(array: RArray<T, D>) -> Self {
+        array.robj
+    }
+}
+
+impl<'a, T: 'a> TryFrom<Robj> for RArray<T, Integers>
+where
+    Robj: AsTypedSlice<'a, T>,
+{
+    type Error = Error;
+
+    fn try_from(robj: Robj) -> Result<Self> {
+        if !robj.is_array() {
+            Err(Error::ExpectedArray(robj))
+        } else {
+            // Ok to unwrap since the robj is an array.
+            let dim = robj.dim().unwrap();
+            Ok(RArray::new(robj, dim))
+        }
+    }
+}
+
+impl<'a, T: 'a> TryFrom<&'a Robj> for RArray<T, Integers>
+where
+    Robj: AsTypedSlice<'a, T>,
+{
+    type Error = Error;
+
+    fn try_from(robj: &'a Robj) -> Result<Self> {
+        Self::try_from(robj.clone())
+    }
+}
+
+impl<'a, T: 'a> TryFrom<Robj> for RMatrix<T>
+where
+    Robj: AsTypedSlice<'a, T>,
+{
+    type Error = Error;
+
+    fn try_from(robj: Robj) -> Result<Self> {
+        if !robj.is_array() {
+            Err(Error::ExpectedArray(robj))
+        } else {
+            // Ok to unwrap since the robj is an array.
+            let dim = robj.dim().unwrap();
+            Ok(RArray::new(
+                robj,
+                [dim[0].inner() as usize, dim[1].inner() as usize],
+            ))
+        }
+    }
+}
+
+impl<'a, T: 'a> TryFrom<&'a Robj> for RMatrix<T>
+where
+    Robj: AsTypedSlice<'a, T>,
+{
+    type Error = Error;
+
+    fn try_from(robj: &'a Robj) -> Result<Self> {
+        Self::try_from(robj.clone())
+    }
+}
+
+impl<T, D> Deref for RArray<T, D> {
+    type Target = Robj;
+
+    fn deref(&self) -> &Self::Target {
+        &self.robj
+    }
+}
 
 const BASE: usize = 0;
 
@@ -57,7 +210,7 @@ impl<T> Offset<[usize; 1]> for RArray<T, [usize; 1]> {
     }
 }
 
-impl<T> Offset<[usize; 2]> for RArray<T, [usize; 2]> {
+impl<T> Offset<[usize; 2]> for RMatrix<T> {
     /// Get the offset into the array for a given index.
     fn offset(&self, index: [usize; 2]) -> usize {
         if index[0] - BASE > self.dim[0] {
@@ -70,281 +223,10 @@ impl<T> Offset<[usize; 2]> for RArray<T, [usize; 2]> {
     }
 }
 
-impl<T> Offset<[usize; 3]> for RArray<T, [usize; 3]> {
-    /// Get the offset into the array for a given index.
-    fn offset(&self, index: [usize; 3]) -> usize {
-        if index[0] - BASE > self.dim[0] {
-            panic!("RArray3D index: row overflow");
-        }
-        if index[1] - BASE > self.dim[1] {
-            panic!("RArray3D index: column overflow");
-        }
-        if index[2] - BASE > self.dim[2] {
-            panic!("RArray3D index: submatrix overflow");
-        }
-        (index[0] - BASE) + self.dim[0] * (index[1] - BASE + self.dim[1] * (index[2] - BASE))
-    }
-}
-
-impl<T, D> RArray<T, D> {
-    /// Make a new RArray type.
-    pub fn from_parts(robj: Robj, data: *mut T, dim: D) -> Self {
-        Self { robj, data, dim }
-    }
-
-    /// Get the underlying data from this RArray.
-    pub fn data(&self) -> &[T] {
-        unsafe { std::slice::from_raw_parts(self.data, self.robj.len()) }
-    }
-
-    /// Get the dimensions for this array.
-    pub fn dim(&self) -> &D {
-        &self.dim
-    }
-
-    /// Make a new RArray type.
-    /// This is different than `from_parts` because it modifies the attributes of the `Robj` with
-    /// dim.
-    pub fn new_array<'a, P>(slice: P, dims: D) -> Result<Self>
-    where
-        P: AsRef<[T]>,
-        T: ToVectorValue + Clone + 'a,
-        D: AsRef<[usize]> + Clone,
-        Robj: AsTypedSlice<'a, T>,
-    {
-        let dims_ref = dims.as_ref();
-        let robj = slice.as_ref().iter().cloned().collect_robj();
-        let mut robj = robj
-            .set_attrib(
-                wrapper::symbol::dim_symbol(),
-                dims_ref.iter().collect_robj(),
-            )
-            .unwrap();
-        let data = robj
-            .as_typed_slice_mut()
-            .ok_or(Error::Other(
-                "Unknown error in converting to slice".to_string(),
-            ))?
-            .as_mut_ptr();
-
-        Ok(Self {
-            robj,
-            data,
-            dim: dims,
-        })
-    }
-}
-
-impl<'a, T: ToVectorValue + 'a> RColumn<T>
+impl<'a, T: 'a> Index<[usize; 2]> for RMatrix<T>
 where
     Robj: AsTypedSlice<'a, T>,
 {
-    /// Make a new column type.
-    pub fn new_column<F: FnMut(usize) -> T>(nrows: usize, f: F) -> Self {
-        let robj = (0..nrows).map(f).collect_robj();
-        let dim = [nrows];
-        let mut robj = robj.set_attrib(wrapper::symbol::dim_symbol(), dim).unwrap();
-        let slice = robj.as_typed_slice_mut().unwrap();
-        let data = slice.as_mut_ptr();
-        RArray::from_parts(robj, data, dim)
-    }
-
-    /// Get the number of rows.
-    pub fn nrows(&self) -> usize {
-        self.dim[0]
-    }
-}
-
-impl<'a, T: ToVectorValue + 'a> RMatrix<T>
-where
-    Robj: AsTypedSlice<'a, T>,
-{
-    /// Create a new matrix wrapper.
-    ///
-    /// # Arguments
-    ///
-    /// * `nrows` - the number of rows the returned matrix will have
-    /// * `ncols` - the number of columns the returned matrix will have
-    /// * `f` - a function that will be called for each entry of the matrix in order to populate it with values.
-    ///     It must return a scalar value that can be converted to an R scalar, such as `u32`, `f64`, i.e. see [ToVectorValue].
-    ///     It accepts two arguments:
-    ///     * `r` - the current row of the entry we are creating
-    ///     * `c` - the current column of the entry we are creating
-    pub fn new_matrix<F: Clone + FnMut(usize, usize) -> T>(
-        nrows: usize,
-        ncols: usize,
-        f: F,
-    ) -> Self {
-        let robj = (0..ncols)
-            .flat_map(|c| {
-                let mut g = f.clone();
-                (0..nrows).map(move |r| g(r, c))
-            })
-            .collect_robj();
-        let dim = [nrows, ncols];
-        let mut robj = robj.set_attrib(wrapper::symbol::dim_symbol(), dim).unwrap();
-        let data = robj.as_typed_slice_mut().unwrap().as_mut_ptr();
-        RArray::from_parts(robj, data, dim)
-    }
-
-    /// Get the number of rows.
-    pub fn nrows(&self) -> usize {
-        self.dim[0]
-    }
-
-    /// Get the number of columns.
-    pub fn ncols(&self) -> usize {
-        self.dim[1]
-    }
-}
-
-impl<'a, T: ToVectorValue + 'a> RArray3D<T>
-where
-    Robj: AsTypedSlice<'a, T>,
-{
-    pub fn new_matrix3d<F: Clone + FnMut(usize, usize, usize) -> T>(
-        nrows: usize,
-        ncols: usize,
-        nmatrix: usize,
-        f: F,
-    ) -> Self {
-        let robj = (0..nmatrix)
-            .flat_map(|m| {
-                let h = f.clone();
-                (0..ncols).flat_map(move |c| {
-                    let mut g = h.clone();
-                    (0..nrows).map(move |r| g(r, c, m))
-                })
-            })
-            .collect_robj();
-        let dim = [nrows, ncols, nmatrix];
-        let mut robj = robj.set_attrib(wrapper::symbol::dim_symbol(), dim).unwrap();
-        let data = robj.as_typed_slice_mut().unwrap().as_mut_ptr();
-        RArray::from_parts(robj, data, dim)
-    }
-
-    /// Get the number of rows.
-    pub fn nrows(&self) -> usize {
-        self.dim[0]
-    }
-
-    /// Get the number of columns.
-    pub fn ncols(&self) -> usize {
-        self.dim[1]
-    }
-
-    /// Get the number of submatrices.
-    pub fn nsub(&self) -> usize {
-        self.dim[2]
-    }
-}
-
-impl<'a, T: 'a> TryFrom<Robj> for RColumn<T>
-where
-    Robj: AsTypedSlice<'a, T>,
-{
-    type Error = Error;
-
-    fn try_from(mut robj: Robj) -> Result<Self> {
-        if let Some(slice) = robj.as_typed_slice_mut() {
-            Ok(RArray::from_parts(robj, slice.as_mut_ptr(), [slice.len()]))
-        } else {
-            Err(Error::ExpectedVector(robj))
-        }
-    }
-}
-
-impl<'a, T: 'a> TryFrom<Robj> for RMatrix<T>
-where
-    Robj: AsTypedSlice<'a, T>,
-{
-    type Error = Error;
-
-    fn try_from(mut robj: Robj) -> Result<Self> {
-        if !robj.is_matrix() {
-            Err(Error::ExpectedMatrix(robj))
-        } else if let Some(slice) = robj.as_typed_slice_mut() {
-            if let Some(dim) = robj.dim() {
-                let dim: Vec<_> = dim.iter().map(|d| d.inner() as usize).collect();
-                if dim.len() != 2 {
-                    Err(Error::ExpectedMatrix(robj))
-                } else {
-                    Ok(RArray::from_parts(
-                        robj,
-                        slice.as_mut_ptr(),
-                        [dim[0], dim[1]],
-                    ))
-                }
-            } else {
-                Err(Error::ExpectedMatrix(robj))
-            }
-        } else {
-            Err(Error::TypeMismatch(robj))
-        }
-    }
-}
-
-impl<'a, T: 'a> TryFrom<Robj> for RArray3D<T>
-where
-    Robj: AsTypedSlice<'a, T>,
-{
-    type Error = Error;
-
-    fn try_from(mut robj: Robj) -> Result<Self> {
-        if let Some(slice) = robj.as_typed_slice_mut() {
-            if let Some(dim) = robj.dim() {
-                if dim.len() != 3 {
-                    Err(Error::ExpectedMatrix3D(robj))
-                } else {
-                    let dim: Vec<_> = dim.iter().map(|d| d.inner() as usize).collect();
-                    Ok(RArray::from_parts(
-                        robj,
-                        slice.as_mut_ptr(),
-                        [dim[0], dim[1], dim[2]],
-                    ))
-                }
-            } else {
-                Err(Error::ExpectedMatrix3D(robj))
-            }
-        } else {
-            Err(Error::TypeMismatch(robj))
-        }
-    }
-}
-
-impl<T, D> From<RArray<T, D>> for Robj {
-    /// Convert a column, matrix or matrix3d to an Robj.
-    fn from(array: RArray<T, D>) -> Self {
-        array.robj
-    }
-}
-
-pub trait MatrixConversions: GetSexp {
-    fn as_column<'a, E: 'a>(&self) -> Option<RColumn<E>>
-    where
-        Robj: AsTypedSlice<'a, E>,
-    {
-        <RColumn<E>>::try_from(self.as_robj().clone()).ok()
-    }
-
-    fn as_matrix<'a, E: 'a>(&self) -> Option<RMatrix<E>>
-    where
-        Robj: AsTypedSlice<'a, E>,
-    {
-        <RMatrix<E>>::try_from(self.as_robj().clone()).ok()
-    }
-
-    fn as_array3d<'a, E: 'a>(&self) -> Option<RArray3D<E>>
-    where
-        Robj: AsTypedSlice<'a, E>,
-    {
-        <RArray3D<E>>::try_from(self.as_robj().clone()).ok()
-    }
-}
-
-impl MatrixConversions for Robj {}
-
-impl<T> Index<[usize; 2]> for RArray<T, [usize; 2]> {
     type Output = T;
 
     /// Zero-based indexing in row, column order.
@@ -353,27 +235,29 @@ impl<T> Index<[usize; 2]> for RArray<T, [usize; 2]> {
     /// ```
     /// use extendr_api::prelude::*;
     /// test! {
-    ///    let matrix = RArray::new_matrix(3, 2, |r, c| [
-    ///        [1., 2., 3.],
-    ///        [4., 5., 6.]][c][r]);
+    ///     let matrix = RArray::from_slice([1.,2.,3.,4.,5.,6.], [3, 2]).unwrap();
     ///     assert_eq!(matrix[[0, 0]], 1.);
     ///     assert_eq!(matrix[[1, 0]], 2.);
     ///     assert_eq!(matrix[[2, 1]], 6.);
     /// }
     /// ```
     fn index(&self, index: [usize; 2]) -> &Self::Output {
-        unsafe { self.data.add(self.offset(index)).as_ref().unwrap() }
+        let ptr = self.robj.as_typed_slice().unwrap().as_ptr();
+        unsafe { ptr.add(self.offset(index)).as_ref().unwrap() }
     }
 }
 
-impl<T> IndexMut<[usize; 2]> for RArray<T, [usize; 2]> {
+impl<'a, T: 'a> IndexMut<[usize; 2]> for RMatrix<T>
+where
+    Robj: AsTypedSlice<'a, T>,
+{
     /// Zero-based mutable indexing in row, column order.
     ///
     /// Panics if out of bounds.
     /// ```
     /// use extendr_api::prelude::*;
     /// test! {
-    ///     let mut matrix = RMatrix::new_matrix(3, 2, |_, _| 0.);
+    ///     let mut matrix = RArray::from_slice([0.,0.,0.,0.,0.,0.], [3, 2]).unwrap();
     ///     matrix[[0, 0]] = 1.;
     ///     matrix[[1, 0]] = 2.;
     ///     matrix[[2, 0]] = 3.;
@@ -382,67 +266,41 @@ impl<T> IndexMut<[usize; 2]> for RArray<T, [usize; 2]> {
     /// }
     /// ```
     fn index_mut(&mut self, index: [usize; 2]) -> &mut Self::Output {
-        unsafe { self.data.add(self.offset(index)).as_mut().unwrap() }
+        let ptr = self.robj.as_typed_slice_mut().unwrap().as_mut_ptr();
+        unsafe { ptr.add(self.offset(index)).as_mut().unwrap() }
     }
 }
 
-impl<T, D> Deref for RArray<T, D> {
-    type Target = Robj;
+mod tests {
+    use super::*;
 
-    fn deref(&self) -> &Self::Target {
-        &self.robj
+    #[test]
+    fn from_slice() {
+        test! {
+            let slice = [1,2,3,4,5,6];
+            let dim = [2,3];
+            let array = RArray::from_slice(slice, dim).unwrap();
+            let dim = array.dim().clone();
+            let robj = r!(array);
+            assert_eq!(dim, [2,3]);
+            assert!(robj.is_array());
+            assert!(robj.is_matrix());
+            assert!(RArray::<i32, Integers>::try_from(robj).is_ok());
+        }
     }
-}
 
-#[test]
-fn matrix_ops() {
-    test! {
-        let vector = RColumn::new_column(3, |r| [1., 2., 3.][r]);
-        let robj = r!(vector);
-        assert_eq!(robj.is_vector(), true);
-        assert_eq!(robj.nrows(), 3);
-
-        let vector2 : RColumn<f64> = robj.as_column().ok_or("expected array")?;
-        assert_eq!(vector2.data().len(), 3);
-        assert_eq!(vector2.nrows(), 3);
-
-        let matrix = RMatrix::new_matrix(3, 2, |r, c| [
-            [1., 2., 3.],
-            [4., 5., 6.]][c][r]);
-        let robj = r!(matrix);
-        assert_eq!(robj.is_matrix(), true);
-        assert_eq!(robj.nrows(), 3);
-        assert_eq!(robj.ncols(), 2);
-        let matrix2 : RMatrix<f64> = robj.as_matrix().ok_or("expected matrix")?;
-        assert_eq!(matrix2.data().len(), 6);
-        assert_eq!(matrix2.nrows(), 3);
-        assert_eq!(matrix2.ncols(), 2);
-
-        let array = RArray3D::new_matrix3d(2, 2, 2, |r, c, m| [
-            [[1., 2.],  [3., 4.]],
-            [[5.,  6.], [7., 8.]]][m][c][r]);
-        let robj = r!(array);
-        assert_eq!(robj.is_array(), true);
-        assert_eq!(robj.nrows(), 2);
-        assert_eq!(robj.ncols(), 2);
-        let array2 : RArray3D<f64> = robj.as_array3d().ok_or("expected matrix3d")?;
-        assert_eq!(array2.data().len(), 8);
-        assert_eq!(array2.nrows(), 2);
-        assert_eq!(array2.ncols(), 2);
-        assert_eq!(array2.nsub(), 2);
-    }
-}
-
-#[test]
-fn new_array() {
-    test! {
-        let slice = [1,2,3,4,5,6];
-        let dim = [2,3];
-        let array = RArray::new_array(slice, dim).unwrap();
-        assert_eq!(array.data().len(), 6);
-        let robj = r!(array);
-        assert_eq!(robj.is_array(), true);
-        assert_eq!(robj.nrows(), 2);
-        assert_eq!(robj.ncols(), 3);
+    #[test]
+    fn try_from_rarray() {
+        test! {
+            let slice = [1,2,3,4,5,6];
+            let dim = [2,3];
+            let array = RArray::from_slice(slice, dim).unwrap();
+            let robj = r!(array);
+            let rarray = RArray::<i32, Integers>::try_from(robj).unwrap();
+            let new_dim = rarray.dim();
+            assert_eq!(new_dim[0].inner(), 2);
+            assert_eq!(new_dim[1].inner(), 3);
+            assert_eq!(new_dim.len(), 2);
+        }
     }
 }

--- a/extendr-api/src/wrapper/array.rs
+++ b/extendr-api/src/wrapper/array.rs
@@ -440,9 +440,7 @@ fn new_array() {
         let dim = [2,3];
         let array = RArray::new_array(slice, dim).unwrap();
         assert_eq!(array.data().len(), 6);
-        println!("{:?}", array);
         let robj = r!(array);
-        println!("{:?}", robj);
         assert_eq!(robj.is_array(), true);
         assert_eq!(robj.nrows(), 2);
         assert_eq!(robj.ncols(), 3);

--- a/extendr-api/src/wrapper/mod.rs
+++ b/extendr-api/src/wrapper/mod.rs
@@ -34,7 +34,7 @@ pub use altrep::{
     AltComplexImpl, AltIntegerImpl, AltLogicalImpl, AltRawImpl, AltRealImpl, AltStringImpl, Altrep,
     AltrepImpl,
 };
-pub use array::{MatrixConversions, RArray, RArray3D, RColumn, RMatrix};
+pub use array::{RArray, RMatrix};
 pub use complexes::Complexes;
 pub use dataframe::{Dataframe, IntoDataFrameRow};
 pub use doubles::Doubles;

--- a/extendr-api/src/wrapper/mod.rs
+++ b/extendr-api/src/wrapper/mod.rs
@@ -6,6 +6,7 @@ use crate::*;
 use libR_sys::*;
 
 pub mod altrep;
+pub mod array;
 pub mod complexes;
 pub mod dataframe;
 pub mod doubles;
@@ -18,7 +19,6 @@ pub mod lang;
 pub mod list;
 pub mod logicals;
 mod macros;
-pub mod matrix;
 pub mod nullable;
 pub mod pairlist;
 pub mod primitive;
@@ -34,6 +34,7 @@ pub use altrep::{
     AltComplexImpl, AltIntegerImpl, AltLogicalImpl, AltRawImpl, AltRealImpl, AltStringImpl, Altrep,
     AltrepImpl,
 };
+pub use array::{MatrixConversions, RArray, RArray3D, RColumn, RMatrix};
 pub use complexes::Complexes;
 pub use dataframe::{Dataframe, IntoDataFrameRow};
 pub use doubles::Doubles;
@@ -45,7 +46,6 @@ pub use integers::Integers;
 pub use lang::Language;
 pub use list::{FromList, List, ListIter};
 pub use logicals::Logicals;
-pub use matrix::{MatrixConversions, RArray, RColumn, RMatrix, RMatrix3D};
 pub use nullable::Nullable;
 pub use pairlist::{Pairlist, PairlistIter};
 pub use primitive::Primitive;

--- a/extendr-api/src/wrapper/strings.rs
+++ b/extendr-api/src/wrapper/strings.rs
@@ -109,7 +109,7 @@ impl<T: AsRef<str>> FromIterator<T> for Strings {
         let iter_collect: Vec<_> = iter.into_iter().collect();
         let len = iter_collect.len();
 
-        let mut robj = Strings::alloc_vector(STRSXP, len);
+        let robj = Strings::alloc_vector(STRSXP, len);
         crate::single_threaded(|| unsafe {
             for (i, v) in iter_collect.into_iter().enumerate() {
                 SET_STRING_ELT(robj.get(), i as isize, str_to_character(v.as_ref()));


### PR DESCRIPTION
I have been using `RArray` for some time so I made changes that I think will make its use easier for an inexperienced user.
So this PR is an `RArray` rebuild, making it easier to create an `RArray` and also removing `RColumn` and `RMatrix3D`, which I don't think make that much sense.
`collect_rarray` now also accepts dynamic arguments like `Vec`.