### PR TITLE
Remove `data`-field from `RArray`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+## Added
+
+- `RArray::data_mut` provides a mutable slice to the underlying array data [[#657]](https://github.com/extendr/extendr/pull/657)
+
+## Changed
+
+- `RArray::from_parts` no longer requires a pointer to the underlying data vector [[#657]](https://github.com/extendr/extendr/pull/657)
+
 ## 0.6.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## Changed
 
-- `RArray::from_parts` no longer requires a pointer to the underlying data vector [[#657]](https://github.com/extendr/extendr/pull/657)
+- Potentially breaking: `RArray::from_parts` no longer requires a pointer to the underlying data vector [[#657]](https://github.com/extendr/extendr/pull/657)
 
 ## 0.6.0
 

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -587,15 +587,11 @@ pub trait RobjItertools: Iterator {
                 prod
             )));
         }
-        let mut robj =
-            vector.set_attrib(wrapper::symbol::dim_symbol(), dims.iter().collect_robj())?;
-        let data = robj
-            .as_typed_slice_mut()
-            .ok_or(Error::Other(
-                "Unknown error in converting to slice".to_string(),
-            ))?
-            .as_mut_ptr();
-        Ok(RArray::from_parts(robj, data, dims))
+        let robj = vector.set_attrib(wrapper::symbol::dim_symbol(), dims.iter().collect_robj())?;
+        let _data = robj.as_typed_slice().ok_or(Error::Other(
+            "Unknown error in converting to slice".to_string(),
+        ))?;
+        Ok(RArray::from_parts(robj, dims))
     }
 }
 

--- a/extendr-api/src/wrapper/matrix.rs
+++ b/extendr-api/src/wrapper/matrix.rs
@@ -50,7 +50,9 @@ where
         let sexptype = T::sexptype();
         let matrix = Robj::alloc_matrix(sexptype, nrow as _, ncol as _);
         // this is pretty much the same?
-        let robj = matrix;
+        let mut robj = matrix;
+        let slice = robj.as_typed_slice_mut().unwrap();
+        let data = slice.as_mut_ptr();
         RArray::from_parts(robj, [nrow, ncol])
     }
 }

--- a/extendr-api/src/wrapper/matrix.rs
+++ b/extendr-api/src/wrapper/matrix.rs
@@ -50,10 +50,8 @@ where
         let sexptype = T::sexptype();
         let matrix = Robj::alloc_matrix(sexptype, nrow as _, ncol as _);
         // this is pretty much the same?
-        let mut robj = matrix;
-        let slice = robj.as_typed_slice_mut().unwrap();
-        let data = slice.as_mut_ptr();
-        RArray::from_parts(robj, data, [nrow, ncol])
+        let robj = matrix;
+        RArray::from_parts(robj, [nrow, ncol])
     }
 }
 


### PR DESCRIPTION
To prepare for reviewing the other `RArray` PR, I decided to take a look and study this bit first..

I don't see any particular reason to have `RArray` equipped with a wild pointer.
I've made adjustments so that this is no longer needed / expected.

I'm more interested in feedback on this..... because it is me trying to understand what was solved here.
