### PR TITLE
Disable macros snapshot test if on `nightly` toolchain

### DIFF
--- a/tests/extendrtests/tests/testthat/helper.R
+++ b/tests/extendrtests/tests/testthat/helper.R
@@ -10,3 +10,25 @@ skip_if_no_cargo_expand <- function() {
   condition <- (result$status == 0) && (!nzchar(result$stderr))
   skip_if_not(condition, "cargo expand not available")
 }
+
+skip_if_on_nightly <- function() {
+  result <- tryCatch(
+    processx::run(
+      "rustup",
+      args = "default",
+      error_on_status = FALSE
+    ),
+    error = function(e) list(status = 1)
+  )
+  if (result[["status"]] == 0) {
+    stdout <- result[["stdout"]]
+    condition <- stringi::stri_startswith_fixed(
+      stringi::stri_trim_left(stdout),
+      pattern = "nightly"
+    )
+  } else {
+    condition <- FALSE
+  }
+
+  skip_if(isTRUE(condition), "`nightly` toolchain")
+}

--- a/tests/extendrtests/tests/testthat/helper.R
+++ b/tests/extendrtests/tests/testthat/helper.R
@@ -27,7 +27,7 @@ skip_if_on_nightly <- function() {
       pattern = "nightly"
     )
   } else {
-    condition <- FALSE
+    condition <- TRUE # rustup failed, something is fishy
   }
 
   skip_if(isTRUE(condition), "`nightly` toolchain")

--- a/tests/extendrtests/tests/testthat/test-macro-snapshot.R
+++ b/tests/extendrtests/tests/testthat/test-macro-snapshot.R
@@ -2,9 +2,10 @@ test_that("Macro expansion of lib.rs", {
   skip_if_no_cargo_expand()
 
   # Since, ALTLIST is available only since R 4.3, the expanded codes don't match
-  # between R < 4.3 and R >= 4.3. 
+  # between R < 4.3 and R >= 4.3.
   skip_if(packageVersion("base") < "4.3")
-  
+  skip_if_on_nightly()
+
   # Define a custom criterion for identifying the presence of a folder named '00_pkg_src'
   contains_extendtests <- rprojroot::has_dir("00_pkg_src")
 


### PR DESCRIPTION
Fix an issue observed in #630.