### PR TITLE
Only start R once

### DIFF
--- a/extendr-engine/src/lib.rs
+++ b/extendr-engine/src/lib.rs
@@ -78,8 +78,6 @@ pub fn with_r(f: impl FnOnce()) {
 
 #[cfg(test)]
 mod tests {
-    use std::ffi::CString;
-
     use super::*;
 
     #[test]
@@ -93,22 +91,5 @@ mod tests {
         // Ending the interpreter is bad if we are running multiple threads.
         // So avoid doing this in tests.
         //end_r();
-    }
-
-    #[test]
-    fn test_cleanup_of_r() {
-        unsafe {
-            dbg!(libR_sys::R_GlobalEnv.is_null());
-            dbg!(libR_sys::R_NilValue.is_null());
-        }
-        with_r(|| unsafe {
-            dbg!(libR_sys::R_GlobalEnv.is_null());
-            dbg!(libR_sys::R_NilValue.is_null());
-            let cmd = CString::new("Sys.getpid()").unwrap();
-            let pid = libR_sys::R_ParseString(cmd.as_ptr());
-            let s = Rf_eval(pid, R_GlobalEnv);
-            dbg!(pid, TYPEOF(pid), TYPEOF(s), *s, *INTEGER(s));
-            // std::thread::sleep(std::time::Duration::from_secs(25));
-        });
     }
 }

--- a/extendr-engine/src/lib.rs
+++ b/extendr-engine/src/lib.rs
@@ -30,6 +30,11 @@ pub fn start_r() {
                 std::env::set_var("R_HOME", env!("R_HOME"));
             }
 
+            // Has R been started before? Or by some other process?
+            if !libR_sys::R_NilValue.is_null() {
+                return;
+            }
+
             // Due to Rf_initEmbeddedR using __libc_stack_end
             // We can't call Rf_initEmbeddedR.
             // Instead we must follow rustr's example and call the parts.


### PR DESCRIPTION
I'd like `extendr-engine` to be more robust.

We already have users asking for ways to run exclusively within Rust.

When R is started, then values like `R_NilValue` are not C `NULL`, but something else. We can use this to ensure that R is only started once. 

This makes `with_r` even more robust, and possibly capable of being used outside of tests only. 