### PR TITLE
Use [workspace.package] in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ authors = [
 edition = "2021"
 
 [workspace.dependencies]
-# When update extendr's version, this version also needs to be updated
+# When updating extendr's version, this version also needs to be updated
 extendr-macros = { path = "./extendr-macros", version = "0.6.0" }
 
 libR-sys = "0.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,25 @@ resolver = "2"
 
 members = ["extendr-api", "extendr-engine", "extendr-macros"]
 
+[workspace.package]
+version = "0.6.0"
+repository = "https://github.com/extendr/extendr"
+license = "MIT"
+authors = [
+    "andy-thomason <andy@andythomason.com>",
+    "Thomas Down",
+    "Mossa Merhi Reimert <mossa@sund.ku.dk>",
+    "Claus O. Wilke <wilke@austin.utexas.edu>",
+    "Hiroaki Yutani",
+    "Ilia A. Kosenkov <ilia.kosenkov@outlook.com>",
+]
+rust-version = "1.64"
+edition = "2021"
+
 [workspace.dependencies]
+# When update extendr's version, this version also needs to be updated
+extendr-macros = { path = "./extendr-macros", version = "0.6.0" }
+
 libR-sys = "0.6.0"
 
 [patch.crates-io]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ authors = [
     "Claus O. Wilke <wilke@austin.utexas.edu>",
     "Hiroaki Yutani",
     "Ilia A. Kosenkov <ilia.kosenkov@outlook.com>",
+    "Michael Milton <michael.r.milton@gmail.com>",
 ]
 rust-version = "1.64"
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ authors = [
     "Ilia A. Kosenkov <ilia.kosenkov@outlook.com>",
     "Michael Milton <michael.r.milton@gmail.com>",
 ]
-rust-version = "1.64"
 edition = "2021"
 
 [workspace.dependencies]

--- a/extendr-api/Cargo.toml
+++ b/extendr-api/Cargo.toml
@@ -6,7 +6,9 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-rust-version.workspace = true
+
+# Note: it seems cargo-msrv doesn't support rust-version.workspace = true.
+rust-version = "1.64"
 
 [dependencies]
 libR-sys = { workspace = true }

--- a/extendr-api/Cargo.toml
+++ b/extendr-api/Cargo.toml
@@ -1,24 +1,16 @@
 [package]
 name = "extendr-api"
-version = "0.6.0"
-authors = [
-    "andy-thomason <andy@andythomason.com>",
-    "Thomas Down",
-    "Mossa Merhi Reimert <mossa@sund.ku.dk>",
-    "Claus O. Wilke <wilke@austin.utexas.edu>",
-    "Hiroaki Yutani",
-    "Ilia A. Kosenkov <ilia.kosenkov@outlook.com>",
-    "Michael Milton <michael.r.milton@gmail.com>",
-]
-edition = "2021"
 description = "Safe and user friendly bindings to the R programming language."
-license = "MIT"
-repository = "https://github.com/extendr/extendr"
-rust-version = "1.60"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 libR-sys = { workspace = true }
-extendr-macros = { path = "../extendr-macros", version = "0.6.0" }
+extendr-macros = { workspace = true }
 once_cell = "1"
 paste = "1.0.5"
 either = { version = "1.8.1", optional = true }
@@ -28,7 +20,7 @@ num-complex = { version = "0.4", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
-extendr-engine = { path = "../extendr-engine", version = "0.6.0" }
+extendr-engine = { path = "../extendr-engine" }
 rstest = "0.18.1"
 
 [features]

--- a/extendr-engine/Cargo.toml
+++ b/extendr-engine/Cargo.toml
@@ -1,21 +1,14 @@
 [package]
 name = "extendr-engine"
-version = "0.6.0"
-authors = [
-    "andy-thomason <andy@andythomason.com>",
-    "Thomas Down",
-    "Mossa Merhi Reimert <mossa@sund.ku.dk>",
-    "Claus O. Wilke <wilke@austin.utexas.edu>",
-    "Hiroaki Yutani",
-    "Ilia A. Kosenkov <ilia.kosenkov@outlook.com>",
-]
-edition = "2021"
 description = "Safe and user friendly bindings to the R programming language."
-license = "MIT"
-repository = "https://github.com/extendr/extendr"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-libR-sys = "0.6.0"
+libR-sys = { workspace = true }
 ctor = "0.2.4"
 
 [features]

--- a/extendr-macros/Cargo.toml
+++ b/extendr-macros/Cargo.toml
@@ -1,18 +1,11 @@
 [package]
 name = "extendr-macros"
-version = "0.6.0"
-authors = [
-    "andy-thomason <andy@andythomason.com>",
-    "Thomas Down",
-    "Mossa Merhi Reimert <mossa@sund.ku.dk>",
-    "Claus O. Wilke <wilke@austin.utexas.edu>",
-    "Hiroaki Yutani",
-    "Ilia A. Kosenkov <ilia.kosenkov@outlook.com>",
-]
-edition = "2021"
 description = "Generate bindings from R to Rust."
-license = "MIT"
-repository = "https://github.com/extendr/extendr"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [lib]
 proc_macro = true


### PR DESCRIPTION
As of [Rust 1.64](https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html#cargo-improvements-workspace-inheritance-and-multi-target-builds), `[workspace.package]` can be used to specify the metadata for the whole workspace. This should be easier to maintain.

https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table

A few notes:

* As described above, this requires 1.64, so we have to increase MSRV. As [eitsupi commented](https://github.com/extendr/extendr/pull/637#issuecomment-1748711501), this version requirement should be safe even on CRAN.
* I found the `authors` field differ between crates. I think it's fine to include an author to all extendr crates even if they contributed to only one of the crates.