### PR TITLE
Implement `devtools-test` xtask

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -13,4 +13,5 @@ publish = false
 
 [dependencies]
 clap = { version = "4.4.6", features = ["derive"] }
+toml_edit = "0.20.2"
 xshell = "*"

--- a/xtask/src/commands/devtools_test.rs
+++ b/xtask/src/commands/devtools_test.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
 use std::path::Path;
 
-use toml_edit::Document;
+use toml_edit::{Document, InlineTable, Value};
 use xshell::Shell;
 
 pub(crate) fn run(shell: &Shell) -> Result<(), Box<dyn Error>> {
@@ -11,15 +11,40 @@ pub(crate) fn run(shell: &Shell) -> Result<(), Box<dyn Error>> {
     // }
 
     {
-        let _ = shell.push_dir("tests/extendrtests/src/rust");
+        let _rust_folder = shell.push_dir("tests/extendrtests/src/rust");
 
-        let (cargo_toml, is_crlf) = read_file_with_line_ending(&shell, "Cargo.toml")?;
+        let (original_cargo_toml, is_crlf) = read_file_with_line_ending(&shell, "Cargo.toml")?;
 
-        let cargo_toml: Document = cargo_toml.parse()?;
+        let original_cargo_toml: Document = original_cargo_toml.parse()?;
+
+        let mut cargo_toml = original_cargo_toml.clone();
+
+        let extendr_api_entry = get_extendr_api_entry(&mut cargo_toml)
+            .ok_or("`extendr-api` not found in Cargo.toml")?;
+
+        let mut replacement = InlineTable::new();
+        let item = Value::from(
+            shell
+                .current_dir()
+                .into_os_string()
+                .to_string_lossy()
+                .to_string()
+                .replace("\\", "/"),
+        );
+        replacement.entry("path").or_insert(item);
+        *extendr_api_entry = Value::InlineTable(replacement);
 
         write_file_preserve_line_ending(&shell, "Cargo.toml", &cargo_toml, is_crlf)?;
     }
     unreachable!("devtools::test()")
+}
+
+fn get_extendr_api_entry(document: &mut Document) -> Option<&mut Value> {
+    document
+        .get_mut("patch")?
+        .get_mut("crates-io")?
+        .get_mut("extendr-api")?
+        .as_value_mut()
 }
 
 fn read_file_with_line_ending<P: AsRef<Path>>(

--- a/xtask/src/commands/devtools_test.rs
+++ b/xtask/src/commands/devtools_test.rs
@@ -1,10 +1,47 @@
-use xshell::{Error, Shell};
+use std::error::Error;
+use std::path::Path;
 
-pub(crate) fn run(_shell: &Shell) -> Result<(), Error> {
+use toml_edit::Document;
+use xshell::Shell;
+
+pub(crate) fn run(shell: &Shell) -> Result<(), Box<dyn Error>> {
     // {
     //     let _ = shell.push_dir(shell.current_dir().join("tests").join("extendrtests"));
     //     let extendrtests = cmd!(shell, "R -e \"devtools::test()\" ").run()?;
     // }
 
+    {
+        let _ = shell.push_dir("tests/extendrtests/src/rust");
+
+        let (cargo_toml, is_crlf) = read_file_with_line_ending(&shell, "Cargo.toml")?;
+
+        let cargo_toml: Document = cargo_toml.parse()?;
+
+        write_file_preserve_line_ending(&shell, "Cargo.toml", &cargo_toml, is_crlf)?;
+    }
     unreachable!("devtools::test()")
+}
+
+fn read_file_with_line_ending<P: AsRef<Path>>(
+    shell: &Shell,
+    path: P,
+) -> Result<(String, bool), Box<dyn Error>> {
+    let file_contents = shell.read_binary_file(path)?;
+    let file_contents = String::from_utf8(file_contents)?;
+    let is_crlf = file_contents.contains("\r\n");
+    Ok((file_contents, is_crlf))
+}
+
+fn write_file_preserve_line_ending<P: AsRef<Path>>(
+    shell: &Shell,
+    path: P,
+    contents: &Document,
+    is_crlf: bool,
+) -> Result<(), Box<dyn Error>> {
+    let mut file_contents = contents.to_string();
+    if is_crlf {
+        file_contents = file_contents.replace("\n", "\r\n");
+    }
+    shell.write_file(path, file_contents)?;
+    Ok(())
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use xshell::Shell;
 
 use crate::cli::RCmdCheckArg;
@@ -9,9 +11,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = cli::parse();
     let shell = Shell::new()?;
 
-    // xtask
-    // shell.change_dir(std::env::var("CARGO_MANIFEST_DIR")?);
-    // dbg!(&shell.current_dir());
+    let path: PathBuf = std::env::var("CARGO_MANIFEST_DIR")?.parse()?;
+
+    shell.change_dir(
+        path.parent()
+            .ok_or("Failed to get parent dir")?
+            .canonicalize()?,
+    );
+
+    dbg!(&shell.current_dir());
+
     dbg! {&cli};
 
     let result = match cli.command {


### PR DESCRIPTION
Implement `devtools-test` with correct absolute path substitution. Allows running `devtools::test()` on `{extendrtests}` from any folder within `extendr/` folder. Changes `Cargo.toml` on the fly, substituting absolute path to local `extendr-api` folder. Reverts changes back after tests finish.