### PR TITLE
`xtask`: Add `r-cmd-check`

### DIFF
--- a/xtask/src/commands/devtools_test.rs
+++ b/xtask/src/commands/devtools_test.rs
@@ -1,12 +1,9 @@
 use std::error::Error;
-use std::path::Path;
 
-use toml_edit::{Document, InlineTable, Value};
+use crate::extendrtests::with_absolute_path::swap_extendr_api_path;
 use xshell::{cmd, Shell};
 
-const RUST_FOLDER_PATH: &str = "tests/extendrtests/src/rust";
 const R_FOLDER_PATH: &str = "tests/extendrtests";
-const CARGO_TOML: &str = "Cargo.toml";
 
 pub(crate) fn run(shell: &Shell) -> Result<(), Box<dyn Error>> {
     let _document_handle = swap_extendr_api_path(shell)?;
@@ -16,77 +13,9 @@ pub(crate) fn run(shell: &Shell) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[derive(Debug, Clone)]
-struct DocumentHandle<'a> {
-    document: Vec<u8>,
-    shell: &'a Shell,
-}
-
-impl<'a> Drop for DocumentHandle<'a> {
-    fn drop(&mut self) {
-        let _rust_folder = self.shell.push_dir(RUST_FOLDER_PATH);
-        self.shell
-            .write_file(CARGO_TOML, &self.document)
-            .expect("Failed to restore Cargo.toml");
-    }
-}
-
 fn run_tests(shell: &Shell) -> Result<(), Box<dyn Error>> {
     let _r_path = shell.push_dir(R_FOLDER_PATH);
     cmd!(shell, "Rscript -e devtools::test()").run()?;
 
     Ok(())
-}
-
-fn swap_extendr_api_path(shell: &Shell) -> Result<DocumentHandle, Box<dyn Error>> {
-    let current_path = shell.current_dir();
-    let _rust_folder = shell.push_dir(RUST_FOLDER_PATH);
-
-    let original_cargo_toml_bytes = read_file_with_line_ending(shell, CARGO_TOML)?;
-
-    let original_cargo_toml: Document = std::str::from_utf8(&original_cargo_toml_bytes)?.parse()?;
-
-    let mut cargo_toml = original_cargo_toml.clone();
-
-    let extendr_api_entry =
-        get_extendr_api_entry(&mut cargo_toml).ok_or("`extendr-api` not found in Cargo.toml")?;
-
-    let mut replacement = InlineTable::new();
-
-    let item = Value::from(get_replacement_path(&current_path));
-    replacement.entry("path").or_insert(item);
-    *extendr_api_entry = Value::InlineTable(replacement);
-
-    shell.write_file(CARGO_TOML, cargo_toml.to_string())?;
-    Ok(DocumentHandle {
-        document: original_cargo_toml_bytes,
-        shell,
-    })
-}
-
-fn get_replacement_path(path: &Path) -> String {
-    let path = path.to_string_lossy();
-    let path = if cfg!(target_os = "windows") && path.starts_with(r"\\?\") {
-        path[4..].replace('\\', "/")
-    } else {
-        path.to_string()
-    };
-
-    format!("{}/extendr-api", path)
-}
-
-fn get_extendr_api_entry(document: &mut Document) -> Option<&mut Value> {
-    document
-        .get_mut("patch")?
-        .get_mut("crates-io")?
-        .get_mut("extendr-api")?
-        .as_value_mut()
-}
-
-fn read_file_with_line_ending<P: AsRef<Path>>(
-    shell: &Shell,
-    path: P,
-) -> Result<Vec<u8>, Box<dyn Error>> {
-    let file_contents = shell.read_binary_file(path)?;
-    Ok(file_contents)
 }

--- a/xtask/src/commands/devtools_test.rs
+++ b/xtask/src/commands/devtools_test.rs
@@ -1,9 +1,8 @@
 use std::error::Error;
 
-use crate::extendrtests::with_absolute_path::swap_extendr_api_path;
 use xshell::{cmd, Shell};
 
-const R_FOLDER_PATH: &str = "tests/extendrtests";
+use crate::extendrtests::with_absolute_path::{swap_extendr_api_path, R_FOLDER_PATH};
 
 pub(crate) fn run(shell: &Shell) -> Result<(), Box<dyn Error>> {
     let _document_handle = swap_extendr_api_path(shell)?;

--- a/xtask/src/commands/r_cmd_check.rs
+++ b/xtask/src/commands/r_cmd_check.rs
@@ -1,17 +1,32 @@
-use xshell::{Error, Shell};
+use std::error::Error;
 
-pub(crate) fn run(shell: &Shell, no_build_vignettes: bool) -> Result<(), Error> {
-    let mut cmd = shell
-        .cmd("R")
-        .arg("CMD")
-        .arg("check")
-        .arg("tests/extendrtests")
-        .arg("--no-manual")
-        .arg("--as-cran")
-        .arg("--force-multiarch");
+use xshell::Shell;
 
+use crate::extendrtests::with_absolute_path::{swap_extendr_api_path, R_FOLDER_PATH};
+
+pub(crate) fn run(shell: &Shell, no_build_vignettes: bool) -> Result<(), Box<dyn Error>> {
+    let _document_handle = swap_extendr_api_path(shell)?;
+
+    run_r_cmd_check(shell, no_build_vignettes)
+}
+
+fn run_r_cmd_check(shell: &Shell, no_build_vignettes: bool) -> Result<(), Box<dyn Error>> {
+    let _r_path = shell.push_dir(R_FOLDER_PATH);
+    let mut args = vec!["'--as-cran'", "'--no-manual'"];
     if no_build_vignettes {
-        cmd = cmd.arg("--no-build-vignettes");
+        args.push("'--no-build-vignettes'");
     }
-    cmd.run()
+
+    let args = format!("c({0})", args.join(", "));
+
+    shell
+        .cmd("Rscript")
+        .arg("-e")
+        .arg(format!(
+            "rcmdcheck::rcmdcheck(args = {}, error_on = 'warning')",
+            args
+        ))
+        .run()?;
+
+    Ok(())
 }

--- a/xtask/src/commands/r_cmd_check.rs
+++ b/xtask/src/commands/r_cmd_check.rs
@@ -23,8 +23,7 @@ fn run_r_cmd_check(shell: &Shell, no_build_vignettes: bool) -> Result<(), Box<dy
         .cmd("Rscript")
         .arg("-e")
         .arg(format!(
-            "rcmdcheck::rcmdcheck(args = {}, error_on = 'warning')",
-            args
+            "rcmdcheck::rcmdcheck(args = {args}, error_on = 'warning')"
         ))
         .run()?;
 

--- a/xtask/src/extendrtests/mod.rs
+++ b/xtask/src/extendrtests/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod with_absolute_path;

--- a/xtask/src/extendrtests/with_absolute_path.rs
+++ b/xtask/src/extendrtests/with_absolute_path.rs
@@ -1,0 +1,76 @@
+use std::error::Error;
+use std::path::Path;
+
+use toml_edit::{Document, InlineTable, Value};
+use xshell::Shell;
+
+const RUST_FOLDER_PATH: &str = "tests/extendrtests/src/rust";
+const CARGO_TOML: &str = "Cargo.toml";
+
+#[derive(Debug)]
+pub(crate) struct DocumentHandle<'a> {
+    document: Vec<u8>,
+    shell: &'a Shell,
+}
+
+impl<'a> Drop for DocumentHandle<'a> {
+    fn drop(&mut self) {
+        let _rust_folder = self.shell.push_dir(RUST_FOLDER_PATH);
+        self.shell
+            .write_file(CARGO_TOML, &self.document)
+            .expect("Failed to restore Cargo.toml");
+    }
+}
+
+pub(crate) fn swap_extendr_api_path(shell: &Shell) -> Result<DocumentHandle, Box<dyn Error>> {
+    let current_path = shell.current_dir();
+    let _rust_folder = shell.push_dir(RUST_FOLDER_PATH);
+
+    let original_cargo_toml_bytes = read_file_with_line_ending(shell, CARGO_TOML)?;
+
+    let original_cargo_toml: Document = std::str::from_utf8(&original_cargo_toml_bytes)?.parse()?;
+
+    let mut cargo_toml = original_cargo_toml.clone();
+
+    let extendr_api_entry =
+        get_extendr_api_entry(&mut cargo_toml).ok_or("`extendr-api` not found in Cargo.toml")?;
+
+    let mut replacement = InlineTable::new();
+
+    let item = Value::from(get_replacement_path(&current_path));
+    replacement.entry("path").or_insert(item);
+    *extendr_api_entry = Value::InlineTable(replacement);
+
+    shell.write_file(CARGO_TOML, cargo_toml.to_string())?;
+    Ok(DocumentHandle {
+        document: original_cargo_toml_bytes,
+        shell,
+    })
+}
+
+fn get_replacement_path(path: &Path) -> String {
+    let path = path.to_string_lossy();
+    let path = if cfg!(target_os = "windows") && path.starts_with(r"\\?\") {
+        path[4..].replace('\\', "/")
+    } else {
+        path.to_string()
+    };
+
+    format!("{}/extendr-api", path)
+}
+
+fn get_extendr_api_entry(document: &mut Document) -> Option<&mut Value> {
+    document
+        .get_mut("patch")?
+        .get_mut("crates-io")?
+        .get_mut("extendr-api")?
+        .as_value_mut()
+}
+
+fn read_file_with_line_ending<P: AsRef<Path>>(
+    shell: &Shell,
+    path: P,
+) -> Result<Vec<u8>, Box<dyn Error>> {
+    let file_contents = shell.read_binary_file(path)?;
+    Ok(file_contents)
+}

--- a/xtask/src/extendrtests/with_absolute_path.rs
+++ b/xtask/src/extendrtests/with_absolute_path.rs
@@ -4,6 +4,8 @@ use std::path::Path;
 use toml_edit::{Document, InlineTable, Value};
 use xshell::Shell;
 
+pub(crate) const R_FOLDER_PATH: &str = "tests/extendrtests";
+
 const RUST_FOLDER_PATH: &str = "tests/extendrtests/src/rust";
 const CARGO_TOML: &str = "Cargo.toml";
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -6,6 +6,7 @@ use xshell::Shell;
 
 mod cli;
 mod commands;
+mod extendrtests;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = cli::parse();


### PR DESCRIPTION
Prototype implementation based on calling `rcmdcheck::rcmdcheck()`. We can do it manually, but it requires using a temp dir, copying files there, running `R CMD build` and only then `R CMD check`. Let's resort to using a proven R package for now.

Reuses the same Cargo rewriting mechanism as `devtools-test`, which is now improved & stores original Cargo.toml as bytes (no cr/lf issue).