### PR TITLE
[Partial fix] 

### DIFF
--- a/extendr-api/src/iter.rs
+++ b/extendr-api/src/iter.rs
@@ -83,7 +83,7 @@ impl Iterator for StrIter {
     }
 
     fn next(&mut self) -> Option<Self::Item> {
-        unsafe {
+        single_threaded(|| unsafe {
             let i = self.i;
             self.i += 1;
             let vector = self.vector.get();
@@ -99,7 +99,7 @@ impl Iterator for StrIter {
             } else {
                 None
             }
-        }
+        })
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {


### PR DESCRIPTION
This adds yet another `single_threaded` that is related to an allocation.

`single_threaded`-calls are no longer "expensive" due to #658, but what is happening now, is any hole in the multithreaded-safety is exposed.

