### PR TITLE
Fix non-Api calls issue in R packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,13 +221,13 @@ jobs:
       # Rust pseudo multi-targeting: R CMD CHECK receives an extra argument '--no-multiarch' if BUILD_TARGETS is not 'default' and does not contain any commas
       # To enable RStudio support, extendrtests should be installable from 'extendr/tests/extendrtests',
       # for this work directory should be modified and then reverted back
-      - name: Run R integration tests using {extendrtests}
+      - name: Run R intergration tests using {extendrtests}
         uses: r-lib/actions/check-r-package@v2
         with:
-          args: '"--no-manual"'
+          args: 'c("--no-manual", "--as-cran", "--force-multiarch")'
           working-directory: 'tests/extendrtests'
           check-dir: '"extendrtests_check"'
-          error-on: '"note"'
+          error-on: '"${{ steps.error-on.outputs.level }}"'
 
       # With https://github.com/extendr/rextendr/pull/31
       # rextendr can be configured using environment variables.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,13 +221,13 @@ jobs:
       # Rust pseudo multi-targeting: R CMD CHECK receives an extra argument '--no-multiarch' if BUILD_TARGETS is not 'default' and does not contain any commas
       # To enable RStudio support, extendrtests should be installable from 'extendr/tests/extendrtests',
       # for this work directory should be modified and then reverted back
-      - name: Run R intergration tests using {extendrtests}
+      - name: Run R integration tests using {extendrtests}
         uses: r-lib/actions/check-r-package@v2
         with:
-          args: 'c("--no-manual", "--as-cran", "--force-multiarch")'
+          args: '"--no-manual"'
           working-directory: 'tests/extendrtests'
           check-dir: '"extendrtests_check"'
-          error-on: '"${{ steps.error-on.outputs.level }}"'
+          error-on: '"note"'
 
       # With https://github.com/extendr/rextendr/pull/31
       # rextendr can be configured using environment variables.

--- a/extendr-api/Cargo.toml
+++ b/extendr-api/Cargo.toml
@@ -19,7 +19,6 @@ rust-version = "1.60"
 [dependencies]
 libR-sys = { workspace = true }
 extendr-macros = { path = "../extendr-macros", version = "0.4.0" }
-extendr-engine = { path = "../extendr-engine", version = "0.4.0" }
 once_cell = "1"
 paste = "1.0.5"
 either = { version = "1.8.1", optional = true }
@@ -29,6 +28,7 @@ num-complex = { version = "0.4", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
+extendr-engine = { path = "../extendr-engine", version = "0.4.0" }
 rstest = "0.18.1"
 
 [features]


### PR DESCRIPTION
` Found non-API calls to R` issue arises because `extendr-engine` uses non-API calls in its methods. `extendr-engine` was included as a dependency even though it is used only for testing (`with_r()` and `test!{}`). Moving `extendr-engine` to `dev-dependencies` solves the problem.