### PR TITLE
Test ownership-module in isolation

### DIFF
--- a/extendr-api/src/ownership.rs
+++ b/extendr-api/src/ownership.rs
@@ -231,6 +231,7 @@ mod test {
     use libR_sys::{Rf_ScalarInteger, Rf_protect, Rf_unprotect};
 
     #[test]
+    #[ignore = "must run in isolation, due to usage of static"]
     fn basic_test() {
         test! {
             single_threaded(|| unsafe {
@@ -294,6 +295,7 @@ mod test {
     }
 
     #[test]
+    #[ignore = "must run in isolation, due to usage of static"]
     fn collection_test() {
         test! {
             single_threaded(|| unsafe {


### PR DESCRIPTION
Currently, `ownership`-module contains two tests. These tests use a function called `check_objects`.
What it does, is it finds `NULL` / `R_NilValue` variables, and sees if there are `refcount` zero. This is meant
to be used in tests, that have cleared out variables from the protection-list, and set to `NULL`.

- Currently, we do protect `R_NilValue` and symbols.
- If these tests run in the middle of other tests, that use `r!(())` or something similar, than a used `R_NilValue` would
be in the protection-list, and it wouldn't be a unintentional.
- These tests should be called in isolation through specifying their name explicitly

