### PR TITLE
Refactor passing of `&str` to r

### DIFF
--- a/extendr-api/src/lang_macros.rs
+++ b/extendr-api/src/lang_macros.rs
@@ -45,13 +45,8 @@ macro_rules! args {
 #[doc(hidden)]
 pub unsafe fn append_with_name(tail: SEXP, obj: Robj, name: &str) -> SEXP {
     single_threaded(|| {
-        let mut name = Vec::from(name.as_bytes());
-        name.push(0);
         let cons = Rf_cons(obj.get(), R_NilValue);
-        SET_TAG(
-            cons,
-            Rf_install(name.as_ptr() as *const std::os::raw::c_char),
-        );
+        SET_TAG(cons, crate::make_symbol(name));
         SETCDR(tail, cons);
         cons
     })
@@ -66,11 +61,7 @@ pub unsafe fn append(tail: SEXP, obj: Robj) -> SEXP {
 
 #[doc(hidden)]
 pub unsafe fn make_lang(sym: &str) -> Robj {
-    let mut name = Vec::from(sym.as_bytes());
-    name.push(0);
-    let sexp =
-        single_threaded(|| Rf_lang1(Rf_install(name.as_ptr() as *const std::os::raw::c_char)));
-    Robj::from_sexp(sexp)
+    Robj::from_sexp(single_threaded(|| Rf_lang1(crate::make_symbol(sym))))
 }
 
 /// Convert a list of tokens to an array of tuples.

--- a/extendr-api/src/thread_safety.rs
+++ b/extendr-api/src/thread_safety.rs
@@ -77,7 +77,10 @@ where
 {
     match std::panic::catch_unwind(f) {
         Ok(res) => res,
-        Err(_) => unsafe { libR_sys::Rf_error(err_str.as_ptr() as *const std::os::raw::c_char) },
+        Err(_) => {
+            let err_str = CString::new(err_str).unwrap();
+            unsafe { libR_sys::Rf_error(err_str.as_ptr()) }
+        }
     }
 }
 

--- a/extendr-api/src/wrapper/mod.rs
+++ b/extendr-api/src/wrapper/mod.rs
@@ -58,9 +58,8 @@ pub use strings::Strings;
 pub use symbol::Symbol;
 
 pub(crate) fn make_symbol(name: &str) -> SEXP {
-    // cannot link to `Rf_installNoTrChar` because it is not present in `libR.so`
-    // unsafe { libR_sys::Rf_installNoTrChar(str_to_character(name)) }
-    unsafe { libR_sys::Rf_installTrChar(str_to_character(name)) }
+    let name = CString::new(name).unwrap();
+    unsafe { libR_sys::Rf_install(name.as_ptr()) }
 }
 
 pub(crate) fn make_vector<T>(sexptype: u32, values: T) -> Robj

--- a/extendr-api/src/wrapper/mod.rs
+++ b/extendr-api/src/wrapper/mod.rs
@@ -58,10 +58,9 @@ pub use strings::Strings;
 pub use symbol::Symbol;
 
 pub(crate) fn make_symbol(name: &str) -> SEXP {
-    let mut bytes = Vec::with_capacity(name.len() + 1);
-    bytes.extend(name.bytes());
-    bytes.push(0);
-    unsafe { Rf_install(bytes.as_ptr() as *const ::std::os::raw::c_char) }
+    // cannot link to `Rf_installNoTrChar` because it is not present in `libR.so`
+    // unsafe { libR_sys::Rf_installNoTrChar(str_to_character(name)) }
+    unsafe { libR_sys::Rf_installTrChar(str_to_character(name)) }
 }
 
 pub(crate) fn make_vector<T>(sexptype: u32, values: T) -> Robj


### PR DESCRIPTION

* Instead of constructing a `CString` by hand, we should just use `CString`.
*`thread_safety` is passing a string
without ensuring it is a null-terminated,
c-string.
* `make_symbol` should just use `Rf_installTrChar`.

