### PR TITLE
Add `clap` to parse cmd args of `xtask`

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -12,4 +12,5 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = { version = "4.4.6", features = ["derive"] }
 xshell = "*"

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -1,0 +1,32 @@
+use clap::{Args, Parser, Subcommand};
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+pub(crate) struct Cli {
+    #[command(subcommand)]
+    pub(crate) command: Commands,
+}
+
+#[derive(Subcommand, Debug)]
+pub(crate) enum Commands {
+    #[command(about = "Run cargo fmt on extendr")]
+    CheckFmt,
+    #[command(about = "Run R CMD check on {extendrtests}")]
+    RCmdCheck(RCmdCheckArg),
+    #[command(about = "Generate docs")]
+    Doc,
+    #[command(about = "???")]
+    Msrv,
+    #[command(about = "Run devtools::test() on {extendrtests}")]
+    DevtoolsTest,
+}
+
+#[derive(Args, Debug)]
+pub(crate) struct RCmdCheckArg {
+    #[arg(long, default_value = "false", help = "Passed to R CMD check")]
+    pub(crate) no_build_vignettes: bool,
+}
+
+pub(crate) fn parse() -> Cli {
+    Cli::parse()
+}

--- a/xtask/src/commands/cargo_fmt_check.rs
+++ b/xtask/src/commands/cargo_fmt_check.rs
@@ -1,0 +1,5 @@
+use xshell::{cmd, Error, Shell};
+
+pub(crate) fn run(shell: &Shell) -> Result<(), Error> {
+    cmd!(shell, "cargo fmt -- --check").run()
+}

--- a/xtask/src/commands/cargo_msrv.rs
+++ b/xtask/src/commands/cargo_msrv.rs
@@ -1,0 +1,18 @@
+use xshell::{Error, Shell};
+
+pub(crate) fn run(_shell: &Shell) -> Result<(), Error> {
+    // let msrv = cmd!(shell, "cargo-msrv --path extendr-api/ verify");
+    // match msrv.run() {
+    //     Ok(_) => {}
+    //     Err(error) => {
+    //         //FIXME: Displays badly
+    //         return Err(format!(
+    //             "{}\n\nInstall `cargo-msrv` by `cargo install cargo-msrv`",
+    //             error.to_string()
+    //         )
+    //         .into());
+    //     }
+    // }
+    //
+    unimplemented!("cargo-msrv --path extendr-api")
+}

--- a/xtask/src/commands/devtools_test.rs
+++ b/xtask/src/commands/devtools_test.rs
@@ -1,0 +1,10 @@
+use xshell::{Error, Shell};
+
+pub(crate) fn run(_shell: &Shell) -> Result<(), Error> {
+    // {
+    //     let _ = shell.push_dir(shell.current_dir().join("tests").join("extendrtests"));
+    //     let extendrtests = cmd!(shell, "R -e \"devtools::test()\" ").run()?;
+    // }
+
+    unreachable!("devtools::test()")
+}

--- a/xtask/src/commands/generate_docs.rs
+++ b/xtask/src/commands/generate_docs.rs
@@ -1,0 +1,11 @@
+use xshell::{Error, Shell};
+
+pub(crate) fn run(_shell: &Shell) -> Result<(), Error> {
+    // let generate_docs = cmd!(
+    //     shell,
+    //     "cargo doc --workspace --no-deps --document-private-items --features full-functionality"
+    // )
+    unimplemented!(
+        "cargo doc --workspace --no-deps --document-private-items --features full-functionality"
+    )
+}

--- a/xtask/src/commands/mod.rs
+++ b/xtask/src/commands/mod.rs
@@ -1,0 +1,5 @@
+pub(crate) mod cargo_fmt_check;
+pub(crate) mod cargo_msrv;
+pub(crate) mod devtools_test;
+pub(crate) mod generate_docs;
+pub(crate) mod r_cmd_check;

--- a/xtask/src/commands/r_cmd_check.rs
+++ b/xtask/src/commands/r_cmd_check.rs
@@ -1,0 +1,17 @@
+use xshell::{Error, Shell};
+
+pub(crate) fn run(shell: &Shell, no_build_vignettes: bool) -> Result<(), Error> {
+    let mut cmd = shell
+        .cmd("R")
+        .arg("CMD")
+        .arg("check")
+        .arg("tests/extendrtests")
+        .arg("--no-manual")
+        .arg("--as-cran")
+        .arg("--force-multiarch");
+
+    if no_build_vignettes {
+        cmd = cmd.arg("--no-build-vignettes");
+    }
+    cmd.run()
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,42 +1,28 @@
-use xshell::{cmd, Shell};
+use xshell::Shell;
+
+use crate::cli::RCmdCheckArg;
+
+mod cli;
+mod commands;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cli = cli::parse();
     let shell = Shell::new()?;
+
     // xtask
     // shell.change_dir(std::env::var("CARGO_MANIFEST_DIR")?);
     // dbg!(&shell.current_dir());
-    let generate_docs = cmd!(
-        shell,
-        "cargo doc --workspace --no-deps --document-private-items --features full-functionality"
-    )
-    .run()?;
-    {
-        let _ = shell.push_dir(shell.current_dir().join("tests").join("extendrtests"));
-        let extendrtests = cmd!(shell, "R -e \"devtools::test()\" ").run()?;
-    }
+    dbg! {&cli};
 
-    //TODO: Add option for `--no-build-vignettes`
-
-    let rcmdcheck_extendrtests = cmd!(
-        shell,
-        "R CMD check --no-manual --as-cran --force-multiarch tests/extendrtests"
-    )
-    .run()?;
-
-    let fmt_check = cmd!(shell, "cargo fmt -- --check").run()?;
-
-    let msrv = cmd!(shell, "cargo-msrv --path extendr-api/ verify");
-    match msrv.run() {
-        Ok(_) => {}
-        Err(error) => {
-            //FIXME: Displays badly
-            return Err(format!(
-                "{}\n\nInstall `cargo-msrv` by `cargo install cargo-msrv`",
-                error.to_string()
-            )
-            .into());
+    let result = match cli.command {
+        cli::Commands::CheckFmt => commands::cargo_fmt_check::run(&shell)?,
+        cli::Commands::RCmdCheck(RCmdCheckArg { no_build_vignettes }) => {
+            commands::r_cmd_check::run(&shell, no_build_vignettes)?
         }
-    }
+        cli::Commands::Doc => commands::generate_docs::run(&shell)?,
+        cli::Commands::Msrv => commands::cargo_msrv::run(&shell)?,
+        cli::Commands::DevtoolsTest => commands::devtools_test::run(&shell)?,
+    };
 
-    Ok(())
+    Ok(result)
 }


### PR DESCRIPTION
- Use `clap` to parse cmd args
- Split tasks into separate modules
- Task implementation not yet fixed