### PR TITLE
Use c_char instead of u8

### DIFF
--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -621,7 +621,7 @@ pub fn sxp_to_rtype(sxptype: i32) -> Rtype {
     }
 }
 
-const PRINTF_NO_FMT_CSTRING: &[i8] = &[37, 115, 0]; // same as "%s\0"
+const PRINTF_NO_FMT_CSTRING: &[std::os::raw::c_char] = &[37, 115, 0]; // same as "%s\0"
 #[doc(hidden)]
 pub fn print_r_output<T: Into<Vec<u8>>>(s: T) {
     let cs = CString::new(s).expect("NulError");


### PR DESCRIPTION
Fix #628 

In C, `char` can be signed or unsigned, depending on the platform, so extendr have to use `c_char` as type of the inputs of R's C API functions.

cf., https://stackoverflow.com/a/2054941