### PR TITLE
[internal] Add CLI tool for extendr developers

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+
+[alias]
+xtask = "run --package xtask --"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,2 @@
-
 [alias]
-xtask = "run --package xtask --"
+extendr = "run --package xtask --"

--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,4 @@
 extendr.Rproj
 tests/extendrtests.Rcheck/
 tests/extendrtests_0.1.0.tar.gz
-**/.cargo/*
 .vscode/settings.json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,23 @@
 [workspace]
 resolver = "2"
 
-members = ["extendr-api", "extendr-engine", "extendr-macros"]
+members = ["extendr-api", "extendr-engine", "extendr-macros", "xtask"]
+
+[workspace.package]
+version = "0.4.0"
+authors = [
+    "andy-thomason <andy@andythomason.com>",
+    "Thomas Down",
+    "Mossa Merhi Reimert <mossa@sund.ku.dk>",
+    "Claus O. Wilke <wilke@austin.utexas.edu>",
+    "Hiroaki Yutani",
+    "Ilia A. Kosenkov <ilia.kosenkov@outlook.com>",
+    "Michael Milton <michael.r.milton@gmail.com>",
+]
+edition = "2021"
+license = "MIT"
+repository = "https://github.com/extendr/extendr"
+rust-version = "1.60"
 
 [workspace.dependencies]
 libR-sys = "0.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 members = ["extendr-api", "extendr-engine", "extendr-macros", "xtask"]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.6.0"
 authors = [
     "andy-thomason <andy@andythomason.com>",
     "Thomas Down",
@@ -18,21 +18,6 @@ edition = "2021"
 license = "MIT"
 repository = "https://github.com/extendr/extendr"
 rust-version = "1.60"
-
-[workspace.package]
-version = "0.6.0"
-repository = "https://github.com/extendr/extendr"
-license = "MIT"
-authors = [
-    "andy-thomason <andy@andythomason.com>",
-    "Thomas Down",
-    "Mossa Merhi Reimert <mossa@sund.ku.dk>",
-    "Claus O. Wilke <wilke@austin.utexas.edu>",
-    "Hiroaki Yutani",
-    "Ilia A. Kosenkov <ilia.kosenkov@outlook.com>",
-    "Michael Milton <michael.r.milton@gmail.com>",
-]
-edition = "2021"
 
 [workspace.dependencies]
 # When updating extendr's version, this version also needs to be updated

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "xtask"
+description = "Facilitates extendr-developer tasks through `cargo`"
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+xshell = "*"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -13,4 +13,5 @@ publish = false
 
 [dependencies]
 clap = { version = "4.4.6", features = ["derive"] }
+toml_edit = "0.20.2"
 xshell = "*"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -9,9 +9,7 @@ edition.workspace = true
 authors.workspace = true
 publish = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 clap = { version = "4.4.6", features = ["derive"] }
 toml_edit = "0.20.2"
-xshell = "*"
+xshell = "0.2.5"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -12,4 +12,5 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = { version = "4.4.6", features = ["derive"] }
 xshell = "*"

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -5,10 +5,10 @@ one can use this tool. In the future, `xtask` will be renamed `ci`, when it can
 perform all the tasks, that our custom CI scripts can do at the moment.
 
 ```shell
-cargo xtask CMD
+cargo extendr CMD
 ```
 
-Running `cargo xtask --help` yields:
+Running `cargo extendr --help` yields:
 
 ```shell
 Facilitates extendr-developer tasks through `cargo`
@@ -59,7 +59,7 @@ use the embedded `extendr/libR-sys`.
 
 ### Copy R-headers
 
-Copy R's C-headers to the current `extendr`-directory. 
+Copy R's C-headers to the current `extendr`-directory.
 
 This helps with researching specific things, and mainly interesting for developers.
 

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -1,0 +1,11 @@
+# `extendr` developer commands
+
+## [NA] Addd `libgcc_eh` for Windows
+
+Hang up is that once a linker is set, and the linker on Windows needing
+the presence of certain files to work, then the `xtask` doesn't compile,
+thus unable to provide those necessary files.
+
+## Credits
+
+Following [`xtask`](https://github.com/matklad/cargo-xtask) template.

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -1,5 +1,14 @@
 # `extendr` developer commands
 
+```shell
+cargo xtask CMD
+```
+
+Options for `CMD`:
+
+- [ ] `doc`: Generates documentation as seen on [/extendr.github.io](https://extendr.github.io/extendr/extendr_api/)
+- 
+
 ## [NA] Addd `libgcc_eh` for Windows
 
 Hang up is that once a linker is set, and the linker on Windows needing

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -1,18 +1,72 @@
-# `extendr` developer commands
+# `extendr` developer tools
+
+In order to perform integration test (with R), generate documentation, etc.,
+one can use this tool. In the future, `xtask` will be renamed `ci`, when it can
+perform all the tasks, that our custom CI scripts can do at the moment.
 
 ```shell
 cargo xtask CMD
 ```
 
-Options for `CMD`:
+Running `cargo xtask --help` yields:
 
-- [ ] `check_fmt`
-- [ ] `test_with_r`: Runs `R CMD check` and `testthat` tests in `tests/extendrtests`.
-- [ ] `doc`: Generates documentation as seen on [/extendr.github.io](https://extendr.github.io/extendr/extendr_api/)
-- [ ] `headers`: Copy R's C-headers to working directory
+```shell
+Facilitates extendr-developer tasks through `cargo`
 
+Usage: xtask <COMMAND>
 
-## [NA] Windows: Add `libgcc_eh` and `libgcc_s.a`
+Commands:
+  check-fmt      Run cargo fmt on extendr
+  r-cmd-check    Run R CMD check on {extendrtests}
+  doc            Generate documentation for all features
+  msrv           Check that the specified rust-version is MSRV
+  devtools-test  Run devtools::test() on {extendrtests}
+  help           Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help     Print help
+  -V, --version  Print version
+```
+
+Let's describe some of the features listed above.
+
+## `check-fmt`
+
+This checks if the rust code follows the specified `rustfmt`. It does not
+format the code. In order to do so, please run `cargo fmt`.
+
+## `devtools-test`
+
+This performs `devtools::test()` in R, within the R-package `tests/extendrtests`.
+
+## `r-cmd-check`
+
+Runs `R CMD check` tests in `tests/extendrtests`.
+
+## `doc`
+
+Generates documentation as seen on [/extendr.github.io](https://extendr.github.io/extendr/extendr_api/), meaning it will enable feature `full-functionality`,
+which includes all the optional dependencies, plus all the additive features.
+
+## TODO
+
+In the following are features that could be added to `xtask`.
+
+### Embed local `libR-sys`
+
+Clone `libR-sys` into `extendr/libR-sys`. Change the `extendr/Cargo.toml` to
+use the embedded `extendr/libR-sys`.
+
+### Copy R-headers
+
+Copy R's C-headers to the current `extendr`-directory. 
+
+This helps with researching specific things, and mainly interesting for developers.
+
+### Windows-specific: Add `libgcc_eh.a` and `libgcc_s.a`
+
+On Windows, and due to specific Rust internal settings, we need to generate
+empty `libgcc_eh.a`, and `libgcc_s.a` files in order to satisfy the linker.
 
 Hang up is that once a linker is set, and the linker on Windows needing
 the presence of certain files to work, then the `xtask` doesn't compile,

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -6,10 +6,13 @@ cargo xtask CMD
 
 Options for `CMD`:
 
+- [ ] `check_fmt`
+- [ ] `test_with_r`: Runs `R CMD check` and `testthat` tests in `tests/extendrtests`.
 - [ ] `doc`: Generates documentation as seen on [/extendr.github.io](https://extendr.github.io/extendr/extendr_api/)
-- 
+- [ ] `headers`: Copy R's C-headers to working directory
 
-## [NA] Addd `libgcc_eh` for Windows
+
+## [NA] Windows: Add `libgcc_eh` and `libgcc_s.a`
 
 Hang up is that once a linker is set, and the linker on Windows needing
 the presence of certain files to work, then the `xtask` doesn't compile,

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -1,0 +1,32 @@
+use clap::{Args, Parser, Subcommand};
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+pub(crate) struct Cli {
+    #[command(subcommand)]
+    pub(crate) command: Commands,
+}
+
+#[derive(Subcommand, Debug)]
+pub(crate) enum Commands {
+    #[command(about = "Run cargo fmt on extendr")]
+    CheckFmt,
+    #[command(about = "Run R CMD check on {extendrtests}")]
+    RCmdCheck(RCmdCheckArg),
+    #[command(about = "Generate docs")]
+    Doc,
+    #[command(about = "???")]
+    Msrv,
+    #[command(about = "Run devtools::test() on {extendrtests}")]
+    DevtoolsTest,
+}
+
+#[derive(Args, Debug)]
+pub(crate) struct RCmdCheckArg {
+    #[arg(long, default_value = "false", help = "Passed to R CMD check")]
+    pub(crate) no_build_vignettes: bool,
+}
+
+pub(crate) fn parse() -> Cli {
+    Cli::parse()
+}

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -13,9 +13,9 @@ pub(crate) enum Commands {
     CheckFmt,
     #[command(about = "Run R CMD check on {extendrtests}")]
     RCmdCheck(RCmdCheckArg),
-    #[command(about = "Generate docs")]
+    #[command(about = "Generate documentation for all features")]
     Doc,
-    #[command(about = "???")]
+    #[command(about = "Check that the specified rust-version is MSRV")]
     Msrv,
     #[command(about = "Run devtools::test() on {extendrtests}")]
     DevtoolsTest,

--- a/xtask/src/commands/cargo_fmt_check.rs
+++ b/xtask/src/commands/cargo_fmt_check.rs
@@ -1,5 +1,12 @@
 use xshell::{cmd, Error, Shell};
 
 pub(crate) fn run(shell: &Shell) -> Result<(), Error> {
-    cmd!(shell, "cargo fmt -- --check").run()
+    let check_result = cmd!(shell, "cargo fmt -- --check").run();
+    if check_result.is_err() {
+        println!("Please run `cargo fmt --all`");
+    } else {
+        println!("Success!");
+    }
+
+    check_result
 }

--- a/xtask/src/commands/cargo_fmt_check.rs
+++ b/xtask/src/commands/cargo_fmt_check.rs
@@ -1,0 +1,5 @@
+use xshell::{cmd, Error, Shell};
+
+pub(crate) fn run(shell: &Shell) -> Result<(), Error> {
+    cmd!(shell, "cargo fmt -- --check").run()
+}

--- a/xtask/src/commands/cargo_msrv.rs
+++ b/xtask/src/commands/cargo_msrv.rs
@@ -3,7 +3,7 @@ use xshell::{cmd, Error, Shell};
 pub(crate) fn run(shell: &Shell) -> Result<(), Error> {
     let msrv = cmd!(shell, "cargo-msrv --path extendr-api verify").run();
     if msrv.is_err() {
-        println!("Cannot perform `cargo-msrv` check\nInstall `cargo-msrv" by `cargo install cargo-msrv`);
+        println!("Cannot perform `cargo-msrv` check\nInstall `cargo-msrv` by `cargo install cargo-msrv`");
     }
     msrv
 }

--- a/xtask/src/commands/cargo_msrv.rs
+++ b/xtask/src/commands/cargo_msrv.rs
@@ -3,7 +3,9 @@ use xshell::{cmd, Error, Shell};
 pub(crate) fn run(shell: &Shell) -> Result<(), Error> {
     let msrv = cmd!(shell, "cargo-msrv --path extendr-api verify").run();
     if msrv.is_err() {
-        println!("Cannot perform `cargo-msrv` check\nInstall `cargo-msrv` by `cargo install cargo-msrv`");
+        println!(
+            "Cannot perform `cargo-msrv` check\nInstall `cargo-msrv` by `cargo install cargo-msrv`"
+        );
     }
     msrv
 }

--- a/xtask/src/commands/cargo_msrv.rs
+++ b/xtask/src/commands/cargo_msrv.rs
@@ -1,0 +1,18 @@
+use xshell::{Error, Shell};
+
+pub(crate) fn run(_shell: &Shell) -> Result<(), Error> {
+    // let msrv = cmd!(shell, "cargo-msrv --path extendr-api/ verify");
+    // match msrv.run() {
+    //     Ok(_) => {}
+    //     Err(error) => {
+    //         //FIXME: Displays badly
+    //         return Err(format!(
+    //             "{}\n\nInstall `cargo-msrv` by `cargo install cargo-msrv`",
+    //             error.to_string()
+    //         )
+    //         .into());
+    //     }
+    // }
+    //
+    unimplemented!("cargo-msrv --path extendr-api")
+}

--- a/xtask/src/commands/cargo_msrv.rs
+++ b/xtask/src/commands/cargo_msrv.rs
@@ -1,18 +1,9 @@
-use xshell::{Error, Shell};
+use xshell::{cmd, Error, Shell};
 
-pub(crate) fn run(_shell: &Shell) -> Result<(), Error> {
-    // let msrv = cmd!(shell, "cargo-msrv --path extendr-api/ verify");
-    // match msrv.run() {
-    //     Ok(_) => {}
-    //     Err(error) => {
-    //         //FIXME: Displays badly
-    //         return Err(format!(
-    //             "{}\n\nInstall `cargo-msrv` by `cargo install cargo-msrv`",
-    //             error.to_string()
-    //         )
-    //         .into());
-    //     }
-    // }
-    //
-    unimplemented!("cargo-msrv --path extendr-api")
+pub(crate) fn run(shell: &Shell) -> Result<(), Error> {
+    let msrv = cmd!(shell, "cargo-msrv --path extendr-api verify").run();
+    if msrv.is_err() {
+        println!("Cannot perform `cargo-msrv` check\nInstall `cargo-msrv" by `cargo install cargo-msrv`);
+    }
+    msrv
 }

--- a/xtask/src/commands/devtools_test.rs
+++ b/xtask/src/commands/devtools_test.rs
@@ -1,10 +1,113 @@
-use xshell::{Error, Shell};
+use std::error::Error;
+use std::path::{Path, PathBuf};
 
-pub(crate) fn run(_shell: &Shell) -> Result<(), Error> {
-    // {
-    //     let _ = shell.push_dir(shell.current_dir().join("tests").join("extendrtests"));
-    //     let extendrtests = cmd!(shell, "R -e \"devtools::test()\" ").run()?;
-    // }
+use toml_edit::{Document, InlineTable, Value};
+use xshell::Shell;
 
-    unreachable!("devtools::test()")
+const RUST_FOLDER_PATH: &str = "tests/extendrtests/src/rust";
+const R_FOLDER_PATH: &str = "tests/extendrtests";
+const CARGO_TOML: &str = "Cargo.toml";
+
+pub(crate) fn run(shell: &Shell) -> Result<(), Box<dyn Error>> {
+    let _document_handle = swap_extendr_api_path(&shell)?;
+
+    run_tests(&shell)?;
+
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct DocumentHandle<'a> {
+    document: Document,
+    is_crlf: bool,
+    shell: &'a Shell,
+}
+
+impl<'a> Drop for DocumentHandle<'a> {
+    fn drop(&mut self) {
+        let _rust_folder = self.shell.push_dir(RUST_FOLDER_PATH);
+        write_file_preserve_line_ending(&self.shell, CARGO_TOML, &self.document, self.is_crlf)
+            .expect("Failed to restore Cargo.toml");
+    }
+}
+
+fn run_tests(shell: &Shell) -> Result<(), Box<dyn Error>> {
+    let _r_path = shell.push_dir(R_FOLDER_PATH);
+    shell
+        .cmd("Rscript")
+        .arg("-e")
+        .arg("devtools::test()")
+        .run()?;
+
+    Ok(())
+}
+
+fn swap_extendr_api_path(shell: &Shell) -> Result<DocumentHandle, Box<dyn Error>> {
+    let current_path = shell.current_dir();
+    let _rust_folder = shell.push_dir(RUST_FOLDER_PATH);
+
+    let (original_cargo_toml, is_crlf) = read_file_with_line_ending(&shell, CARGO_TOML)?;
+
+    let original_cargo_toml: Document = original_cargo_toml.parse()?;
+
+    let mut cargo_toml = original_cargo_toml.clone();
+
+    let extendr_api_entry =
+        get_extendr_api_entry(&mut cargo_toml).ok_or("`extendr-api` not found in Cargo.toml")?;
+
+    let mut replacement = InlineTable::new();
+
+    let item = Value::from(get_replacement_path(&current_path));
+    replacement.entry("path").or_insert(item);
+    *extendr_api_entry = Value::InlineTable(replacement);
+
+    write_file_preserve_line_ending(&shell, CARGO_TOML, &cargo_toml, is_crlf)?;
+    Ok(DocumentHandle {
+        document: original_cargo_toml,
+        is_crlf,
+        shell,
+    })
+}
+
+fn get_replacement_path(path: &PathBuf) -> String {
+    let path = path.to_string_lossy();
+    let path = if cfg!(target_os = "windows") && path.starts_with(r"\\?\") {
+        path[4..].replace("\\", "/")
+    } else {
+        path.to_string()
+    };
+
+    format!("{}/extendr-api", path)
+}
+
+fn get_extendr_api_entry(document: &mut Document) -> Option<&mut Value> {
+    document
+        .get_mut("patch")?
+        .get_mut("crates-io")?
+        .get_mut("extendr-api")?
+        .as_value_mut()
+}
+
+fn read_file_with_line_ending<P: AsRef<Path>>(
+    shell: &Shell,
+    path: P,
+) -> Result<(String, bool), Box<dyn Error>> {
+    let file_contents = shell.read_binary_file(path)?;
+    let file_contents = String::from_utf8(file_contents)?;
+    let is_crlf = file_contents.contains("\r\n");
+    Ok((file_contents, is_crlf))
+}
+
+fn write_file_preserve_line_ending<P: AsRef<Path>>(
+    shell: &Shell,
+    path: P,
+    contents: &Document,
+    is_crlf: bool,
+) -> Result<(), Box<dyn Error>> {
+    let mut file_contents = contents.to_string();
+    if is_crlf {
+        file_contents = file_contents.replace("\n", "\r\n");
+    }
+    shell.write_file(path, file_contents)?;
+    Ok(())
 }

--- a/xtask/src/commands/devtools_test.rs
+++ b/xtask/src/commands/devtools_test.rs
@@ -1,0 +1,10 @@
+use xshell::{Error, Shell};
+
+pub(crate) fn run(_shell: &Shell) -> Result<(), Error> {
+    // {
+    //     let _ = shell.push_dir(shell.current_dir().join("tests").join("extendrtests"));
+    //     let extendrtests = cmd!(shell, "R -e \"devtools::test()\" ").run()?;
+    // }
+
+    unreachable!("devtools::test()")
+}

--- a/xtask/src/commands/generate_docs.rs
+++ b/xtask/src/commands/generate_docs.rs
@@ -1,10 +1,11 @@
-use xshell::{Error, Shell, cmd};
+use xshell::{cmd, Error, Shell};
 
 pub(crate) fn run(shell: &Shell) -> Result<(), Error> {
     let _generate_docs = cmd!(
         shell,
         "cargo doc --workspace --no-deps --document-private-items --features full-functionality"
-    ).run()?;
+    )
+    .run()?;
 
     Ok(())
 }

--- a/xtask/src/commands/generate_docs.rs
+++ b/xtask/src/commands/generate_docs.rs
@@ -1,0 +1,11 @@
+use xshell::{Error, Shell};
+
+pub(crate) fn run(_shell: &Shell) -> Result<(), Error> {
+    // let generate_docs = cmd!(
+    //     shell,
+    //     "cargo doc --workspace --no-deps --document-private-items --features full-functionality"
+    // )
+    unimplemented!(
+        "cargo doc --workspace --no-deps --document-private-items --features full-functionality"
+    )
+}

--- a/xtask/src/commands/generate_docs.rs
+++ b/xtask/src/commands/generate_docs.rs
@@ -1,11 +1,10 @@
-use xshell::{Error, Shell};
+use xshell::{Error, Shell, cmd};
 
-pub(crate) fn run(_shell: &Shell) -> Result<(), Error> {
-    // let generate_docs = cmd!(
-    //     shell,
-    //     "cargo doc --workspace --no-deps --document-private-items --features full-functionality"
-    // )
-    unimplemented!(
+pub(crate) fn run(shell: &Shell) -> Result<(), Error> {
+    let _generate_docs = cmd!(
+        shell,
         "cargo doc --workspace --no-deps --document-private-items --features full-functionality"
-    )
+    ).run()?;
+
+    Ok(())
 }

--- a/xtask/src/commands/mod.rs
+++ b/xtask/src/commands/mod.rs
@@ -1,0 +1,5 @@
+pub(crate) mod cargo_fmt_check;
+pub(crate) mod cargo_msrv;
+pub(crate) mod devtools_test;
+pub(crate) mod generate_docs;
+pub(crate) mod r_cmd_check;

--- a/xtask/src/commands/r_cmd_check.rs
+++ b/xtask/src/commands/r_cmd_check.rs
@@ -1,0 +1,17 @@
+use xshell::{Error, Shell};
+
+pub(crate) fn run(shell: &Shell, no_build_vignettes: bool) -> Result<(), Error> {
+    let mut cmd = shell
+        .cmd("R")
+        .arg("CMD")
+        .arg("check")
+        .arg("tests/extendrtests")
+        .arg("--no-manual")
+        .arg("--as-cran")
+        .arg("--force-multiarch");
+
+    if no_build_vignettes {
+        cmd = cmd.arg("--no-build-vignettes");
+    }
+    cmd.run()
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,3 +1,14 @@
-fn main() {
-    println!("Hello, world!");
+use xshell::{cmd, Shell};
+
+
+fn main() -> Result<(), Box<dyn std::error::Error>>{
+    let shell = Shell::new()?;
+    let generate_docs = cmd!(
+        shell,
+        "cargo doc --workspace --no-deps --document-private-items --features full-functionality"
+    );
+
+    generate_docs.run()?;
+
+    Ok(())
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,42 +1,28 @@
-use xshell::{cmd, Shell};
+use xshell::Shell;
+
+use crate::cli::RCmdCheckArg;
+
+mod cli;
+mod commands;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cli = cli::parse();
     let shell = Shell::new()?;
+
     // xtask
     // shell.change_dir(std::env::var("CARGO_MANIFEST_DIR")?);
     // dbg!(&shell.current_dir());
-    let generate_docs = cmd!(
-        shell,
-        "cargo doc --workspace --no-deps --document-private-items --features full-functionality"
-    )
-    .run()?;
-    {
-        let _ = shell.push_dir(shell.current_dir().join("tests").join("extendrtests"));
-        let extendrtests = cmd!(shell, "R -e \"devtools::test()\" ").run()?;
-    }
+    dbg! {&cli};
 
-    //TODO: Add option for `--no-build-vignettes`
-
-    let rcmdcheck_extendrtests = cmd!(
-        shell,
-        "R CMD check --no-manual --as-cran --force-multiarch tests/extendrtests"
-    )
-    .run()?;
-
-    let fmt_check = cmd!(shell, "cargo fmt -- --check").run()?;
-
-    let msrv = cmd!(shell, "cargo-msrv --path extendr-api/ verify");
-    match msrv.run() {
-        Ok(_) => {}
-        Err(error) => {
-            //FIXME: Displays badly
-            return Err(format!(
-                "{}\n\nInstall `cargo-msrv` by `cargo install cargo-msrv`",
-                error.to_string()
-            )
-            .into());
+    let result = match cli.command {
+        cli::Commands::CheckFmt => commands::cargo_fmt_check::run(&shell)?,
+        cli::Commands::RCmdCheck(RCmdCheckArg { no_build_vignettes }) => {
+            commands::r_cmd_check::run(&shell, no_build_vignettes)?
         }
-    }
+        cli::Commands::Doc => commands::generate_docs::run(&shell)?,
+        cli::Commands::Msrv => commands::cargo_msrv::run(&shell)?,
+        cli::Commands::DevtoolsTest => commands::devtools_test::run(&shell)?,
+    };
 
-    Ok(())
+    Ok(result)
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,8 +1,8 @@
+use crate::cli::RCmdCheckArg;
+
 use std::path::PathBuf;
 
 use xshell::Shell;
-
-use crate::cli::RCmdCheckArg;
 
 mod cli;
 mod commands;
@@ -19,9 +19,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .canonicalize()?,
     );
 
-    dbg!(&shell.current_dir());
-
-    dbg! {&cli};
+    // dbg!(&shell.current_dir());
+    // dbg! {&cli};
 
     let result = match cli.command {
         cli::Commands::CheckFmt => commands::cargo_fmt_check::run(&shell)?,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -17,8 +17,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     //TODO: Add option for `--no-build-vignettes`
 
-    let rcmdcheck_extendrtests =
-        cmd!(shell, "R CMD check --no-manual --as-cran --force-multiarch tests/extendrtests").run()?;
+    let rcmdcheck_extendrtests = cmd!(
+        shell,
+        "R CMD check --no-manual --as-cran --force-multiarch tests/extendrtests"
+    )
+    .run()?;
 
     let fmt_check = cmd!(shell, "cargo fmt -- --check").run()?;
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // dbg!(&shell.current_dir());
     // dbg! {&cli};
 
-    let result = match cli.command {
+    match cli.command {
         cli::Commands::CheckFmt => commands::cargo_fmt_check::run(&shell)?,
         cli::Commands::RCmdCheck(RCmdCheckArg { no_build_vignettes }) => {
             commands::r_cmd_check::run(&shell, no_build_vignettes)?
@@ -32,5 +32,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         cli::Commands::DevtoolsTest => commands::devtools_test::run(&shell)?,
     };
 
-    Ok(result)
+    Ok(())
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,14 +1,39 @@
 use xshell::{cmd, Shell};
 
-
-fn main() -> Result<(), Box<dyn std::error::Error>>{
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let shell = Shell::new()?;
+    // xtask
+    // shell.change_dir(std::env::var("CARGO_MANIFEST_DIR")?);
+    // dbg!(&shell.current_dir());
     let generate_docs = cmd!(
         shell,
         "cargo doc --workspace --no-deps --document-private-items --features full-functionality"
-    );
+    )
+    .run()?;
+    {
+        let _ = shell.push_dir(shell.current_dir().join("tests").join("extendrtests"));
+        let extendrtests = cmd!(shell, "R -e \"devtools::test()\" ").run()?;
+    }
 
-    generate_docs.run()?;
+    //TODO: Add option for `--no-build-vignettes`
+
+    let rcmdcheck_extendrtests =
+        cmd!(shell, "R CMD check --no-manual --as-cran --force-multiarch tests/extendrtests").run()?;
+
+    let fmt_check = cmd!(shell, "cargo fmt -- --check").run()?;
+
+    let msrv = cmd!(shell, "cargo-msrv --path extendr-api/ verify");
+    match msrv.run() {
+        Ok(_) => {}
+        Err(error) => {
+            //FIXME: Displays badly
+            return Err(format!(
+                "{}\n\nInstall `cargo-msrv` by `cargo install cargo-msrv`",
+                error.to_string()
+            )
+            .into());
+        }
+    }
 
     Ok(())
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use xshell::Shell;
 
 use crate::cli::RCmdCheckArg;
@@ -9,9 +11,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = cli::parse();
     let shell = Shell::new()?;
 
-    // xtask
-    // shell.change_dir(std::env::var("CARGO_MANIFEST_DIR")?);
-    // dbg!(&shell.current_dir());
+    let path: PathBuf = std::env::var("CARGO_MANIFEST_DIR")?.parse()?;
+
+    shell.change_dir(
+        path.parent()
+            .ok_or("Failed to get parent dir")?
+            .canonicalize()?,
+    );
+
+    dbg!(&shell.current_dir());
+
     dbg! {&cli};
 
     let result = match cli.command {


### PR DESCRIPTION
We should have an [`xtask`](https://github.com/matklad/cargo-xtask).

There are many idiosyncracies with being and `extendr`-developer (not user, although...) and it is about time we solved some of our issues with rust (read: `cargo`).

I'd like to develop this in the open, so please give me your suggestions,
and I can see if I've a prototype for it somewhere that would
do the job.
