### PR TITLE
[internal] Ignore `extendrtests.Rcheck` whereever it is, plus whichever version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@
 
 # misc
 extendr.Rproj
-tests/extendrtests.Rcheck/
-tests/extendrtests_0.1.0.tar.gz
+**/extendrtests.Rcheck/
+**/extendrtests_[0-9].[0-9].[0-9].tar.gz
 **/.cargo/*
 .vscode/settings.json


### PR DESCRIPTION
Updated `.gitignore` to ignore `extendrtests.Rcheck` if it is in root of workspace, or elsewhere.

To test extendr locally is a nuisance and I'm working on improving it.

Also `[0-9]` is how we may ignore the version numbers. It will do for now, until we get into two digit versions.