### PR TITLE
Add `Option<String>` conversion to `Rstr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - `use_rng` option for the `extendr` attribute macro, which enables the use of
 random number sampling methods from R, e.g. `#[extendr(use_rng = true)` [[#476]](https://github.com/extendr/extendr/pull/476)
 - `[T; N]` conversions to `Robj` [[#594]](https://github.com/extendr/extendr/pull/594/)
-- `Rstr` can be constructed from `Option<String>` now [[#630]](https://github.com/extendr/extendr/pull/630)
+- `Rstr` can now be constructed from `Option<String>`  [[#630]](https://github.com/extendr/extendr/pull/630)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `use_rng` option for the `extendr` attribute macro, which enables the use of
 random number sampling methods from R, e.g. `#[extendr(use_rng = true)` [[#476]](https://github.com/extendr/extendr/pull/476)
 - `[T; N]` conversions to `Robj` [[#594]](https://github.com/extendr/extendr/pull/594/)
+- `Rstr` can be constructed from `Option<String>` now [[#630]](https://github.com/extendr/extendr/pull/630)
 
 ### Fixed
 

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -889,8 +889,9 @@ pub trait Attributes: Types + Length {
 
     /// Set the names attribute from a string iterator.
     ///
-    /// Returns Error::NamesLengthMismatch if the length of the names does
+    /// Returns `Error::NamesLengthMismatch` if the length of the names does
     /// not match the length of the object.
+    ///
     /// ```
     /// use extendr_api::prelude::*;
     /// test! {

--- a/extendr-api/src/wrapper/list.rs
+++ b/extendr-api/src/wrapper/list.rs
@@ -98,7 +98,7 @@ impl List {
     }
 
     /// Build a list using separate names and values iterators.
-    /// Used internally by the list! macro.
+    /// Used internally by the `list!` macro.
     pub fn from_names_and_values<N, V>(names: N, values: V) -> Result<Self>
     where
         N: IntoIterator,

--- a/extendr-api/src/wrapper/rstr.rs
+++ b/extendr-api/src/wrapper/rstr.rs
@@ -61,10 +61,20 @@ impl From<&str> for Rstr {
     }
 }
 
+impl From<Option<String>> for Rstr {
+    fn from(value: Option<String>) -> Self {
+        if let Some(string) = value {
+            Self::from(string)
+        } else {
+            Self { robj: na_string() }
+        }
+    }
+}
+
 impl Deref for Rstr {
     type Target = str;
 
-    /// Treat Rstr like &str.
+    /// Treat `Rstr` like `&str`.
     fn deref(&self) -> &Self::Target {
         self.as_str()
     }


### PR DESCRIPTION
While helping a user with a type-conversion issue, it came up that `Rstr` doesn't cover `Option<String>` conversion.

