### PR TITLE
Use once_cell instead of lazy_static

### DIFF
--- a/extendr-api/Cargo.toml
+++ b/extendr-api/Cargo.toml
@@ -18,9 +18,9 @@ rust-version = "1.60"
 
 [dependencies]
 libR-sys = { workspace = true }
-extendr-macros = { path = "../extendr-macros", version="0.4.0" }
-extendr-engine = { path = "../extendr-engine", version="0.4.0" }
-lazy_static = "1.4"
+extendr-macros = { path = "../extendr-macros", version = "0.4.0" }
+extendr-engine = { path = "../extendr-engine", version = "0.4.0" }
+once_cell = "1"
 paste = "1.0.5"
 either = { version = "1.8.1", optional = true }
 libc = { version = "0.2", optional = true }

--- a/extendr-api/src/na.rs
+++ b/extendr-api/src/na.rs
@@ -1,27 +1,25 @@
-use lazy_static::lazy_static;
 use libR_sys::{R_IsNA, R_NaReal};
+use once_cell::sync::Lazy;
 use std::alloc::{self, Layout};
 
 // To make sure this "NA" is allocated at a different place than any other "NA"
 // strings (so that it can be used as a sentinel value), we allocate it by
 // ourselves.
-lazy_static! {
-    static ref EXTENDR_NA_STRING: &'static str = unsafe {
-        // Layout::array() can fail when the size exceeds `isize::MAX`, but we
-        // only need 2 here, so it's safe to unwrap().
-        let layout = Layout::array::<u8>(2).unwrap();
+static EXTENDR_NA_STRING: Lazy<&'static str> = Lazy::new(|| unsafe {
+    // Layout::array() can fail when the size exceeds `isize::MAX`, but we
+    // only need 2 here, so it's safe to unwrap().
+    let layout = Layout::array::<u8>(2).unwrap();
 
-        // We allocate and never free it because we need this pointer to be
-        // alive until the program ends.
-        let ptr = alloc::alloc(layout);
+    // We allocate and never free it because we need this pointer to be
+    // alive until the program ends.
+    let ptr = alloc::alloc(layout);
 
-        let v: &mut [u8] = std::slice::from_raw_parts_mut(ptr, 2);
-        v[0] = b'N';
-        v[1] = b'A';
+    let v: &mut [u8] = std::slice::from_raw_parts_mut(ptr, 2);
+    v[0] = b'N';
+    v[1] = b'A';
 
-        std::str::from_utf8_unchecked(v)
-    };
-}
+    std::str::from_utf8_unchecked(v)
+});
 
 /// Return true if this primitive is `NA`.
 pub trait CanBeNA {

--- a/extendr-api/src/ownership.rs
+++ b/extendr-api/src/ownership.rs
@@ -8,7 +8,7 @@
 //!
 //! This module exports two functions, protect(sexp) and unprotect(sexp).
 
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use std::collections::hash_map::{Entry, HashMap};
 use std::sync::Mutex;
 
@@ -17,9 +17,7 @@ use libR_sys::{
     Rf_unprotect, LENGTH, SET_VECTOR_ELT, SEXP, VECSXP, VECTOR_ELT,
 };
 
-lazy_static! {
-    static ref OWNERSHIP: Mutex<Ownership> = Mutex::new(Ownership::new());
-}
+static OWNERSHIP: Lazy<Mutex<Ownership>> = Lazy::new(|| Mutex::new(Ownership::new()));
 
 pub(crate) unsafe fn protect(sexp: SEXP) {
     let mut own = OWNERSHIP.lock().expect("protect failed");

--- a/extendr-api/tests/externalptr_tests.rs
+++ b/extendr-api/tests/externalptr_tests.rs
@@ -1,5 +1,5 @@
 use extendr_api::prelude::*;
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 
 #[test]
 fn test_externalptr() {
@@ -16,9 +16,7 @@ fn test_externalptr() {
 fn test_externalptr_drop() {
     test! {
         // This flag will get set when we do the drop.
-        lazy_static! {
-            static ref Z : std::sync::Mutex<bool> = std::sync::Mutex::new(false);
-        }
+        static Z : Lazy<std::sync::Mutex<bool>> = Lazy::new(|| std::sync::Mutex::new(false));
 
         // Dummy structure that will show if we drop correctly.
         #[derive(Debug)]


### PR DESCRIPTION
Close #579 

As I described on #579, it seems the lazy_static crate is going to be deprecated (https://github.com/rust-lang-nursery/lazy-static.rs/issues/214) and the implementation based on once_cell is getting stabilized in std. It's not that the lazy-static will become unusable soon, so this isn't very urgent.