### PR TITLE
[CI] Use `cargo extendr r-cmd-check` to run `{extendrtests}`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -206,7 +206,7 @@ jobs:
 
       - name: Run R integration tests using {extendrtests} and `cargo extendr r-cmd-check`
         run: |
-          cargo extendr r-cmd-check --error-on ${{ steps.error-on.outputs.level }}
+          cargo extendr r-cmd-check --error-on ${{ steps.error-on.outputs.level }} --check-dir extendrtests_check
 
       # With https://github.com/extendr/rextendr/pull/31
       # rextendr can be configured using environment variables.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,20 +26,20 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: 'release', rust-version: 'stable-msvc', rtools-version: '43'}
-          - {os: windows-latest, r: 'devel',   rust-version: 'stable-msvc', rtools-version: '43'}
-          - {os: windows-latest, r: 'oldrel',  rust-version: 'stable-msvc', rtools-version: '42'}
+          - { os: windows-latest, r: 'release', rust-version: 'stable-msvc', rtools-version: '43' }
+          - { os: windows-latest, r: 'devel',   rust-version: 'stable-msvc', rtools-version: '43' }
+          - { os: windows-latest, r: 'oldrel',  rust-version: 'stable-msvc', rtools-version: '42' }
 
-          - {os: macOS-latest,   r: 'release', rust-version: 'stable'}
+          - { os: macOS-latest,   r: 'release', rust-version: 'stable' }
           # - {os: macOS-latest,   r: 'release', rust-version: 'nightly'}
           # - {os: macOS-latest,   r: 'devel', rust-version: 'stable'}
           # - {os: macOS-latest,   r: 'oldrel', rust-version: 'stable'}
 
-          - {os: ubuntu-latest,   r: 'release', rust-version: 'stable', check_fmt: true}
-          - {os: ubuntu-latest,   r: 'release', rust-version: 'nightly'}
+          - { os: ubuntu-latest,   r: 'release', rust-version: 'stable', check_fmt: true }
+          - { os: ubuntu-latest,   r: 'release', rust-version: 'nightly' }
           # R-devel requires LD_LIBRARY_PATH
-          - {os: ubuntu-latest,   r: 'devel',   rust-version: 'stable'}
-          - {os: ubuntu-latest,   r: 'oldrel',  rust-version: 'stable'}
+          - { os: ubuntu-latest,   r: 'devel',   rust-version: 'stable' }
+          - { os: ubuntu-latest,   r: 'oldrel',  rust-version: 'stable' }
 
 
 
@@ -136,7 +136,7 @@ jobs:
           [env]
           LIBRARY_PATH = "${pwd_slash}/libgcc_mock"
           "@ | Out-File -FilePath .cargo/config.toml -Encoding utf8 -Append ;
-        env: 
+        env:
           RUST_TOOLCHAIN: ${{ matrix.config.rust-version }}
 
       # This is required for ubuntu r-devel
@@ -190,21 +190,8 @@ jobs:
         with:
           cache-version: 4
           working-directory: tests/rextendr
-
-      # Regex is used to inject absolute path into Cargo.toml
-      - name: Configure R for integration testing
-        run: |
-          api_path <- normalizePath(file.path(getwd(), "extendr-api"), winslash = "/")
-          toml_path <- file.path(getwd(), "tests", "extendrtests", "src", "rust", "Cargo.toml")
-          lines <- readLines(toml_path)
-          lines <- gsub(
-            "(^\\s*extendr-api\\s*=\\s*\\{\\s*path\\s*=\\s*\")(.*?)(\"\\s*\\})",
-            paste0("\\1", api_path, "\\3"),
-            lines
-          )
-          writeLines(lines, toml_path)
-        shell: Rscript {0}
-
+      
+      
       # TODO: allow warnings on oldrel (cf., https://stat.ethz.ch/pipermail/r-package-devel/2023q2/009229.html)
       - name: Check R version
         id: error-on
@@ -217,17 +204,9 @@ jobs:
           }
         shell: Rscript {0}
 
-      # Windows: modified PATH will launch 32-bit Rscript if the build targets only i686/i386, so no conflict will arise
-      # Rust pseudo multi-targeting: R CMD CHECK receives an extra argument '--no-multiarch' if BUILD_TARGETS is not 'default' and does not contain any commas
-      # To enable RStudio support, extendrtests should be installable from 'extendr/tests/extendrtests',
-      # for this work directory should be modified and then reverted back
-      - name: Run R intergration tests using {extendrtests}
-        uses: r-lib/actions/check-r-package@v2
-        with:
-          args: 'c("--no-manual", "--as-cran", "--force-multiarch")'
-          working-directory: 'tests/extendrtests'
-          check-dir: '"extendrtests_check"'
-          error-on: '"${{ steps.error-on.outputs.level }}"'
+      - name: Run R integration tests using {extendrtests} and `cargo extendr r-cmd-check`
+        run: |
+          cargo extendr r-cmd-check --error-on ${{ steps.error-on.outputs.level }}
 
       # With https://github.com/extendr/rextendr/pull/31
       # rextendr can be configured using environment variables.
@@ -283,20 +262,20 @@ jobs:
     runs-on: ${{ matrix.config.os }}
 
     name: ${{ matrix.config.os }} w/ bindgen (R-${{ matrix.config.r }} rust-${{ matrix.config.rust-version }} ${{join(matrix.config.rust-targets, ',')}})
-            
+    
     strategy:
       fail-fast: false
       matrix:
         config:
-          - {os: ubuntu-latest,  r: 'devel',   rust-version: 'stable'}
-          - {os: macOS-latest,   r: 'devel',   rust-version: 'stable'}
-          - {os: windows-latest, r: 'release', rust-version: 'stable-msvc',  rust-targets: ['x86_64-pc-windows-gnu'], rtools-version: '43'}
-          - {os: windows-latest, r: 'devel',   rust-version: 'stable-msvc',  rust-targets: ['x86_64-pc-windows-gnu'], rtools-version: '43'}
+          - { os: ubuntu-latest,  r: 'devel',   rust-version: 'stable' }
+          - { os: macOS-latest,   r: 'devel',   rust-version: 'stable' }
+          - { os: windows-latest, r: 'release', rust-version: 'stable-msvc',  rust-targets: [ 'x86_64-pc-windows-gnu' ], rtools-version: '43' }
+          - { os: windows-latest, r: 'devel',   rust-version: 'stable-msvc',  rust-targets: [ 'x86_64-pc-windows-gnu' ], rtools-version: '43' }
           # When the MSVC target is used, since it's cross-compilation from MSVC
           # to GNU, the doc tests are usually skipped. Adding `-Zdoctest-xcompile`
           # lets the doctests run, which accordingly require the nightly toolchain.
-          - {os: windows-latest, r: 'release', rust-version: 'nightly-msvc', rust-targets: ['x86_64-pc-windows-gnu'], rtools-version: '43', extra-args: ['-Zdoctest-xcompile']}
-          - {os: windows-latest, r: 'oldrel',  rust-version: 'nightly-msvc', rust-targets: ['x86_64-pc-windows-gnu'], rtools-version: '42', extra-args: ['-Zdoctest-xcompile']}
+          - { os: windows-latest, r: 'release', rust-version: 'nightly-msvc', rust-targets: [ 'x86_64-pc-windows-gnu' ], rtools-version: '43', extra-args: [ '-Zdoctest-xcompile' ] }
+          - { os: windows-latest, r: 'oldrel',  rust-version: 'nightly-msvc', rust-targets: [ 'x86_64-pc-windows-gnu' ], rtools-version: '42', extra-args: [ '-Zdoctest-xcompile' ] }
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
@@ -423,11 +402,11 @@ jobs:
             }
 
             ci-cargo +$toolchain build --manifest-path extendr-api/Cargo.toml --features tests-all $(if($target -ne 'default') {"--target=$target"} ) -ActionName "Build extendr-api for $toolchain/$target"
-         
+          
             ci-cargo +$toolchain build --manifest-path extendr-engine/Cargo.toml --features tests-all $(if($target -ne 'default') {"--target=$target"} ) -ActionName "Build extendr-engine for $toolchain/$target"
-            
+          
           }
-        env: 
+        env:
           BUILD_TARGETS: ${{ join(matrix.config.rust-targets, ',') }}
           RUST_TOOLCHAIN: ${{ matrix.config.rust-version }}
 
@@ -455,11 +434,11 @@ jobs:
             ci-cargo +$toolchain test graphics_tests:: --manifest-path extendr-api/Cargo.toml --features tests-graphics $(if($target -ne 'default') {"--target=$target"} ) $env:EXTRA_ARGS '--' --nocapture --test-threads=1 -ActionName "Test extendr-api \w graphics for $target target"
 
             ci-cargo +$toolchain test --manifest-path extendr-api/Cargo.toml --features tests-minimal $(if($target -ne 'default') {"--target=$target"} ) $env:EXTRA_ARGS '--' --nocapture -ActionName "Test extendr-api \w tests-minimal for $target target"
-                      
+          
             ci-cargo +$toolchain test --manifest-path extendr-macros/Cargo.toml  $(if($target -ne 'default') {"--target=$target"} ) $env:EXTRA_ARGS '--' --nocapture -ActionName "Test extendr-macros for $target target"
-            
+          
           }
-        env: 
+        env:
           BUILD_TARGETS: ${{ join(matrix.config.rust-targets, ',') }}
           RUST_TOOLCHAIN: ${{ matrix.config.rust-version }}
           EXTRA_ARGS: ${{ join(matrix.config.extra-args, ',') }}

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -25,6 +25,16 @@ pub(crate) enum Commands {
 pub(crate) struct RCmdCheckArg {
     #[arg(long, default_value = "false", help = "Passed to R CMD check")]
     pub(crate) no_build_vignettes: bool,
+    #[arg(long, short, default_value = "warning", help = "Passed to R CMD check")]
+    pub(crate) error_on: ErrorOn,
+}
+
+#[derive(ValueEnum, Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) enum ErrorOn {
+    Never,
+    Note,
+    Warning,
+    Error,
 }
 
 pub(crate) fn parse() -> Cli {

--- a/xtask/src/cli/mod.rs
+++ b/xtask/src/cli/mod.rs
@@ -1,4 +1,8 @@
-use clap::{Args, Parser, Subcommand, ValueEnum};
+use clap::{Parser, Subcommand};
+
+use crate::cli::r_cmd_check::RCmdCheckArg;
+
+mod r_cmd_check;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -19,22 +23,6 @@ pub(crate) enum Commands {
     Msrv,
     #[command(about = "Run devtools::test() on {extendrtests}")]
     DevtoolsTest,
-}
-
-#[derive(Args, Debug)]
-pub(crate) struct RCmdCheckArg {
-    #[arg(long, default_value = "false", help = "Passed to R CMD check")]
-    pub(crate) no_build_vignettes: bool,
-    #[arg(long, short, default_value = "warning", help = "Passed to R CMD check")]
-    pub(crate) error_on: ErrorOn,
-}
-
-#[derive(ValueEnum, Debug, Clone, Copy, Eq, PartialEq)]
-pub(crate) enum ErrorOn {
-    Never,
-    Note,
-    Warning,
-    Error,
 }
 
 pub(crate) fn parse() -> Cli {

--- a/xtask/src/cli/mod.rs
+++ b/xtask/src/cli/mod.rs
@@ -2,7 +2,7 @@ use clap::{Parser, Subcommand};
 
 use crate::cli::r_cmd_check::RCmdCheckArg;
 
-mod r_cmd_check;
+pub(crate) mod r_cmd_check;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]

--- a/xtask/src/cli/r_cmd_check.rs
+++ b/xtask/src/cli/r_cmd_check.rs
@@ -1,3 +1,4 @@
+use crate::commands::r_cmd_check::RCmdCheckErrorOn;
 use clap::{Args, ValueEnum};
 
 #[derive(Args, Debug)]
@@ -14,4 +15,15 @@ pub(crate) enum ErrorOn {
     Note,
     Warning,
     Error,
+}
+
+impl Into<RCmdCheckErrorOn> for ErrorOn {
+    fn into(self) -> RCmdCheckErrorOn {
+        match self {
+            ErrorOn::Never => RCmdCheckErrorOn::Never,
+            ErrorOn::Note => RCmdCheckErrorOn::Note,
+            ErrorOn::Warning => RCmdCheckErrorOn::Warning,
+            ErrorOn::Error => RCmdCheckErrorOn::Error,
+        }
+    }
 }

--- a/xtask/src/cli/r_cmd_check.rs
+++ b/xtask/src/cli/r_cmd_check.rs
@@ -12,7 +12,7 @@ pub(crate) struct RCmdCheckArg {
         help = "Determines which R CMD check errors to fail on"
     )]
     pub(crate) error_on: ErrorOn,
-    #[arg(long, help = "If not specified, temp dir is used")]
+    #[arg(long, help = "Defaults to a temporary directory")]
     pub(crate) check_dir: Option<String>,
 }
 

--- a/xtask/src/cli/r_cmd_check.rs
+++ b/xtask/src/cli/r_cmd_check.rs
@@ -1,0 +1,17 @@
+use clap::{Args, ValueEnum};
+
+#[derive(Args, Debug)]
+pub(crate) struct RCmdCheckArg {
+    #[arg(long, default_value = "false", help = "Passed to R CMD check")]
+    pub(crate) no_build_vignettes: bool,
+    #[arg(long, short, default_value = "warning", help = "Passed to R CMD check")]
+    pub(crate) error_on: ErrorOn,
+}
+
+#[derive(ValueEnum, Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) enum ErrorOn {
+    Never,
+    Note,
+    Warning,
+    Error,
+}

--- a/xtask/src/cli/r_cmd_check.rs
+++ b/xtask/src/cli/r_cmd_check.rs
@@ -1,12 +1,19 @@
-use crate::commands::r_cmd_check::RCmdCheckErrorOn;
 use clap::{Args, ValueEnum};
+
+use crate::commands::r_cmd_check::RCmdCheckErrorOn;
 
 #[derive(Args, Debug)]
 pub(crate) struct RCmdCheckArg {
     #[arg(long, default_value = "false", help = "Passed to R CMD check")]
     pub(crate) no_build_vignettes: bool,
-    #[arg(long, default_value = "warning", help = "Passed to R CMD check")]
+    #[arg(
+        long,
+        default_value = "warning",
+        help = "Determines which R CMD check errors to fail on"
+    )]
     pub(crate) error_on: ErrorOn,
+    #[arg(long, help = "If not specified, temp dir is used")]
+    pub(crate) check_dir: Option<String>,
 }
 
 #[derive(ValueEnum, Debug, Clone, Copy, Eq, PartialEq)]

--- a/xtask/src/cli/r_cmd_check.rs
+++ b/xtask/src/cli/r_cmd_check.rs
@@ -5,7 +5,7 @@ use clap::{Args, ValueEnum};
 pub(crate) struct RCmdCheckArg {
     #[arg(long, default_value = "false", help = "Passed to R CMD check")]
     pub(crate) no_build_vignettes: bool,
-    #[arg(long, short, default_value = "warning", help = "Passed to R CMD check")]
+    #[arg(long, default_value = "warning", help = "Passed to R CMD check")]
     pub(crate) error_on: ErrorOn,
 }
 

--- a/xtask/src/commands/r_cmd_check.rs
+++ b/xtask/src/commands/r_cmd_check.rs
@@ -4,7 +4,19 @@ use xshell::Shell;
 
 use crate::extendrtests::with_absolute_path::{swap_extendr_api_path, R_FOLDER_PATH};
 
-pub(crate) fn run(shell: &Shell, no_build_vignettes: bool) -> Result<(), Box<dyn Error>> {
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) enum RCmdCheckErrorOn {
+    Never,
+    Note,
+    Warning,
+    Error,
+}
+
+pub(crate) fn run(
+    shell: &Shell,
+    no_build_vignettes: bool,
+    error_on: RCmdCheckErrorOn,
+) -> Result<(), Box<dyn Error>> {
     let _document_handle = swap_extendr_api_path(shell)?;
 
     run_r_cmd_check(shell, no_build_vignettes)

--- a/xtask/src/commands/r_cmd_check.rs
+++ b/xtask/src/commands/r_cmd_check.rs
@@ -15,10 +15,10 @@ pub(crate) enum RCmdCheckErrorOn {
 impl RCmdCheckErrorOn {
     fn get_error_on(&self) -> &'static str {
         match self {
-            RCmdCheckErrorOn::Never => "never",
-            RCmdCheckErrorOn::Note => "note",
-            RCmdCheckErrorOn::Warning => "warning",
-            RCmdCheckErrorOn::Error => "error",
+            RCmdCheckErrorOn::Never => "'never'",
+            RCmdCheckErrorOn::Note => "'note'",
+            RCmdCheckErrorOn::Warning => "'warning'",
+            RCmdCheckErrorOn::Error => "'error'",
         }
     }
 }
@@ -51,7 +51,7 @@ fn run_r_cmd_check(
         .cmd("Rscript")
         .arg("-e")
         .arg(format!(
-            "rcmdcheck::rcmdcheck(args = {args}, error_on = '{error_on}')"
+            "rcmdcheck::rcmdcheck(args = {args}, error_on = {error_on})"
         ))
         .run()?;
 

--- a/xtask/src/commands/r_cmd_check.rs
+++ b/xtask/src/commands/r_cmd_check.rs
@@ -13,7 +13,7 @@ pub(crate) enum RCmdCheckErrorOn {
 }
 
 impl RCmdCheckErrorOn {
-    fn into_arg(&self) -> &'static str {
+    fn get_error_on(&self) -> &'static str {
         match self {
             RCmdCheckErrorOn::Never => "never",
             RCmdCheckErrorOn::Note => "note",
@@ -46,7 +46,7 @@ fn run_r_cmd_check(
 
     let args = format!("c({0})", args.join(", "));
 
-    let error_on = error_on.into_arg();
+    let error_on = error_on.get_error_on();
     shell
         .cmd("Rscript")
         .arg("-e")

--- a/xtask/src/extendrtests/mod.rs
+++ b/xtask/src/extendrtests/mod.rs
@@ -1,1 +1,2 @@
+pub(crate) mod path_helper;
 pub(crate) mod with_absolute_path;

--- a/xtask/src/extendrtests/path_helper.rs
+++ b/xtask/src/extendrtests/path_helper.rs
@@ -4,7 +4,7 @@ pub(crate) trait RCompatiblePath
 where
     Self: AsRef<Path>,
 {
-    fn canonicalize_for_r(&self) -> String {
+    fn adjust_for_r(&self) -> String {
         let path = self.as_ref().to_string_lossy();
         if cfg!(target_os = "windows") && path.starts_with(r"\\?\") {
             path[4..].replace('\\', "/")

--- a/xtask/src/extendrtests/path_helper.rs
+++ b/xtask/src/extendrtests/path_helper.rs
@@ -1,0 +1,17 @@
+use std::path::Path;
+
+pub(crate) trait RCompatiblePath
+where
+    Self: AsRef<Path>,
+{
+    fn canonicalize_for_r(&self) -> String {
+        let path = self.as_ref().to_string_lossy();
+        if cfg!(target_os = "windows") && path.starts_with(r"\\?\") {
+            path[4..].replace('\\', "/")
+        } else {
+            path.to_string()
+        }
+    }
+}
+
+impl<T> RCompatiblePath for T where T: AsRef<Path> {}

--- a/xtask/src/extendrtests/with_absolute_path.rs
+++ b/xtask/src/extendrtests/with_absolute_path.rs
@@ -4,6 +4,8 @@ use std::path::Path;
 use toml_edit::{Document, InlineTable, Value};
 use xshell::Shell;
 
+use crate::extendrtests::path_helper::RCompatiblePath;
+
 pub(crate) const R_FOLDER_PATH: &str = "tests/extendrtests";
 
 const RUST_FOLDER_PATH: &str = "tests/extendrtests/src/rust";
@@ -51,14 +53,9 @@ pub(crate) fn swap_extendr_api_path(shell: &Shell) -> Result<DocumentHandle, Box
 }
 
 fn get_replacement_path(path: &Path) -> String {
-    let path = path.to_string_lossy();
-    let path = if cfg!(target_os = "windows") && path.starts_with(r"\\?\") {
-        path[4..].replace('\\', "/")
-    } else {
-        path.to_string()
-    };
+    let path = path.canonicalize_for_r();
 
-    format!("{}/extendr-api", path)
+    format!("{path}/extendr-api")
 }
 
 fn get_extendr_api_entry(document: &mut Document) -> Option<&mut Value> {

--- a/xtask/src/extendrtests/with_absolute_path.rs
+++ b/xtask/src/extendrtests/with_absolute_path.rs
@@ -53,7 +53,7 @@ pub(crate) fn swap_extendr_api_path(shell: &Shell) -> Result<DocumentHandle, Box
 }
 
 fn get_replacement_path(path: &Path) -> String {
-    let path = path.canonicalize_for_r();
+    let path = path.adjust_for_r();
 
     format!("{path}/extendr-api")
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -25,8 +25,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     match cli.command {
         cli::Commands::CheckFmt => commands::cargo_fmt_check::run(&shell)?,
         cli::Commands::RCmdCheck(RCmdCheckArg {
-            no_build_vignettes, ..
-        }) => commands::r_cmd_check::run(&shell, no_build_vignettes)?,
+            no_build_vignettes,
+            error_on,
+        }) => commands::r_cmd_check::run(&shell, no_build_vignettes, error_on.into())?,
         cli::Commands::Doc => commands::generate_docs::run(&shell)?,
         cli::Commands::Msrv => commands::cargo_msrv::run(&shell)?,
         cli::Commands::DevtoolsTest => commands::devtools_test::run(&shell)?,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,8 +1,8 @@
-use crate::cli::RCmdCheckArg;
-
 use std::path::PathBuf;
 
 use xshell::Shell;
+
+use cli::r_cmd_check::RCmdCheckArg;
 
 mod cli;
 mod commands;
@@ -20,14 +20,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .canonicalize()?,
     );
 
-    // dbg!(&shell.current_dir());
-    // dbg! {&cli};
+    dbg! {&cli};
 
     match cli.command {
         cli::Commands::CheckFmt => commands::cargo_fmt_check::run(&shell)?,
-        cli::Commands::RCmdCheck(RCmdCheckArg { no_build_vignettes }) => {
-            commands::r_cmd_check::run(&shell, no_build_vignettes)?
-        }
+        cli::Commands::RCmdCheck(RCmdCheckArg {
+            no_build_vignettes, ..
+        }) => commands::r_cmd_check::run(&shell, no_build_vignettes)?,
         cli::Commands::Doc => commands::generate_docs::run(&shell)?,
         cli::Commands::Msrv => commands::cargo_msrv::run(&shell)?,
         cli::Commands::DevtoolsTest => commands::devtools_test::run(&shell)?,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -11,6 +11,7 @@ mod extendrtests;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = cli::parse();
     let shell = Shell::new()?;
+    let original_path = shell.current_dir();
 
     let path: PathBuf = std::env::var("CARGO_MANIFEST_DIR")?.parse()?;
 
@@ -19,7 +20,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .ok_or("Failed to get parent dir")?
             .canonicalize()?,
     );
-
     match cli.command {
         cli::Commands::CheckFmt => commands::cargo_fmt_check::run(&shell)?,
         cli::Commands::RCmdCheck(RCmdCheckArg {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -20,8 +20,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .canonicalize()?,
     );
 
-    dbg! {&cli};
-
     match cli.command {
         cli::Commands::CheckFmt => commands::cargo_fmt_check::run(&shell)?,
         cli::Commands::RCmdCheck(RCmdCheckArg {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -25,8 +25,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         cli::Commands::RCmdCheck(RCmdCheckArg {
             no_build_vignettes,
             error_on,
-            ..
-        }) => commands::r_cmd_check::run(&shell, no_build_vignettes, error_on.into())?,
+            check_dir,
+        }) => commands::r_cmd_check::run(
+            &shell,
+            no_build_vignettes,
+            error_on.into(),
+            check_dir,
+            original_path,
+        )?,
         cli::Commands::Doc => commands::generate_docs::run(&shell)?,
         cli::Commands::Msrv => commands::cargo_msrv::run(&shell)?,
         cli::Commands::DevtoolsTest => commands::devtools_test::run(&shell)?,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -25,6 +25,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         cli::Commands::RCmdCheck(RCmdCheckArg {
             no_build_vignettes,
             error_on,
+            ..
         }) => commands::r_cmd_check::run(&shell, no_build_vignettes, error_on.into())?,
         cli::Commands::Doc => commands::generate_docs::run(&shell)?,
         cli::Commands::Msrv => commands::cargo_msrv::run(&shell)?,


### PR DESCRIPTION
- Switch to using `cargo extendr r-cmd-check` to run `{extendrtests}` on CI (and also replace local paths)
- Add support for `--error-on` option to control when `R CMD check` fails
- Add support for `--check-dir`