### PR TITLE
hotfix for `RMatrix`'s `new_matrix`

### DIFF
--- a/extendr-api/src/wrapper/matrix.rs
+++ b/extendr-api/src/wrapper/matrix.rs
@@ -361,6 +361,12 @@ impl<T, D> Deref for RArray<T, D> {
     }
 }
 
+impl<T, D> DerefMut for RArray<T, D> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.robj
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
There is an issue in using `RMatrix::new_matrix`. This is likely due to `mut`-correctness introduced in #644

There are a few more areas where this is present.

This wasn't captured by our test suite, for reasons that I cannot comprehend. 



```
   Compiling arcpbf v0.1.0 (C:\Users\minin\Documents\GitHub\arcpbf\src\rust\arcpbf)
error[E0596]: cannot borrow data in dereference of `RArray<f64, [usize; 2]>` as mutable
  --> arcpbf\src\geometry\point.rs:40:5
   |
40 |     RMatrix::new_matrix(decoded.len(), 2, |r, c| decoded[r][c])
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot borrow as mutable
   |
   = help: trait `DerefMut` is required to modify through a dereference, but it is not implemented for `RArray<f64, [usize; 2]>`

For more information about this error, try `rustc --explain E0596`.
error: could not compile `arcpbf` (lib) due to previous error
```

The code in question

```rs

pub fn read_multipoint(x: Option<CompressedGeometry>, trans: &Translate, scale: &Scale) -> Robj {
    if x.is_none() {
        let empty_mpnt = Doubles::new(0)
            .into_robj()
            .set_attrib("dim", Integers::from_values([0, 2]))
            .unwrap();
        return empty_mpnt;
    }

    let mut crds = match x.unwrap() {
        CompressedGeometry::Geometry(g) => g.coords,
        CompressedGeometry::ShapeBuffer(_) => todo!(),
    };

    let decoded = delta_decode(&mut crds, trans, scale);

    RMatrix::new_matrix(decoded.len(), 2, |r, c| decoded[r][c])
        .set_class(&["XY", "MULTIPOINT", "sfg"])
        .unwrap()
}

```