### PR TITLE
Use error instead of panic! in extendr-macros

### DIFF
--- a/extendr-macros/Cargo.toml
+++ b/extendr-macros/Cargo.toml
@@ -19,3 +19,4 @@ proc-macro2 = { version = "1.0" }
 extendr-api = { path = "../extendr-api" }
 extendr-engine = { path = "../extendr-engine" }
 libR-sys = { workspace = true }
+trybuild = "1.0"

--- a/extendr-macros/src/extendr_function.rs
+++ b/extendr-macros/src/extendr_function.rs
@@ -6,7 +6,12 @@ use syn::{meta::ParseNestedMeta, ItemFn, Lit, LitBool};
 /// Generate bindings for a single function.
 pub fn extendr_function(mut func: ItemFn, opts: &wrappers::ExtendrOptions) -> TokenStream {
     let mut wrappers: Vec<ItemFn> = Vec::new();
-    wrappers::make_function_wrappers(opts, &mut wrappers, "", &func.attrs, &mut func.sig, None);
+
+    let res =
+        wrappers::make_function_wrappers(opts, &mut wrappers, "", &func.attrs, &mut func.sig, None);
+    if let Err(e) = res {
+        return e.into_compile_error().into();
+    };
 
     TokenStream::from(quote! {
         #func

--- a/extendr-macros/src/extendr_function.rs
+++ b/extendr-macros/src/extendr_function.rs
@@ -25,45 +25,46 @@ impl wrappers::ExtendrOptions {
     /// - `use_rng = bool` ensures the RNG-state is pulled and pushed
     ///
     pub fn parse(&mut self, meta: ParseNestedMeta) -> syn::parse::Result<()> {
-        fn help_message() -> ! {
-            panic!("expected #[extendr(use_try_from = bool, r_name = \"name\", mod_name = \"r_mod_name\", use_rng = bool)]");
-        }
+        let value = meta.value()?;
+        let path = meta
+            .path
+            .get_ident()
+            .ok_or(meta.error("Unexpected syntax"))?;
 
-        let value = match meta.value() {
-            Ok(value) => value,
-            Err(_) => help_message(),
-        };
-
-        if meta.path.is_ident("use_try_from") {
-            if let Ok(LitBool { value, .. }) = value.parse() {
-                self.use_try_from = value;
-                Ok(())
-            } else {
-                help_message();
+        match path.to_string().as_str() {
+            "use_try_from" => {
+                if let Ok(LitBool { value, .. }) = value.parse() {
+                    self.use_try_from = value;
+                    Ok(())
+                } else {
+                    Err(value.error("`use_try_from` must be `true` or `false`"))
+                }
             }
-        } else if meta.path.is_ident("r_name") {
-            if let Ok(Lit::Str(litstr)) = value.parse() {
-                self.r_name = Some(litstr.value());
-                Ok(())
-            } else {
-                help_message();
+            "r_name" => {
+                if let Ok(Lit::Str(litstr)) = value.parse() {
+                    self.r_name = Some(litstr.value());
+                    Ok(())
+                } else {
+                    Err(value.error("`r_name` must be a string literal"))
+                }
             }
-        } else if meta.path.is_ident("mod_name") {
-            if let Ok(Lit::Str(litstr)) = value.parse() {
-                self.mod_name = Some(litstr.value());
-                Ok(())
-            } else {
-                help_message();
+            "mod_name" => {
+                if let Ok(Lit::Str(litstr)) = value.parse() {
+                    self.mod_name = Some(litstr.value());
+                    Ok(())
+                } else {
+                    Err(value.error("`mod_name` must be a string literal"))
+                }
             }
-        } else if meta.path.is_ident("use_rng") {
-            if let Ok(LitBool { value, .. }) = value.parse() {
-                self.use_rng = value;
-                Ok(())
-            } else {
-                help_message();
+            "use_rng" => {
+                if let Ok(LitBool { value, .. }) = value.parse() {
+                    self.use_rng = value;
+                    Ok(())
+                } else {
+                    Err(value.error("`use_rng` must be `true` or `false`"))
+                }
             }
-        } else {
-            help_message();
+            _ => Err(syn::Error::new_spanned(meta.path, "Unexpected key")),
         }
     }
 }

--- a/extendr-macros/src/extendr_impl.rs
+++ b/extendr-macros/src/extendr_impl.rs
@@ -36,22 +36,34 @@ use crate::wrappers;
 ///     fn aux_func;
 /// }
 /// ```
-pub fn extendr_impl(mut item_impl: ItemImpl) -> TokenStream {
+pub fn extendr_impl(mut item_impl: ItemImpl) -> syn::Result<TokenStream> {
     // Only `impl name { }` allowed
     if item_impl.defaultness.is_some() {
-        return quote! { compile_error!("default not allowed in #[extendr] impl"); }.into();
+        return Err(syn::Error::new_spanned(
+            item_impl,
+            "default not allowed in #[extendr] impl",
+        ));
     }
 
     if item_impl.unsafety.is_some() {
-        return quote! { compile_error!("unsafe not allowed in #[extendr] impl"); }.into();
+        return Err(syn::Error::new_spanned(
+            item_impl,
+            "unsafe not allowed in #[extendr] impl",
+        ));
     }
 
     if item_impl.generics.const_params().count() != 0 {
-        return quote! { compile_error!("const params not allowed in #[extendr] impl"); }.into();
+        return Err(syn::Error::new_spanned(
+            item_impl,
+            "const params not allowed in #[extendr] impl",
+        ));
     }
 
     if item_impl.generics.type_params().count() != 0 {
-        return quote! { compile_error!("type params not allowed in #[extendr] impl"); }.into();
+        return Err(syn::Error::new_spanned(
+            item_impl,
+            "type params not allowed in #[extendr] impl",
+        ));
     }
 
     // if item_impl.generics.lifetimes().count() != 0 {
@@ -59,7 +71,10 @@ pub fn extendr_impl(mut item_impl: ItemImpl) -> TokenStream {
     // }
 
     if item_impl.generics.where_clause.is_some() {
-        return quote! { compile_error!("where clause not allowed in #[extendr] impl"); }.into();
+        return Err(syn::Error::new_spanned(
+            item_impl,
+            "where clause not allowed in #[extendr] impl",
+        ));
     }
 
     let opts = wrappers::ExtendrOptions::default();
@@ -97,7 +112,7 @@ pub fn extendr_impl(mut item_impl: ItemImpl) -> TokenStream {
                 &method.attrs,
                 &mut method.sig,
                 Some(self_ty),
-            );
+            )?;
         }
     }
 
@@ -187,7 +202,7 @@ pub fn extendr_impl(mut item_impl: ItemImpl) -> TokenStream {
     });
 
     //eprintln!("{}", expanded);
-    expanded
+    Ok(expanded)
 }
 
 // This structure contains parameters parsed from the #[extendr_module] definition.

--- a/extendr-macros/src/lib.rs
+++ b/extendr-macros/src/lib.rs
@@ -203,7 +203,10 @@ pub fn Rraw(item: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro_derive(TryFromRobj)]
 pub fn derive_try_from_robj(item: TokenStream) -> TokenStream {
-    list_struct::derive_try_from_robj(item)
+    match list_struct::derive_try_from_robj(item) {
+        Ok(result) => result,
+        Err(e) => e.into_compile_error().into(),
+    }
 }
 
 /// Derives an implementation of `From<Struct> for Robj` and `From<&Struct> for Robj` on this struct.
@@ -241,7 +244,10 @@ pub fn derive_try_from_robj(item: TokenStream) -> TokenStream {
 /// and converting it back to Rust will produce a copy of the original struct.
 #[proc_macro_derive(IntoRobj)]
 pub fn derive_into_robj(item: TokenStream) -> TokenStream {
-    list_struct::derive_into_robj(item)
+    match list_struct::derive_into_robj(item) {
+        Ok(result) => result,
+        Err(e) => e.into_compile_error().into(),
+    }
 }
 
 /// Enable the construction of dataframes from arrays of structures.

--- a/extendr-macros/src/lib.rs
+++ b/extendr-macros/src/lib.rs
@@ -80,7 +80,10 @@ pub fn extendr(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     match parse_macro_input!(item as Item) {
         Item::Fn(func) => extendr_function::extendr_function(func, &opts),
-        Item::Impl(item_impl) => extendr_impl::extendr_impl(item_impl),
+        Item::Impl(item_impl) => match extendr_impl::extendr_impl(item_impl) {
+            Ok(result) => result,
+            Err(e) => e.into_compile_error().into(),
+        },
         other_item => TokenStream::from(quote! {#other_item}),
     }
 }

--- a/extendr-macros/tests/cases/case-extendr-macro.rs
+++ b/extendr-macros/tests/cases/case-extendr-macro.rs
@@ -16,15 +16,50 @@ fn foo() {}
 #[extendr(use_rng = 1)]
 fn foo() {}
 
+// impl -----------------------------------------
+
+struct FooStruct {}
+
+#[extendr]
+impl FooStruct {
+    fn nonref_self(self) {}
+}
+
+impl FooStruct {
+    #[extendr]
+    fn misplaced_macro(&self) {}
+}
+
+#[extendr]
+default impl FooStruct {}
+
+#[extendr]
+unsafe impl FooStruct {}
+
+#[extendr]
+impl<const N: usize> FooStruct {}
+
+struct FooStructWithParam<A> {
+    a: A,
+}
+
+#[extendr]
+impl<A> FooStructWithParam<A> {}
+
+#[extendr]
+impl FooStructWithParam<A> where A: usize {}
+
+// derive ---------------------------------------
+
 #[derive(TryFromRobj)]
-enum Foo1 {
+enum FooEnum1 {
     A,
     B,
     C,
 }
 
 #[derive(IntoRobj)]
-enum Foo2 {
+enum FooEnum2 {
     A,
     B,
     C,

--- a/extendr-macros/tests/cases/case-extendr-macro.rs
+++ b/extendr-macros/tests/cases/case-extendr-macro.rs
@@ -1,4 +1,5 @@
 use extendr_macros::extendr;
+use extendr_macros::{IntoRobj, TryFromRobj};
 
 #[extendr(foo = true)]
 fn foo() {}
@@ -14,5 +15,19 @@ fn foo() {}
 
 #[extendr(use_rng = 1)]
 fn foo() {}
+
+#[derive(TryFromRobj)]
+enum Foo1 {
+    A,
+    B,
+    C,
+}
+
+#[derive(IntoRobj)]
+enum Foo2 {
+    A,
+    B,
+    C,
+}
 
 fn main() {}

--- a/extendr-macros/tests/cases/case-extendr-macro.rs
+++ b/extendr-macros/tests/cases/case-extendr-macro.rs
@@ -1,0 +1,18 @@
+use extendr_macros::extendr;
+
+#[extendr(foo = true)]
+fn foo() {}
+
+#[extendr(use_try_from = 1)]
+fn foo() {}
+
+#[extendr(r_name = 1)]
+fn foo() {}
+
+#[extendr(mod_name = 1)]
+fn foo() {}
+
+#[extendr(use_rng = 1)]
+fn foo() {}
+
+fn main() {}

--- a/extendr-macros/tests/cases/case-extendr-macro.stderr
+++ b/extendr-macros/tests/cases/case-extendr-macro.stderr
@@ -1,0 +1,37 @@
+error: Unexpected key
+ --> tests/cases/case-extendr-macro.rs:3:11
+  |
+3 | #[extendr(foo = true)]
+  |           ^^^
+
+error: unexpected end of input, `use_try_from` must be `true` or `false`
+ --> tests/cases/case-extendr-macro.rs:6:1
+  |
+6 | #[extendr(use_try_from = 1)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `extendr` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: unexpected end of input, `r_name` must be a string literal
+ --> tests/cases/case-extendr-macro.rs:9:1
+  |
+9 | #[extendr(r_name = 1)]
+  | ^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `extendr` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: unexpected end of input, `mod_name` must be a string literal
+  --> tests/cases/case-extendr-macro.rs:12:1
+   |
+12 | #[extendr(mod_name = 1)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `extendr` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: unexpected end of input, `use_rng` must be `true` or `false`
+  --> tests/cases/case-extendr-macro.rs:15:1
+   |
+15 | #[extendr(use_rng = 1)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `extendr` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/extendr-macros/tests/cases/case-extendr-macro.stderr
+++ b/extendr-macros/tests/cases/case-extendr-macro.stderr
@@ -36,22 +36,64 @@ error: unexpected end of input, `use_rng` must be `true` or `false`
    |
    = note: this error originates in the attribute macro `extendr` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: Only struct is supported
-  --> tests/cases/case-extendr-macro.rs:20:1
+error: expected &self or &mut self
+  --> tests/cases/case-extendr-macro.rs:25:20
    |
-20 | / enum Foo1 {
-21 | |     A,
-22 | |     B,
-23 | |     C,
-24 | | }
+25 |     fn nonref_self(self) {}
+   |                    ^^^^
+
+error: found &self in non-impl function - have you missed the #[extendr] before the impl?
+  --> tests/cases/case-extendr-macro.rs:30:24
+   |
+30 |     fn misplaced_macro(&self) {}
+   |                        ^^^^^
+
+error: default not allowed in #[extendr] impl
+  --> tests/cases/case-extendr-macro.rs:34:1
+   |
+34 | default impl FooStruct {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: unsafe not allowed in #[extendr] impl
+  --> tests/cases/case-extendr-macro.rs:37:1
+   |
+37 | unsafe impl FooStruct {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: const params not allowed in #[extendr] impl
+  --> tests/cases/case-extendr-macro.rs:40:1
+   |
+40 | impl<const N: usize> FooStruct {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: type params not allowed in #[extendr] impl
+  --> tests/cases/case-extendr-macro.rs:47:1
+   |
+47 | impl<A> FooStructWithParam<A> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: where clause not allowed in #[extendr] impl
+  --> tests/cases/case-extendr-macro.rs:50:1
+   |
+50 | impl FooStructWithParam<A> where A: usize {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Only struct is supported
+  --> tests/cases/case-extendr-macro.rs:55:1
+   |
+55 | / enum FooEnum1 {
+56 | |     A,
+57 | |     B,
+58 | |     C,
+59 | | }
    | |_^
 
 error: Only struct is supported
-  --> tests/cases/case-extendr-macro.rs:27:1
+  --> tests/cases/case-extendr-macro.rs:62:1
    |
-27 | / enum Foo2 {
-28 | |     A,
-29 | |     B,
-30 | |     C,
-31 | | }
+62 | / enum FooEnum2 {
+63 | |     A,
+64 | |     B,
+65 | |     C,
+66 | | }
    | |_^

--- a/extendr-macros/tests/cases/case-extendr-macro.stderr
+++ b/extendr-macros/tests/cases/case-extendr-macro.stderr
@@ -1,37 +1,57 @@
 error: Unexpected key
- --> tests/cases/case-extendr-macro.rs:3:11
+ --> tests/cases/case-extendr-macro.rs:4:11
   |
-3 | #[extendr(foo = true)]
+4 | #[extendr(foo = true)]
   |           ^^^
 
 error: unexpected end of input, `use_try_from` must be `true` or `false`
- --> tests/cases/case-extendr-macro.rs:6:1
+ --> tests/cases/case-extendr-macro.rs:7:1
   |
-6 | #[extendr(use_try_from = 1)]
+7 | #[extendr(use_try_from = 1)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in the attribute macro `extendr` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unexpected end of input, `r_name` must be a string literal
- --> tests/cases/case-extendr-macro.rs:9:1
-  |
-9 | #[extendr(r_name = 1)]
-  | ^^^^^^^^^^^^^^^^^^^^^^
-  |
-  = note: this error originates in the attribute macro `extendr` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> tests/cases/case-extendr-macro.rs:10:1
+   |
+10 | #[extendr(r_name = 1)]
+   | ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `extendr` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unexpected end of input, `mod_name` must be a string literal
-  --> tests/cases/case-extendr-macro.rs:12:1
+  --> tests/cases/case-extendr-macro.rs:13:1
    |
-12 | #[extendr(mod_name = 1)]
+13 | #[extendr(mod_name = 1)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the attribute macro `extendr` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unexpected end of input, `use_rng` must be `true` or `false`
-  --> tests/cases/case-extendr-macro.rs:15:1
+  --> tests/cases/case-extendr-macro.rs:16:1
    |
-15 | #[extendr(use_rng = 1)]
+16 | #[extendr(use_rng = 1)]
    | ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the attribute macro `extendr` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Only struct is supported
+  --> tests/cases/case-extendr-macro.rs:20:1
+   |
+20 | / enum Foo1 {
+21 | |     A,
+22 | |     B,
+23 | |     C,
+24 | | }
+   | |_^
+
+error: Only struct is supported
+  --> tests/cases/case-extendr-macro.rs:27:1
+   |
+27 | / enum Foo2 {
+28 | |     A,
+29 | |     B,
+30 | |     C,
+31 | | }
+   | |_^

--- a/extendr-macros/tests/trybuild.rs
+++ b/extendr-macros/tests/trybuild.rs
@@ -1,0 +1,5 @@
+#[test]
+fn test_macro_failures() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/cases/*.rs");
+}


### PR DESCRIPTION
Make the `#[extendr]` macro return clear error like this (See `extendr-macros/tests/cases/case-extendr-macro.stderr` for more examples).

```
error: Unexpected key
 --> tests/cases/case-extendr-macro.rs:4:11
  |
4 | #[extendr(foo = true)]
  |   
```