### PR TITLE
Fix a typo

### DIFF
--- a/extendr-api/src/wrapper/logicals.rs
+++ b/extendr-api/src/wrapper/logicals.rs
@@ -110,7 +110,7 @@ mod tests {
 impl Logicals {
     pub fn set_elt(&mut self, index: usize, val: Rbool) {
         unsafe {
-            SET_INTEGER_ELT(self.get(), index as R_xlen_t, val.inner());
+            SET_LOGICAL_ELT(self.get(), index as R_xlen_t, val.inner());
         }
     }
 }


### PR DESCRIPTION
Just happened to find. Maybe this doesn't matter because the internal representation of `LGLSXP` and `INTSXP` are the same?