### PR TITLE
Use R_RegisterCFinalizerEx() instead of R_RegisterCFinalizer()

### DIFF
--- a/extendr-api/src/robj/rinternals.rs
+++ b/extendr-api/src/robj/rinternals.rs
@@ -272,7 +272,9 @@ pub trait Rinternals: Types + Conversions {
 
     #[doc(hidden)]
     unsafe fn register_c_finalizer(&self, func: R_CFinalizer_t) {
-        single_threaded(|| R_RegisterCFinalizer(self.get(), func));
+        // Use R_RegisterCFinalizerEx() and set onexit to 1 (TRUE) to invoke the
+        // finalizer on a shutdown of the R session as well.
+        single_threaded(|| R_RegisterCFinalizerEx(self.get(), func, 1));
     }
 
     /// Copy a vector and resize it.

--- a/extendr-api/src/wrapper/altrep.rs
+++ b/extendr-api/src/wrapper/altrep.rs
@@ -509,7 +509,10 @@ impl Altrep {
             let tag = R_NilValue;
             let prot = R_NilValue;
             let state = R_MakeExternalPtr(ptr as *mut c_void, tag, prot);
-            R_RegisterCFinalizer(state, Some(finalizer::<StateType>));
+
+            // Use R_RegisterCFinalizerEx() and set onexit to 1 (TRUE) to invoke
+            // the finalizer on a shutdown of the R session as well.
+            R_RegisterCFinalizerEx(state, Some(finalizer::<StateType>), 1);
 
             let class_ptr = R_altrep_class_t { ptr: class.get() };
             let sexp = R_new_altrep(class_ptr, state, R_NilValue);


### PR DESCRIPTION
(This isn't a big problem. Just for housekeeping.)

During reading the source code of cpp11, I found they use `R_RegisterCFinalizerEx()` instead of `R_RegisterCFinalizer()`. The difference is the additional `onexit` argument, which is explaind in [WRE](https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#External-pointers-and-weak-references) as below:

> R does not perform a garbage collection when shutting down, and the `onexit` argument of the extended forms can be used to ask that the finalizer be run during a normal shutdown of the R session. It is suggested that it is good practice to clear the pointer on finalization.

Actually, `R_RegisterCFinalizer()` is equivalent to `R_RegisterCFinalizerEx(..., FALSE)`.

https://github.com/wch/r-source/blob/6691d53058214c16e5ab8fd6eb41c06e7fb3227f/src/main/memory.c#L1619

I'm not 100% sure if there's no case that this should be `FALSE`, but in extendr's case, it seems there's no interface that users can supply their own finalizers and the current two are what should also be called on the shutdown. So, I think it's fine to pass `TRUE` fixedly.

https://github.com/extendr/extendr/blob/593be3da4a627c8efe8c2eccf99440a90fa00714/extendr-api/src/wrapper/altrep.rs#L502-L506
https://github.com/extendr/extendr/blob/593be3da4a627c8efe8c2eccf99440a90fa00714/extendr-api/src/wrapper/externalptr.rs#L93-L107