### PR TITLE
Added unsafe `SendSEXP` to `ownership`-module

### DIFF
--- a/extendr-api/src/ownership.rs
+++ b/extendr-api/src/ownership.rs
@@ -69,7 +69,7 @@ pub(crate) unsafe fn unprotect(sexp: SEXP) {
 pub const INITIAL_PRESERVATION_SIZE: usize = 100000;
 pub const EXTRA_PRESERVATION_SIZE: usize = 100000;
 
-// `Object` is a manual refernce counting mechanism that is used for each SEXP.
+// `Object` is a manual reference counting mechanism that is used for each SEXP.
 // `refcount` is the number of times the SEXP is accessed.
 // `index` is the index of the SEXP in the preservation vector.
 #[derive(Debug)]
@@ -146,7 +146,10 @@ impl Ownership {
         // Because the Ownership object already protects an SEXP in the `preservation` field.
         // The new `sexp` is inserted into the preservation list via `SET_VECTOR_ELT` below.
         // If list is protected then so are all of its elements.
-        // "Protecting an R object automatically protects all the R objects pointed to in the corresponding SEXPREC, for example all elements of a protected list are automatically protected." 5.9.1
+        // 
+        // > Protecting an R object automatically protects all the R objects 
+        // > pointed to in the corresponding SEXPREC, for example all elements
+        // > of a protected list are automatically protected." 5.9.1
         Rf_protect(sexp);
 
         if self.cur_index == self.max_index {

--- a/extendr-api/src/ownership.rs
+++ b/extendr-api/src/ownership.rs
@@ -150,7 +150,7 @@ impl Ownership {
             self.garbage_collect();
         }
 
-        let sexp_usize = sexp.into();
+        let send_sexp = sexp.into();
         let Ownership {
             ref mut preservation,
             ref mut cur_index,
@@ -158,7 +158,7 @@ impl Ownership {
             ref mut objects,
         } = *self;
 
-        let mut entry = objects.entry(sexp_usize);
+        let mut entry = objects.entry(send_sexp);
         let preservation_sexp = preservation.inner();
         match entry {
             Entry::Occupied(ref mut occupied) => {

--- a/extendr-api/src/ownership.rs
+++ b/extendr-api/src/ownership.rs
@@ -238,26 +238,26 @@ impl Ownership {
     // Check the consistency of the model.
     #[allow(dead_code)]
     unsafe fn check_objects(&mut self) {
-            let preservation_sexp = self.preservation.inner();
-            assert_eq!(self.max_index, LENGTH(preservation_sexp) as usize);
+        let preservation_sexp = self.preservation.inner();
+        assert_eq!(self.max_index, LENGTH(preservation_sexp) as usize);
 
-            // println!("\ncheck");
+        // println!("\ncheck");
 
-            for (addr, object) in self.objects.iter() {
-                assert!(object.index < self.max_index);
-                let elt = VECTOR_ELT(preservation_sexp, object.index as R_xlen_t);
-                // println!(
-                //     "refcount={:?} index={:?} elt={:?}",
-                //     object.refcount, object.index, elt
-                // );
-                if object.refcount != 0 {
-                    // A non-zero refcount implies the object is in the vector.
-                    assert_eq!(elt, addr.inner());
-                } else {
-                    // A zero refcount implies the object is NULL in the vector.
-                    assert_eq!(elt, R_NilValue);
-                }
+        for (addr, object) in self.objects.iter() {
+            assert!(object.index < self.max_index);
+            let elt = VECTOR_ELT(preservation_sexp, object.index as R_xlen_t);
+            // println!(
+            //     "refcount={:?} index={:?} elt={:?}",
+            //     object.refcount, object.index, elt
+            // );
+            if object.refcount != 0 {
+                // A non-zero refcount implies the object is in the vector.
+                assert_eq!(elt, addr.inner());
+            } else {
+                // A zero refcount implies the object is NULL in the vector.
+                assert_eq!(elt, R_NilValue);
             }
+        }
 
         // println!("check 2");
         for i in 0..self.max_index {

--- a/extendr-api/src/ownership.rs
+++ b/extendr-api/src/ownership.rs
@@ -45,20 +45,6 @@ mod send_sexp {
             self.0 = value;
         }
     }
-
-    // impl std::ops::Deref for SendSEXP {
-    //     type Target = SEXP;
-
-    //     fn deref(&self) -> &Self::Target {
-    //         &self.0
-    //     }
-    // }
-
-    // impl std::ops::DerefMut for SendSEXP {
-    //     fn deref_mut(&mut self) -> &mut Self::Target {
-    //         &mut self.0
-    //     }
-    // }
 }
 
 use self::send_sexp::SendSEXP;

--- a/extendr-api/src/ownership.rs
+++ b/extendr-api/src/ownership.rs
@@ -21,7 +21,7 @@ mod send_sexp {
     //! Provide a wrapper around R's pointer type `SEXP` that is `Send`.
     //!
     //! This can lead to soundness issues, therefore accessing the `SEXP` has
-    //! to happen through the unsafe methods [`SendSEXP::inner`] and [`SendSEXP::set_inner`].
+    //! to happen through the unsafe method [`SendSEXP::inner`].
     //!
     use libR_sys::SEXP;
 
@@ -43,11 +43,6 @@ mod send_sexp {
         /// Get the inner `SEXP`
         pub unsafe fn inner(&self) -> SEXP {
             self.0
-        }
-
-        /// Set the inner `SEXP` as another `SEXP`
-        pub unsafe fn set_inner(&mut self, value: SEXP) {
-            self.0 = value;
         }
     }
 }

--- a/extendr-api/src/ownership.rs
+++ b/extendr-api/src/ownership.rs
@@ -146,8 +146,8 @@ impl Ownership {
         // Because the Ownership object already protects an SEXP in the `preservation` field.
         // The new `sexp` is inserted into the preservation list via `SET_VECTOR_ELT` below.
         // If list is protected then so are all of its elements.
-        // 
-        // > Protecting an R object automatically protects all the R objects 
+        //
+        // > Protecting an R object automatically protects all the R objects
         // > pointed to in the corresponding SEXPREC, for example all elements
         // > of a protected list are automatically protected." 5.9.1
         Rf_protect(sexp);


### PR DESCRIPTION
Currently, the `Ownership` module converts all `SEXP` to `usize` (?), such that they become `Send`, so that the ownership module can be used from multiple threads.

- Wrap `SEXP` in an explicit `Send` type. Accessing the pointer would require safety comments, as it can only be accessed through `inner` and `set_inner`. 
- No pointer conversion to `usize` and back.
- Prototype for an eventual support for an unsafe `SendRobj`. 

## Background

This came up when looking at why tests started to fail sporadically. This isn't meant to fix anything in particular,
but it adds an explicit unsafe layer that is involved with what the `ownership`-module currently does. If we get rid of multithreaded support, we'd still provide users with something similar to this, or they would write something themselves, see #659 for discussion. 