### PR TITLE
[DO NOT MERGE THIS] Altrep test failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- `ALTLIST` support allowing users to represent structs as R list objects
 - [**either**] `TryFrom<&Robj> for Either<T, R>` and `From<Either<T, R>> for Robj` if `T` and `R` are themselves implement these traits. This unblocks scenarios like accepting any numeric vector from R via `Either<Integers, Doubles>` without extra memory allocation [[#480]](https://github.com/extendr/extendr/pull/480)
 - `PartialOrd` trait implementation for `Rfloat`, `Rint` and `Rbool`. `Rfloat` and `Rint` gained `min()` and `max()` methods [[#573]](https://github.com/extendr/extendr/pull/573)
 - `use_rng` option for the `extendr` attribute macro, which enables the use of

--- a/extendr-api/build.rs
+++ b/extendr-api/build.rs
@@ -26,4 +26,8 @@ fn main() {
     if &*major >= "4" && &*minor >= "2" {
         println!("cargo:rustc-cfg=use_r_ge_version_15");
     }
+
+    if &*major >= "4" && &*minor >= "3" {
+        println!("cargo:rustc-cfg=use_r_altlist");
+    }
 }

--- a/extendr-api/src/robj/rinternals.rs
+++ b/extendr-api/src/robj/rinternals.rs
@@ -471,6 +471,12 @@ pub trait Rinternals: Types + Conversions {
         unsafe { ALTREP(self.get()) != 0 && TYPEOF(self.get()) == STRSXP as i32 }
     }
 
+    /// Returns `true` if this is an integer ALTREP object.
+    #[cfg(use_r_altlist)]
+    fn is_altlist(&self) -> bool {
+        unsafe { ALTREP(self.get()) != 0 && TYPEOF(self.get()) == VECSXP as i32 }
+    }
+
     /// Generate a text representation of this object.
     fn deparse(&self) -> Result<String> {
         use crate as extendr_api;

--- a/extendr-api/src/wrapper/altrep.rs
+++ b/extendr-api/src/wrapper/altrep.rs
@@ -500,7 +500,7 @@ impl Altrep {
             use std::os::raw::c_void;
 
             unsafe extern "C" fn finalizer<StateType: 'static>(x: SEXP) {
-                let state = Altrep::get_state_mut::<StateType>(x);
+                let state = R_ExternalPtrAddr(x);
                 let ptr = state as *mut StateType;
                 drop(Box::from_raw(ptr));
             }
@@ -540,11 +540,7 @@ impl Altrep {
     #[allow(dead_code)]
     pub(crate) fn get_state_mut<StateType>(x: SEXP) -> &'static mut StateType {
         unsafe {
-            let sexp = R_altrep_data1(x);
-            if TYPEOF(sexp) as u32 != libR_sys::EXTPTRSXP {
-                panic!("This isn't an external pointer! (type {})", TYPEOF(sexp));
-            };
-            let state_ptr = R_ExternalPtrAddr(sexp);
+            let state_ptr = R_ExternalPtrAddr(R_altrep_data1(x));
             &mut *(state_ptr as *mut StateType)
         }
     }

--- a/extendr-api/src/wrapper/altrep.rs
+++ b/extendr-api/src/wrapper/altrep.rs
@@ -540,7 +540,11 @@ impl Altrep {
     #[allow(dead_code)]
     pub(crate) fn get_state_mut<StateType>(x: SEXP) -> &'static mut StateType {
         unsafe {
-            let state_ptr = R_ExternalPtrAddr(R_altrep_data1(x));
+            let sexp = R_altrep_data1(x);
+            if TYPEOF(sexp) as u32 != libR_sys::EXTPTRSXP {
+                panic!("This isn't an external pointer! (type {})", TYPEOF(sexp));
+            };
+            let state_ptr = R_ExternalPtrAddr(sexp);
             &mut *(state_ptr as *mut StateType)
         }
     }

--- a/extendr-api/src/wrapper/altrep.rs
+++ b/extendr-api/src/wrapper/altrep.rs
@@ -455,6 +455,16 @@ pub trait AltStringImpl {
     }
 }
 
+#[cfg(use_r_altlist)]
+pub trait AltListImpl {
+    /// Get a single element from this vector
+    /// a single element of a list can be any Robj
+    fn elt(&self, _index: usize) -> Robj;
+
+    /// Set a single element in this list.
+    fn set_elt(&mut self, _index: usize, _value: Robj) {}
+}
+
 impl Altrep {
     /// Safely implement R_altrep_data1, R_altrep_data2.
     /// When implementing Altrep classes, this gets the metadata.
@@ -656,6 +666,10 @@ impl Altrep {
                 }
                 Rtype::Strings => {
                     R_make_altstring_class(csname.as_ptr(), csbase.as_ptr(), std::ptr::null_mut())
+                }
+                #[cfg(use_r_altlist)]
+                Rtype::List => {
+                    R_make_altlist_class(csname.as_ptr(), csbase.as_ptr(), std::ptr::null_mut())
                 }
                 _ => panic!("expected Altvec compatible type"),
             };
@@ -956,7 +970,7 @@ impl Altrep {
         })
     }
 
-    /// Make a complex ALTREP class that can be used to make vectors.
+    /// Make a string ALTREP class that can be used to make vectors.
     pub fn make_altstring_class<StateType: AltrepImpl + AltStringImpl + 'static>(
         name: &str,
         base: &str,
@@ -1001,6 +1015,39 @@ impl Altrep {
             R_set_altstring_Is_sorted_method(class_ptr, Some(altstring_Is_sorted::<StateType>));
             R_set_altstring_No_NA_method(class_ptr, Some(altstring_No_NA::<StateType>));
 
+            class
+        })
+    }
+
+    #[cfg(use_r_altlist)]
+    pub fn make_altlist_class<StateType: AltrepImpl + AltListImpl + 'static>(
+        name: &str,
+        base: &str,
+    ) -> Robj {
+        #![allow(non_snake_case)]
+
+        single_threaded(|| unsafe {
+            let class = Altrep::altrep_class::<StateType>(Rtype::List, name, base);
+            let class_ptr = R_altrep_class_t { ptr: class.get() };
+
+            unsafe extern "C" fn altlist_Elt<StateType: AltListImpl + 'static>(
+                x: SEXP,
+                i: R_xlen_t,
+            ) -> SEXP {
+                Altrep::get_state::<StateType>(x).elt(i as usize).get()
+            }
+
+            unsafe extern "C" fn altlist_Set_elt<StateType: AltListImpl + 'static>(
+                x: SEXP,
+                i: R_xlen_t,
+                v: SEXP,
+            ) {
+                Altrep::get_state_mut::<StateType>(x)
+                    .set_elt(i as usize, Robj::from_sexp(v).try_into().unwrap())
+            }
+
+            R_set_altlist_Elt_method(class_ptr, Some(altlist_Elt::<StateType>));
+            R_set_altlist_Set_elt_method(class_ptr, Some(altlist_Set_elt::<StateType>));
             class
         })
     }

--- a/extendr-api/src/wrapper/mod.rs
+++ b/extendr-api/src/wrapper/mod.rs
@@ -30,6 +30,8 @@ pub mod strings;
 pub mod symbol;
 
 pub use self::rstr::Rstr;
+#[cfg(use_r_altlist)]
+pub use altrep::AltListImpl;
 pub use altrep::{
     AltComplexImpl, AltIntegerImpl, AltLogicalImpl, AltRawImpl, AltRealImpl, AltStringImpl, Altrep,
     AltrepImpl,

--- a/tests/extendrtests/R/extendr-wrappers.R
+++ b/tests/extendrtests/R/extendr-wrappers.R
@@ -122,6 +122,19 @@ leak_positive_control <- function(x) invisible(.Call(wrap__leak_positive_control
 
 leak_negative_control <- function(x) invisible(.Call(wrap__leak_negative_control, x))
 
+#' Create an ALTLIST usize vector
+#' 
+#' @param robj an integer vector 
+#' 
+#' The object is `Vec<Option<usize>>` represented as an ALTLIST
+new_usize <- function(robj) .Call(wrap__new_usize, robj)
+
+#' Test ALTSTRING representation
+tst_altstring <- function() .Call(wrap__tst_altstring)
+
+#' Test ALTINTEGER support
+tst_altinteger <- function() .Call(wrap__tst_altinteger)
+
 #' Class for testing (exported)
 #' @examples
 #' x <- MyClass$new()

--- a/tests/extendrtests/src/rust/src/altrep.rs
+++ b/tests/extendrtests/src/rust/src/altrep.rs
@@ -1,0 +1,123 @@
+use extendr_api::prelude::*;
+use extendr_api::AltListImpl;
+
+// struct contains an inner vector of Option<usize> 
+#[derive(Debug, Clone)]
+pub struct VecUsize(pub Vec<Option<usize>>);
+
+impl AltrepImpl for VecUsize {
+    fn length(&self) -> usize {
+        self.0.len()
+    }
+}
+
+// we need to be able to return an Robj of this type so 
+// we add an empty extendr macro above the impl
+#[extendr]
+impl VecUsize {}
+
+impl AltListImpl for VecUsize {
+    fn elt(&self, index: usize) -> Robj {
+        self.into_robj()
+    }
+}
+
+
+#[extendr]
+/// Create an ALTLIST usize vector
+/// 
+/// @param robj an integer vector 
+/// 
+/// The object is `Vec<Option<usize>>` represented as an ALTLIST
+/// @export
+fn new_usize(robj: Integers) -> Altrep {
+    let x = robj
+        .iter()
+        .map(|x| match &x {
+            _ if x.is_na() => None,
+            _ if x.inner() < 0 => None,
+            _ => Some(x.inner() as usize),
+        })
+        .collect();
+    
+    // we can't return the object as is, it needs to
+    // be converted to an altrep object
+    let obj = VecUsize(x);
+    // this provides a hidden class to the altrep object for the package extendrtests
+    let class = Altrep::make_altlist_class::<VecUsize>("li", "mypkg");
+
+    // create an altrep object from the class
+    Altrep::from_state_and_class(obj, class, false)
+}
+
+
+
+
+#[derive(Debug, Clone)]
+struct StringInts {
+    len: usize
+}
+
+impl AltrepImpl for StringInts {
+    fn length(&self) -> usize {
+        self.len as usize
+    }
+}
+
+impl AltStringImpl for StringInts {
+    fn elt(&self, index: usize) -> Rstr {
+        format!("{}", index).into()
+    }
+}
+
+
+#[extendr]
+/// Test ALTSTRING representation
+/// @export
+fn tst_altstring() -> Altrep {
+    let mystate = StringInts { len: 10 };
+    let class = Altrep::make_altstring_class::<StringInts>("si", "mypkg");
+    Altrep::from_state_and_class(mystate, class, false)
+}
+
+
+#[derive(Debug, Clone)]
+struct MyCompactIntRange {
+    start: i32,
+    len: i32,
+    step: i32,
+    missing_index: usize,  // For testing NA
+}
+
+impl AltrepImpl for MyCompactIntRange {
+    fn length(&self) -> usize {
+        self.len as usize
+    }
+}
+
+impl AltIntegerImpl for MyCompactIntRange {
+    fn elt(&self, index: usize) -> Rint {
+        if index == self.missing_index {
+            Rint::na()
+        } else {
+            Rint::new(self.start + self.step * index as i32)
+        }
+    }
+}
+
+
+#[extendr]
+/// Test ALTINTEGER support
+/// @export
+fn tst_altinteger() -> Altrep {
+    let mystate = MyCompactIntRange { start: 0, len: 10, step: 1, missing_index: usize::MAX };
+    let class = Altrep::make_altinteger_class::<MyCompactIntRange>("cir", "mypkg");
+    Altrep::from_state_and_class(mystate, class.clone(), false)
+}
+
+extendr_module! {
+    mod altlist;
+    fn new_usize;
+    fn tst_altstring;
+    fn tst_altinteger;
+}

--- a/tests/extendrtests/src/rust/src/altrep.rs
+++ b/tests/extendrtests/src/rust/src/altrep.rs
@@ -29,7 +29,6 @@ impl AltListImpl for VecUsize {
 /// @param robj an integer vector 
 /// 
 /// The object is `Vec<Option<usize>>` represented as an ALTLIST
-/// @export
 fn new_usize(robj: Integers) -> Altrep {
     let x = robj
         .iter()
@@ -73,7 +72,6 @@ impl AltStringImpl for StringInts {
 
 #[extendr]
 /// Test ALTSTRING representation
-/// @export
 fn tst_altstring() -> Altrep {
     let mystate = StringInts { len: 10 };
     let class = Altrep::make_altstring_class::<StringInts>("si", "mypkg");
@@ -106,17 +104,16 @@ impl AltIntegerImpl for MyCompactIntRange {
 }
 
 
-#[extendr]
 /// Test ALTINTEGER support
-/// @export
+#[extendr]
 fn tst_altinteger() -> Altrep {
     let mystate = MyCompactIntRange { start: 0, len: 10, step: 1, missing_index: usize::MAX };
     let class = Altrep::make_altinteger_class::<MyCompactIntRange>("cir", "mypkg");
-    Altrep::from_state_and_class(mystate, class.clone(), false)
+    Altrep::from_state_and_class(mystate, class, false)
 }
 
 extendr_module! {
-    mod altlist;
+    mod altrep;
     fn new_usize;
     fn tst_altstring;
     fn tst_altinteger;

--- a/tests/extendrtests/src/rust/src/lib.rs
+++ b/tests/extendrtests/src/rust/src/lib.rs
@@ -12,7 +12,7 @@ mod raw_identifiers;
 
 mod memory_leaks;
 
-// mod altrep;
+mod altrep;
 
 // Return string `"Hello world!"` to R.
 #[extendr]
@@ -365,7 +365,7 @@ extendr_module! {
     use optional_either;
     use raw_identifiers;
     use memory_leaks;
-    // use altrep;
+    use altrep;
 }
 
 

--- a/tests/extendrtests/src/rust/src/lib.rs
+++ b/tests/extendrtests/src/rust/src/lib.rs
@@ -12,6 +12,8 @@ mod raw_identifiers;
 
 mod memory_leaks;
 
+// mod altrep;
+
 // Return string `"Hello world!"` to R.
 #[extendr]
 fn hello_world() -> &'static str {
@@ -363,4 +365,7 @@ extendr_module! {
     use optional_either;
     use raw_identifiers;
     use memory_leaks;
+    // use altrep;
 }
+
+

--- a/tests/extendrtests/tests/testthat/test-altlist.R
+++ b/tests/extendrtests/tests/testthat/test-altlist.R
@@ -1,0 +1,27 @@
+# Results in a panic!
+# thread '<unnamed>' panicked at .../extendr/extendr-api/src/wrapper/altrep.rs:544:13:
+#   misaligned pointer dereference: address must be a multiple of 0x8 but is 0x1f100000d
+# note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+# thread caused non-unwinding panic. aborting.
+
+# test_that("ALTLIST creation works", {
+#   x <- new_usize(c(1L, NA, 99L))
+#   expect_true(is.list(x))
+#   expect_length(x, 3)
+# })
+# 
+
+# Results in the same panic 
+# test_that("ALTINTEGER creation works", {
+#   x <- tst_altinteger()
+#   expect_true(is.integer(x))
+#   expect_length(x, 10) 
+# })
+# 
+
+# Results in a memory leak test failure
+# test_that("ALTSTRING creation works", {
+#   x <- tst_altstring()
+#   expect_true(is.character(x))
+#   expect_length(x, 10)
+# })

--- a/tests/extendrtests/tests/testthat/test-altrep.R
+++ b/tests/extendrtests/tests/testthat/test-altrep.R
@@ -11,17 +11,14 @@
 # })
 # 
 
-# Results in the same panic 
-# test_that("ALTINTEGER creation works", {
-#   x <- tst_altinteger()
-#   expect_true(is.integer(x))
-#   expect_length(x, 10) 
-# })
-# 
+test_that("ALTINTEGER creation works", {
+  x <- tst_altinteger()
+  expect_true(is.integer(x))
+  expect_length(x, 10) 
+})
 
-# Results in a memory leak test failure
-# test_that("ALTSTRING creation works", {
-#   x <- tst_altstring()
-#   expect_true(is.character(x))
-#   expect_length(x, 10)
-# })
+test_that("ALTSTRING creation works", {
+  x <- tst_altstring()
+  expect_true(is.character(x))
+  expect_length(x, 10)
+})


### PR DESCRIPTION
This branch is a tweaked version of #600 to show the test failures discussed in https://github.com/extendr/extendr/pull/600#issuecomment-1706978167.

I could reproduce the error on my local, and the error message says it happens here:

https://github.com/extendr/extendr/blob/1c32f6904274f55e109e132bf1ef0e2e4b11647c/extendr-api/src/wrapper/altrep.rs#L533

To investigate what's happening, I expanded the line as below in the assumption that the problem is that extendr tries to extract the pointer address from a wrong data. As expected, I saw this error message on my local, so it's probably means my assumption is right.

``` rs
            let sexp = R_altrep_data1(x);
            if TYPEOF(sexp) as u32 != libR_sys::EXTPTRSXP {
                panic!("This isn't an external pointer! (type {})", TYPEOF(sexp));
            };
            let state_ptr = R_ExternalPtrAddr(sexp);
```

So, what's the problem? ~~My guess is that the `R_altrep_data1()` above is a mistake~~ (edit: sorry, this itself is correct, but this should not be used in finalizer). Since this finalizer is defined for the external pointer inside the altrep, not for the altrep itself, `R_ExternalPtrAddr()` should be applied to `x` instead of `R_altrep_data1(x)`.

https://github.com/extendr/extendr/blob/1c32f6904274f55e109e132bf1ef0e2e4b11647c/extendr-api/src/wrapper/altrep.rs#L492-L496