### PR TITLE
Add `get_mut` to deal with unsoundness of `Robj`

### DIFF
--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -631,7 +631,7 @@ pub trait RobjItertools: Iterator {
         Robj: AsTypedSlice<'a, Self::Item>,
         Self::Item: 'a,
     {
-        let vector = self.collect_robj();
+        let mut vector = self.collect_robj();
         let prod = dims.iter().product::<usize>();
         if prod != vector.len() {
             return Err(Error::Other(format!(

--- a/extendr-api/src/wrapper/complexes.rs
+++ b/extendr-api/src/wrapper/complexes.rs
@@ -63,7 +63,7 @@ impl DerefMut for Complexes {
     /// Treat Complexes as if it is a mutable slice, like `Vec<Rcplx>`
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe {
-            let ptr = DATAPTR(self.get()) as *mut Rcplx;
+            let ptr = DATAPTR(self.get_mut()) as *mut Rcplx;
             std::slice::from_raw_parts_mut(ptr, self.len())
         }
     }

--- a/extendr-api/src/wrapper/doubles.rs
+++ b/extendr-api/src/wrapper/doubles.rs
@@ -54,7 +54,7 @@ impl Doubles {
 impl Doubles {
     pub fn set_elt(&mut self, index: usize, val: Rfloat) {
         unsafe {
-            SET_REAL_ELT(self.get(), index as R_xlen_t, val.inner());
+            SET_REAL_ELT(self.get_mut(), index as R_xlen_t, val.inner());
         }
     }
 }
@@ -75,7 +75,7 @@ impl DerefMut for Doubles {
     /// Treat Doubles as if it is a mutable slice, like `Vec<Rfloat>`
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe {
-            let ptr = DATAPTR(self.get()) as *mut Rfloat;
+            let ptr = DATAPTR(self.get_mut()) as *mut Rfloat;
             std::slice::from_raw_parts_mut(ptr, self.len())
         }
     }

--- a/extendr-api/src/wrapper/environment.rs
+++ b/extendr-api/src/wrapper/environment.rs
@@ -83,7 +83,7 @@ impl Environment {
     /// Set the enclosing (parent) environment.
     pub fn set_parent(&mut self, parent: Environment) -> &mut Self {
         single_threaded(|| unsafe {
-            let sexp = self.robj.get();
+            let sexp = self.robj.get_mut();
             SET_ENCLOS(sexp, parent.robj.get());
         });
         self
@@ -100,7 +100,7 @@ impl Environment {
     /// Set the environment flags.
     pub fn set_envflags(&mut self, flags: i32) -> &mut Self {
         unsafe {
-            let sexp = self.robj.get();
+            let sexp = self.robj.get_mut();
             SET_ENVFLAGS(sexp, flags)
         }
         self

--- a/extendr-api/src/wrapper/externalptr.rs
+++ b/extendr-api/src/wrapper/externalptr.rs
@@ -29,6 +29,10 @@ impl<T: Debug + 'static> robj::GetSexp for ExternalPtr<T> {
         self.robj.get()
     }
 
+    unsafe fn get_mut(&mut self) -> SEXP {
+        self.robj.get_mut()
+    }
+
     /// Get a reference to a Robj for this type.
     fn as_robj(&self) -> &Robj {
         &self.robj

--- a/extendr-api/src/wrapper/integers.rs
+++ b/extendr-api/src/wrapper/integers.rs
@@ -75,7 +75,7 @@ impl DerefMut for Integers {
     /// Treat Integers as if it is a mutable slice, like `Vec<Rint>`
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe {
-            let ptr = DATAPTR(self.get()) as *mut Rint;
+            let ptr = DATAPTR(self.get_mut()) as *mut Rint;
             std::slice::from_raw_parts_mut(ptr, self.len())
         }
     }

--- a/extendr-api/src/wrapper/list.rs
+++ b/extendr-api/src/wrapper/list.rs
@@ -169,7 +169,7 @@ impl List {
             if i >= self.robj.len() {
                 Err(Error::OutOfRange(self.robj.clone()))
             } else {
-                SET_VECTOR_ELT(self.robj.get(), i as R_xlen_t, value.get());
+                SET_VECTOR_ELT(self.robj.get_mut(), i as R_xlen_t, value.get());
                 Ok(())
             }
         }
@@ -384,7 +384,7 @@ impl<T: Into<Robj>> FromIterator<T> for List {
         let len = iter_collect.len();
 
         crate::single_threaded(|| unsafe {
-            let robj = Robj::alloc_vector(VECSXP, len);
+            let mut robj = Robj::alloc_vector(VECSXP, len);
             for (i, v) in iter_collect.into_iter().enumerate() {
                 // We don't PROTECT each element here, as they will be immediately
                 // placed into a list which will protect them:
@@ -392,7 +392,7 @@ impl<T: Into<Robj>> FromIterator<T> for List {
                 // note: Currently, `Robj` automatically registers `v` by the
                 // `ownership`-module, making it protected, even though it isn't necessary to do so.
                 let item: Robj = v.into();
-                SET_VECTOR_ELT(robj.get(), i as isize, item.get());
+                SET_VECTOR_ELT(robj.get_mut(), i as isize, item.get());
             }
 
             List { robj }

--- a/extendr-api/src/wrapper/logicals.rs
+++ b/extendr-api/src/wrapper/logicals.rs
@@ -45,7 +45,7 @@ impl Logicals {
 impl Logicals {
     pub fn set_elt(&mut self, index: usize, val: Rbool) {
         unsafe {
-            SET_INTEGER_ELT(self.get(), index as R_xlen_t, val.inner());
+            SET_INTEGER_ELT(self.get_mut(), index as R_xlen_t, val.inner());
         }
     }
 }
@@ -66,7 +66,7 @@ impl DerefMut for Logicals {
     /// Treat Logicals as if it is a mutable slice, like `Vec<Rint>`
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe {
-            let ptr = DATAPTR(self.get()) as *mut Rbool;
+            let ptr = DATAPTR(self.get_mut()) as *mut Rbool;
             std::slice::from_raw_parts_mut(ptr, self.len())
         }
     }

--- a/extendr-api/src/wrapper/matrix.rs
+++ b/extendr-api/src/wrapper/matrix.rs
@@ -108,7 +108,7 @@ where
 {
     /// Make a new column type.
     pub fn new_column<F: FnMut(usize) -> T>(nrows: usize, f: F) -> Self {
-        let robj = (0..nrows).map(f).collect_robj();
+        let mut robj = (0..nrows).map(f).collect_robj();
         let dim = [nrows];
         let mut robj = robj.set_attrib(wrapper::symbol::dim_symbol(), dim).unwrap();
         let slice = robj.as_typed_slice_mut().unwrap();
@@ -142,7 +142,7 @@ where
         ncols: usize,
         f: F,
     ) -> Self {
-        let robj = (0..ncols)
+        let mut robj = (0..ncols)
             .flat_map(|c| {
                 let mut g = f.clone();
                 (0..nrows).map(move |r| g(r, c))
@@ -175,7 +175,7 @@ where
         nmatrix: usize,
         f: F,
     ) -> Self {
-        let robj = (0..nmatrix)
+        let mut robj = (0..nmatrix)
             .flat_map(|m| {
                 let h = f.clone();
                 (0..ncols).flat_map(move |c| {

--- a/extendr-api/src/wrapper/mod.rs
+++ b/extendr-api/src/wrapper/mod.rs
@@ -72,8 +72,8 @@ where
 {
     single_threaded(|| unsafe {
         let values = values.into_iter();
-        let res = Robj::alloc_vector(sexptype, values.len());
-        let sexp = res.get();
+        let mut res = Robj::alloc_vector(sexptype, values.len());
+        let sexp = res.get_mut();
         for (i, val) in values.enumerate() {
             SET_VECTOR_ELT(sexp, i as R_xlen_t, val.into().get());
         }
@@ -139,6 +139,10 @@ macro_rules! make_getsexp {
         $($impl)* GetSexp for $typename {
             unsafe fn get(&self) -> SEXP {
                 self.robj.get()
+            }
+
+            unsafe fn get_mut(&mut self) -> SEXP {
+                self.robj.get_mut()
             }
 
             fn as_robj(&self) -> &Robj {

--- a/extendr-api/src/wrapper/strings.rs
+++ b/extendr-api/src/wrapper/strings.rs
@@ -47,8 +47,8 @@ impl Strings {
         single_threaded(|| unsafe {
             let values = values.into_iter();
             let maxlen = values.len();
-            let robj = Robj::alloc_vector(STRSXP, maxlen);
-            let sexp = robj.get();
+            let mut robj = Robj::alloc_vector(STRSXP, maxlen);
+            let sexp = robj.get_mut();
             for (i, v) in values.into_iter().take(maxlen).enumerate() {
                 let v = v.as_ref();
                 let ch = str_to_character(v);
@@ -82,7 +82,7 @@ impl Strings {
     pub fn set_elt(&mut self, i: usize, e: Rstr) {
         single_threaded(|| unsafe {
             if i < self.len() {
-                SET_STRING_ELT(self.robj.get(), i as isize, e.get());
+                SET_STRING_ELT(self.robj.get_mut(), i as isize, e.get());
             }
         });
     }
@@ -112,7 +112,7 @@ impl<T: AsRef<str>> FromIterator<T> for Strings {
         let mut robj = Strings::alloc_vector(STRSXP, len);
         crate::single_threaded(|| unsafe {
             for (i, v) in iter_collect.into_iter().enumerate() {
-                SET_STRING_ELT(robj.get(), i as isize, str_to_character(v.as_ref()));
+                SET_STRING_ELT(robj.get_mut(), i as isize, str_to_character(v.as_ref()));
             }
             Strings { robj }
         })

--- a/extendr-api/tests/issue-397-memory-allocation.rs
+++ b/extendr-api/tests/issue-397-memory-allocation.rs
@@ -14,7 +14,7 @@ fn test_allocation() {
             assert_eq!(Some((ix + 1) as f64), v.as_real())
         }
 
-        let obj: Robj = List::from_names_and_values(&["A"], vec![data]).into();
+        let mut obj: Robj = List::from_names_and_values(&["A"], vec![data]).into();
         obj.set_attrib(
             row_names_symbol(),
             (1i32..=COUNT as i32).collect_robj(),

--- a/extendr-macros/src/extendr_impl.rs
+++ b/extendr-macros/src/extendr_impl.rs
@@ -141,7 +141,7 @@ pub fn extendr_impl(mut item_impl: ItemImpl) -> TokenStream {
             fn from(value: #self_ty) -> Self {
                 unsafe {
                     let ptr = Box::into_raw(Box::new(value));
-                    let res = Robj::make_external_ptr(ptr, Robj::from(()));
+                    let mut res = Robj::make_external_ptr(ptr, Robj::from(()));
                     res.set_attrib(class_symbol(), #self_ty_name).unwrap();
                     res.register_c_finalizer(Some(#finalizer_name));
                     res
@@ -154,7 +154,7 @@ pub fn extendr_impl(mut item_impl: ItemImpl) -> TokenStream {
             fn from(value: &'a #self_ty) -> Self {
                 unsafe {
                     let ptr = Box::into_raw(Box::new(value));
-                    let res = Robj::make_external_ptr(ptr, Robj::from(()));
+                    let mut res = Robj::make_external_ptr(ptr, Robj::from(()));
                     res.set_attrib(class_symbol(), #self_ty_name).unwrap();
                     res.register_c_finalizer(Some(#finalizer_name));
                     res

--- a/tests/extendrtests/tests/testthat/_snaps/macro-snapshot.md
+++ b/tests/extendrtests/tests/testthat/_snaps/macro-snapshot.md
@@ -452,7 +452,7 @@
               fn from(value: MySubmoduleClass) -> Self {
                   unsafe {
                       let ptr = Box::into_raw(Box::new(value));
-                      let res = Robj::make_external_ptr(ptr, Robj::from(()));
+                      let mut res = Robj::make_external_ptr(ptr, Robj::from(()));
                       res.set_attrib(class_symbol(), "MySubmoduleClass").unwrap();
                       res.register_c_finalizer(Some(__finalize__MySubmoduleClass));
                       res
@@ -463,7 +463,7 @@
               fn from(value: &'a MySubmoduleClass) -> Self {
                   unsafe {
                       let ptr = Box::into_raw(Box::new(value));
-                      let res = Robj::make_external_ptr(ptr, Robj::from(()));
+                      let mut res = Robj::make_external_ptr(ptr, Robj::from(()));
                       res.set_attrib(class_symbol(), "MySubmoduleClass").unwrap();
                       res.register_c_finalizer(Some(__finalize__MySubmoduleClass));
                       res
@@ -2140,7 +2140,7 @@
               fn from(value: VecUsize) -> Self {
                   unsafe {
                       let ptr = Box::into_raw(Box::new(value));
-                      let res = Robj::make_external_ptr(ptr, Robj::from(()));
+                      let mut res = Robj::make_external_ptr(ptr, Robj::from(()));
                       res.set_attrib(class_symbol(), "VecUsize").unwrap();
                       res.register_c_finalizer(Some(__finalize__VecUsize));
                       res
@@ -2151,7 +2151,7 @@
               fn from(value: &'a VecUsize) -> Self {
                   unsafe {
                       let ptr = Box::into_raw(Box::new(value));
-                      let res = Robj::make_external_ptr(ptr, Robj::from(()));
+                      let mut res = Robj::make_external_ptr(ptr, Robj::from(()));
                       res.set_attrib(class_symbol(), "VecUsize").unwrap();
                       res.register_c_finalizer(Some(__finalize__VecUsize));
                       res
@@ -4976,7 +4976,7 @@
           fn from(value: MyClass) -> Self {
               unsafe {
                   let ptr = Box::into_raw(Box::new(value));
-                  let res = Robj::make_external_ptr(ptr, Robj::from(()));
+                  let mut res = Robj::make_external_ptr(ptr, Robj::from(()));
                   res.set_attrib(class_symbol(), "MyClass").unwrap();
                   res.register_c_finalizer(Some(__finalize__MyClass));
                   res
@@ -4987,7 +4987,7 @@
           fn from(value: &'a MyClass) -> Self {
               unsafe {
                   let ptr = Box::into_raw(Box::new(value));
-                  let res = Robj::make_external_ptr(ptr, Robj::from(()));
+                  let mut res = Robj::make_external_ptr(ptr, Robj::from(()));
                   res.set_attrib(class_symbol(), "MyClass").unwrap();
                   res.register_c_finalizer(Some(__finalize__MyClass));
                   res
@@ -5200,7 +5200,7 @@
           fn from(value: __MyClass) -> Self {
               unsafe {
                   let ptr = Box::into_raw(Box::new(value));
-                  let res = Robj::make_external_ptr(ptr, Robj::from(()));
+                  let mut res = Robj::make_external_ptr(ptr, Robj::from(()));
                   res.set_attrib(class_symbol(), "__MyClass").unwrap();
                   res.register_c_finalizer(Some(__finalize____MyClass));
                   res
@@ -5211,7 +5211,7 @@
           fn from(value: &'a __MyClass) -> Self {
               unsafe {
                   let ptr = Box::into_raw(Box::new(value));
-                  let res = Robj::make_external_ptr(ptr, Robj::from(()));
+                  let mut res = Robj::make_external_ptr(ptr, Robj::from(()));
                   res.set_attrib(class_symbol(), "__MyClass").unwrap();
                   res.register_c_finalizer(Some(__finalize____MyClass));
                   res
@@ -5438,7 +5438,7 @@
           fn from(value: MyClassUnexported) -> Self {
               unsafe {
                   let ptr = Box::into_raw(Box::new(value));
-                  let res = Robj::make_external_ptr(ptr, Robj::from(()));
+                  let mut res = Robj::make_external_ptr(ptr, Robj::from(()));
                   res.set_attrib(class_symbol(), "MyClassUnexported").unwrap();
                   res.register_c_finalizer(Some(__finalize__MyClassUnexported));
                   res
@@ -5449,7 +5449,7 @@
           fn from(value: &'a MyClassUnexported) -> Self {
               unsafe {
                   let ptr = Box::into_raw(Box::new(value));
-                  let res = Robj::make_external_ptr(ptr, Robj::from(()));
+                  let mut res = Robj::make_external_ptr(ptr, Robj::from(()));
                   res.set_attrib(class_symbol(), "MyClassUnexported").unwrap();
                   res.register_c_finalizer(Some(__finalize__MyClassUnexported));
                   res


### PR DESCRIPTION
In `GetSexp` we have a `get`, but not a `get_mut`. While these functions return pointers, it doesn't mean the semantics of exclusive (`mut`) and shared (`ref`) should be completely neglected.

I believe this is referred to as unsoundness.

EDIT:

- [ ] It is important that the unsoundness from `Clone for &Robj` is dealt with as well.
