### PR TITLE
Add `.Generic` symbol

### DIFF
--- a/extendr-api/src/functions.rs
+++ b/extendr-api/src/functions.rs
@@ -178,10 +178,8 @@ pub fn nil_value() -> Robj {
     unsafe { Robj::from_sexp(R_NilValue) }
 }
 
-/* fix version issues.
 /// ".Generic"
-pub fn dot_Generic() -> Robj { unsafe { Robj::from_sexp(R_dot_Generic) }}
-*/
+pub fn dot_generic() -> Robj { unsafe { Robj::from_sexp(R_dot_Generic) }}
 
 /// NA_STRING as a CHARSXP
 pub fn na_string() -> Robj {

--- a/extendr-api/src/functions.rs
+++ b/extendr-api/src/functions.rs
@@ -179,7 +179,9 @@ pub fn nil_value() -> Robj {
 }
 
 /// ".Generic"
-pub fn dot_generic() -> Robj { unsafe { Robj::from_sexp(R_dot_Generic) }}
+pub fn dot_generic() -> Robj {
+    unsafe { Robj::from_sexp(R_dot_Generic) }
+}
 
 /// NA_STRING as a CHARSXP
 pub fn na_string() -> Robj {


### PR DESCRIPTION
I don't know what the versioning problem is.

This symbol was added to R in 2011. 
