### PR TITLE
Make extendr not thread-safe

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,4 @@
+[env]
+RUST_TEST_THREADS = "1"
 [alias]
 extendr = "run --package xtask --"

--- a/extendr-api/src/iter.rs
+++ b/extendr-api/src/iter.rs
@@ -57,7 +57,7 @@ impl StrIter {
 
 // Get a string reference from a CHARSXP
 fn str_from_strsxp<'a>(sexp: SEXP, index: isize) -> &'a str {
-    single_threaded(|| unsafe {
+    unsafe {
         if index < 0 || index >= Rf_xlength(sexp) {
             <&str>::na()
         } else {
@@ -72,7 +72,7 @@ fn str_from_strsxp<'a>(sexp: SEXP, index: isize) -> &'a str {
                 <&str>::na()
             }
         }
-    })
+    }
 }
 
 impl Iterator for StrIter {

--- a/extendr-api/src/lang_macros.rs
+++ b/extendr-api/src/lang_macros.rs
@@ -3,7 +3,6 @@
 
 use crate::robj::GetSexp;
 use crate::robj::Robj;
-use crate::single_threaded;
 use libR_sys::*;
 
 /// Convert a list of tokens to an array of tuples.
@@ -43,26 +42,26 @@ macro_rules! args {
 
 #[doc(hidden)]
 pub unsafe fn append_with_name(tail: SEXP, obj: Robj, name: &str) -> SEXP {
-    single_threaded(|| {
+    {
         let cons = Rf_cons(obj.get(), R_NilValue);
         SET_TAG(cons, crate::make_symbol(name));
         SETCDR(tail, cons);
         cons
-    })
+    }
 }
 
 #[doc(hidden)]
 pub unsafe fn append(tail: SEXP, obj: Robj) -> SEXP {
-    single_threaded(|| {
+    {
         let cons = Rf_cons(obj.get(), R_NilValue);
         SETCDR(tail, cons);
         cons
-    })
+    }
 }
 
 #[doc(hidden)]
 pub unsafe fn make_lang(sym: &str) -> Robj {
-    Robj::from_sexp(single_threaded(|| Rf_lang1(crate::make_symbol(sym))))
+    Robj::from_sexp(Rf_lang1(crate::make_symbol(sym)))
 }
 
 /// Convert a list of tokens to an array of tuples.

--- a/extendr-api/src/ownership.rs
+++ b/extendr-api/src/ownership.rs
@@ -233,7 +233,7 @@ mod test {
     #[test]
     fn basic_test() {
         test! {
-            single_threaded(|| unsafe {
+             unsafe {
                 {
                     let mut own = OWNERSHIP.lock().expect("lock failed");
                     own.check_objects();
@@ -289,14 +289,14 @@ mod test {
                     assert_eq!(own.ref_count(sexp2), 1);
                 }
                 Rf_unprotect(2);
-            });
+            };
         }
     }
 
     #[test]
     fn collection_test() {
         test! {
-            single_threaded(|| unsafe {
+             unsafe {
                 {
                     let mut own = OWNERSHIP.lock().expect("protect failed");
                     own.check_objects();
@@ -330,7 +330,7 @@ mod test {
                 }
 
                 Rf_unprotect(1);
-            });
+            };
         }
     }
 }

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -1,6 +1,5 @@
 use super::*;
 use crate::scalar::Scalar;
-use crate::single_threaded;
 
 mod repeat_into_robj;
 
@@ -9,13 +8,13 @@ pub(crate) fn str_to_character(s: &str) -> SEXP {
         if s.is_na() {
             R_NaString
         } else {
-            single_threaded(|| {
+            {
                 Rf_mkCharLenCE(
                     s.as_ptr() as *const raw::c_char,
                     s.len() as i32,
                     cetype_t_CE_UTF8,
                 )
-            })
+            }
         }
     }
 }
@@ -520,7 +519,7 @@ where
     I: Sized,
     I::Item: ToVectorValue,
 {
-    single_threaded(|| unsafe {
+    unsafe {
         // Length of the vector is known in advance.
         let sexptype = I::Item::sexptype();
         if sexptype != 0 {
@@ -570,7 +569,7 @@ where
         } else {
             Robj::from(())
         }
-    })
+    }
 }
 
 /// Extensions to iterators for R objects including [RobjItertools::collect_robj()].

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -220,10 +220,10 @@ impl Length for Robj {}
 
 impl Robj {
     pub fn from_sexp(sexp: SEXP) -> Self {
-        single_threaded(|| {
+        {
             unsafe { ownership::protect(sexp) };
             Robj { inner: sexp }
-        })
+        }
     }
 
     /// A ref of an robj can be constructed from a ref to a SEXP
@@ -703,7 +703,7 @@ pub trait Eval: GetSexp {
     /// }
     /// ```
     fn eval_with_env(&self, env: &Environment) -> Result<Robj> {
-        single_threaded(|| unsafe {
+        unsafe {
             let mut error: raw::c_int = 0;
             let res = R_tryEval(self.get(), env.get(), &mut error as *mut raw::c_int);
             if error != 0 {
@@ -711,7 +711,7 @@ pub trait Eval: GetSexp {
             } else {
                 Ok(Robj::from_sexp(res))
             }
-        })
+        }
     }
 
     /// Evaluate the expression and return NULL or an R object.
@@ -865,13 +865,13 @@ pub trait Attributes: Types + Length {
         let value = value.into();
         unsafe {
             let sexp = self.get_mut();
-            single_threaded(|| {
+            {
                 catch_r_error(|| Rf_setAttrib(sexp, name.get(), value.get()))
                     // FIXME: there is no reason to re-wrap this, as this mutates
                     // the input `self`, and returns another pointer to the same
                     // object
                     .map(|_| Robj::from_sexp(sexp))
-            })
+            }
         }
     }
 

--- a/extendr-api/src/robj/operators.rs
+++ b/extendr-api/src/robj/operators.rs
@@ -101,10 +101,10 @@ pub trait Operators: Rinternals {
     /// ```
     fn call(&self, args: Pairlist) -> Result<Robj> {
         if self.is_function() {
-            single_threaded(|| unsafe {
+            unsafe {
                 let call = Robj::from_sexp(Rf_lcons(self.get(), args.get()));
                 call.eval()
-            })
+            }
         } else {
             Err(Error::ExpectedFunction(self.as_robj().clone()))
         }

--- a/extendr-api/src/robj/rinternals.rs
+++ b/extendr-api/src/robj/rinternals.rs
@@ -82,35 +82,33 @@ pub trait Rinternals: Types + Conversions {
 
     /// Convert to vectors of many kinds.
     fn coerce_vector(&self, sexptype: u32) -> Robj {
-        single_threaded(|| unsafe {
-            Robj::from_sexp(Rf_coerceVector(self.get(), sexptype as SEXPTYPE))
-        })
+        unsafe { Robj::from_sexp(Rf_coerceVector(self.get(), sexptype as SEXPTYPE)) }
     }
 
     /// Convert a pairlist (LISTSXP) to a vector list (VECSXP).
     fn pair_to_vector_list(&self) -> Robj {
-        single_threaded(|| unsafe { Robj::from_sexp(Rf_PairToVectorList(self.get())) })
+        unsafe { Robj::from_sexp(Rf_PairToVectorList(self.get())) }
     }
 
     /// Convert a vector list (VECSXP) to a pair list (LISTSXP)
     fn vector_to_pair_list(&self) -> Robj {
-        single_threaded(|| unsafe { Robj::from_sexp(Rf_VectorToPairList(self.get())) })
+        unsafe { Robj::from_sexp(Rf_VectorToPairList(self.get())) }
     }
 
     /// Convert a factor to a string vector.
     fn as_character_factor(&self) -> Robj {
-        single_threaded(|| unsafe { Robj::from_sexp(Rf_asCharacterFactor(self.get())) })
+        unsafe { Robj::from_sexp(Rf_asCharacterFactor(self.get())) }
     }
 
     /// Allocate a matrix object.
     fn alloc_matrix(sexptype: SEXPTYPE, rows: i32, cols: i32) -> Robj {
-        single_threaded(|| unsafe { Robj::from_sexp(Rf_allocMatrix(sexptype, rows, cols)) })
+        unsafe { Robj::from_sexp(Rf_allocMatrix(sexptype, rows, cols)) }
     }
 
     /// Do a deep copy of this object.
     /// Note that clone() only adds a reference.
     fn duplicate(&self) -> Robj {
-        single_threaded(|| unsafe { Robj::from_sexp(Rf_duplicate(self.get())) })
+        unsafe { Robj::from_sexp(Rf_duplicate(self.get())) }
     }
 
     /// Find a function in an environment ignoring other variables.
@@ -243,13 +241,13 @@ pub trait Rinternals: Types + Conversions {
     #[doc(hidden)]
     unsafe fn make_external_ptr<T>(p: *mut T, prot: Robj) -> Robj {
         let type_name: Robj = std::any::type_name::<T>().into();
-        Robj::from_sexp(single_threaded(|| {
+        Robj::from_sexp({
             R_MakeExternalPtr(
                 p as *mut ::std::os::raw::c_void,
                 type_name.get(),
                 prot.get(),
             )
-        }))
+        })
     }
 
     /// Internal function used to implement `#[extendr]` impl
@@ -274,7 +272,7 @@ pub trait Rinternals: Types + Conversions {
     unsafe fn register_c_finalizer(&self, func: R_CFinalizer_t) {
         // Use R_RegisterCFinalizerEx() and set onexit to 1 (TRUE) to invoke the
         // finalizer on a shutdown of the R session as well.
-        single_threaded(|| R_RegisterCFinalizerEx(self.get(), func, 1));
+        R_RegisterCFinalizerEx(self.get(), func, 1);
     }
 
     /// Copy a vector and resize it.
@@ -282,9 +280,10 @@ pub trait Rinternals: Types + Conversions {
     fn xlengthgets(&self, new_len: usize) -> Result<Robj> {
         unsafe {
             if self.is_vector() {
-                Ok(single_threaded(|| {
-                    Robj::from_sexp(Rf_xlengthgets(self.get(), new_len as R_xlen_t))
-                }))
+                Ok(Robj::from_sexp(Rf_xlengthgets(
+                    self.get(),
+                    new_len as R_xlen_t,
+                )))
             } else {
                 Err(Error::ExpectedVector(self.as_robj().clone()))
             }
@@ -293,12 +292,12 @@ pub trait Rinternals: Types + Conversions {
 
     /// Allocated an owned object of a certain type.
     fn alloc_vector(sexptype: u32, len: usize) -> Robj {
-        single_threaded(|| unsafe { Robj::from_sexp(Rf_allocVector(sexptype, len as R_xlen_t)) })
+        unsafe { Robj::from_sexp(Rf_allocVector(sexptype, len as R_xlen_t)) }
     }
 
     /// Return true if two arrays have identical dims.
     fn conformable(a: &Robj, b: &Robj) -> bool {
-        single_threaded(|| unsafe { Rf_conformable(a.get(), b.get()) != 0 })
+        unsafe { Rf_conformable(a.get(), b.get()) != 0 }
     }
 
     /// Return true if this is an array.

--- a/extendr-api/src/thread_safety.rs
+++ b/extendr-api/src/thread_safety.rs
@@ -105,7 +105,7 @@ where
         }
     }
 
-    single_threaded(|| unsafe {
+    unsafe {
         let fun_ptr = do_call::<F> as *const ();
         let clean_ptr = do_cleanup as *const ();
         let x = false;
@@ -125,5 +125,5 @@ where
         };
         Rf_unprotect(1);
         res
-    })
+    }
 }

--- a/extendr-api/src/wrapper/doubles.rs
+++ b/extendr-api/src/wrapper/doubles.rs
@@ -53,9 +53,9 @@ impl Doubles {
 // TODO: this should be a trait.
 impl Doubles {
     pub fn set_elt(&mut self, index: usize, val: Rfloat) {
-        single_threaded(|| unsafe {
+        unsafe {
             SET_REAL_ELT(self.get_mut(), index as R_xlen_t, val.inner());
-        })
+        }
     }
 }
 

--- a/extendr-api/src/wrapper/environment.rs
+++ b/extendr-api/src/wrapper/environment.rs
@@ -58,7 +58,7 @@ impl Environment {
         NV: IntoIterator,
         NV::Item: SymPair,
     {
-        single_threaded(|| {
+        {
             let dict_len = 29;
             let env = new_env(parent, true, dict_len);
             for nv in names_and_values {
@@ -68,7 +68,7 @@ impl Environment {
                 }
             }
             env
-        })
+        }
     }
 
     /// Get the enclosing (parent) environment.
@@ -82,10 +82,10 @@ impl Environment {
 
     /// Set the enclosing (parent) environment.
     pub fn set_parent(&mut self, parent: Environment) -> &mut Self {
-        single_threaded(|| unsafe {
+        unsafe {
             let sexp = self.robj.get_mut();
             SET_ENCLOS(sexp, parent.robj.get());
-        });
+        };
         self
     }
 
@@ -99,10 +99,10 @@ impl Environment {
 
     /// Set the environment flags.
     pub fn set_envflags(&mut self, flags: i32) -> &mut Self {
-        single_threaded(|| unsafe {
+        unsafe {
             let sexp = self.robj.get_mut();
             SET_ENVFLAGS(sexp, flags);
-        });
+        };
         self
     }
 
@@ -152,9 +152,9 @@ impl Environment {
         let key = key.into();
         let value = value.into();
         if key.is_symbol() {
-            single_threaded(|| unsafe {
+            unsafe {
                 Rf_defineVar(key.get(), value.get(), self.get());
-            })
+            }
         }
     }
 

--- a/extendr-api/src/wrapper/externalptr.rs
+++ b/extendr-api/src/wrapper/externalptr.rs
@@ -86,7 +86,7 @@ impl<T: Any + Debug> ExternalPtr<T> {
     /// An ExternalPtr behaves like a Box except that the information is
     /// tracked by a R object.
     pub fn new(val: T) -> Self {
-        single_threaded(|| unsafe {
+        unsafe {
             // This allocates some memory for our object and moves the object into it.
             let boxed = Box::new(val);
 
@@ -118,7 +118,7 @@ impl<T: Any + Debug> ExternalPtr<T> {
                 robj,
                 marker: std::marker::PhantomData,
             }
-        })
+        }
     }
 
     // TODO: make a constructor for references?

--- a/extendr-api/src/wrapper/function.rs
+++ b/extendr-api/src/wrapper/function.rs
@@ -41,14 +41,14 @@ impl Function {
     /// }
     /// ```
     pub fn from_parts(formals: Pairlist, body: Language, env: Environment) -> Result<Self> {
-        single_threaded(|| unsafe {
+        unsafe {
             let sexp = Rf_allocSExp(CLOSXP);
             let robj = Robj::from_sexp(sexp);
             SET_FORMALS(sexp, formals.get());
             SET_BODY(sexp, body.get());
             SET_CLOENV(sexp, env.get());
             Ok(Function { robj })
-        })
+        }
     }
 
     /// Do the equivalent of x(a, b, c)
@@ -60,10 +60,10 @@ impl Function {
     /// }
     /// ```
     pub fn call(&self, args: Pairlist) -> Result<Robj> {
-        single_threaded(|| unsafe {
+        unsafe {
             let call = Robj::from_sexp(Rf_lcons(self.get(), args.get()));
             call.eval()
-        })
+        }
     }
 
     /// Get the formal arguments of the function or None if it is a primitive.

--- a/extendr-api/src/wrapper/integers.rs
+++ b/extendr-api/src/wrapper/integers.rs
@@ -53,9 +53,9 @@ impl Integers {
 // TODO: this should be a trait.
 impl Integers {
     pub fn set_elt(&mut self, index: usize, val: Rint) {
-        single_threaded(|| unsafe {
+        unsafe {
             SET_INTEGER_ELT(self.get(), index as R_xlen_t, val.inner());
-        })
+        }
     }
 }
 

--- a/extendr-api/src/wrapper/lang.rs
+++ b/extendr-api/src/wrapper/lang.rs
@@ -23,7 +23,7 @@ impl Language {
         T::IntoIter: DoubleEndedIterator,
         T::Item: Into<Robj>,
     {
-        single_threaded(|| unsafe {
+        unsafe {
             let mut res = R_NilValue;
             let mut num_protected = 0;
             for val in values.into_iter().rev() {
@@ -34,7 +34,7 @@ impl Language {
             let robj = Robj::from_sexp(res);
             Rf_unprotect(num_protected);
             Language { robj }
-        })
+        }
     }
 
     pub fn iter(&self) -> PairlistIter {

--- a/extendr-api/src/wrapper/list.rs
+++ b/extendr-api/src/wrapper/list.rs
@@ -165,14 +165,14 @@ impl List {
 
     /// Set an element in the list.
     pub fn set_elt(&mut self, i: usize, value: Robj) -> Result<()> {
-        single_threaded(|| unsafe {
+        unsafe {
             if i >= self.robj.len() {
                 Err(Error::OutOfRange(self.robj.clone()))
             } else {
                 SET_VECTOR_ELT(self.robj.get_mut(), i as R_xlen_t, value.get());
                 Ok(())
             }
-        })
+        }
     }
 
     /// Convert a List into a HashMap, consuming the list.
@@ -383,7 +383,7 @@ impl<T: Into<Robj>> FromIterator<T> for List {
         let iter_collect: Vec<_> = iter.into_iter().collect();
         let len = iter_collect.len();
 
-        crate::single_threaded(|| unsafe {
+        unsafe {
             let mut robj = Robj::alloc_vector(VECSXP, len);
             for (i, v) in iter_collect.into_iter().enumerate() {
                 // We don't PROTECT each element here, as they will be immediately
@@ -396,7 +396,7 @@ impl<T: Into<Robj>> FromIterator<T> for List {
             }
 
             List { robj }
-        })
+        }
     }
 }
 

--- a/extendr-api/src/wrapper/logicals.rs
+++ b/extendr-api/src/wrapper/logicals.rs
@@ -44,9 +44,9 @@ impl Logicals {
 // TODO: this should be a trait.
 impl Logicals {
     pub fn set_elt(&mut self, index: usize, val: Rbool) {
-        single_threaded(|| unsafe {
+        unsafe {
             SET_INTEGER_ELT(self.get_mut(), index as R_xlen_t, val.inner());
-        })
+        }
     }
 }
 

--- a/extendr-api/src/wrapper/macros.rs
+++ b/extendr-api/src/wrapper/macros.rs
@@ -42,7 +42,7 @@ macro_rules! gen_vector_wrapper_impl {
                     V::IntoIter: ExactSizeIterator,
                     V::Item: Into<$scalar_type>,
                 {
-                    single_threaded(|| {
+                     {
                         let values: V::IntoIter = values.into_iter();
 
                         let mut robj = Robj::alloc_vector($sexp, values.len());
@@ -52,7 +52,7 @@ macro_rules! gen_vector_wrapper_impl {
                             *d = v.into();
                         }
                         Self { robj }
-                    })
+                    }
                 }
             }
 
@@ -66,15 +66,14 @@ macro_rules! gen_vector_wrapper_impl {
                     V::IntoIter: ExactSizeIterator + std::fmt::Debug + Clone + 'static + std::any::Any,
                     V::Item: Into<$scalar_type>,
                 {
-                    single_threaded(|| {
+                    {
                         let values: V::IntoIter = values.into_iter();
-
                         let robj =
                                   Altrep::$altrep_constructor(values)
                                 .try_into()
                                 .unwrap();
                         Self { robj }
-                    })
+                    }
                 }
             }
 

--- a/extendr-api/src/wrapper/mod.rs
+++ b/extendr-api/src/wrapper/mod.rs
@@ -68,7 +68,7 @@ where
     T::IntoIter: ExactSizeIterator,
     T::Item: Into<Robj>,
 {
-    single_threaded(|| unsafe {
+    unsafe {
         let values = values.into_iter();
         let mut res = Robj::alloc_vector(sexptype, values.len());
         let sexp = res.get_mut();
@@ -76,7 +76,7 @@ where
             SET_VECTOR_ELT(sexp, i as R_xlen_t, val.into().get());
         }
         res
-    })
+    }
 }
 
 macro_rules! make_conversions {

--- a/extendr-api/src/wrapper/pairlist.rs
+++ b/extendr-api/src/wrapper/pairlist.rs
@@ -34,7 +34,7 @@ impl Pairlist {
         NV::IntoIter: DoubleEndedIterator,
         NV::Item: SymPair,
     {
-        crate::single_threaded(|| unsafe {
+        unsafe {
             let mut num_protects = 0;
             let mut res = R_NilValue;
             for nv in pairs.into_iter().rev() {
@@ -51,7 +51,7 @@ impl Pairlist {
             };
             Rf_unprotect(num_protects);
             res
-        })
+        }
     }
 
     /// Generate paits of names and values.

--- a/extendr-api/src/wrapper/primitive.rs
+++ b/extendr-api/src/wrapper/primitive.rs
@@ -28,7 +28,7 @@ impl Primitive {
     /// }
     /// ```
     pub fn from_string(val: &str) -> Result<Self> {
-        single_threaded(|| unsafe {
+        unsafe {
             // Primitives have a special "SYMVALUE" entry in their symbol.
             let sym = Symbol::from_string(val);
             let symvalue = Robj::from_sexp(SYMVALUE(sym.get()));
@@ -37,7 +37,7 @@ impl Primitive {
             } else {
                 Err(Error::ExpectedPrimitive(sym.into()))
             }
-        })
+        }
     }
 
     // There is currently no way to convert a primitive to a string.

--- a/extendr-api/src/wrapper/promise.rs
+++ b/extendr-api/src/wrapper/promise.rs
@@ -18,14 +18,14 @@ impl Promise {
     /// }
     /// ```
     pub fn from_parts(code: Robj, environment: Environment) -> Result<Self> {
-        single_threaded(|| unsafe {
+        unsafe {
             let sexp = Rf_allocSExp(PROMSXP);
             let robj = Robj::from_sexp(sexp);
             SET_PRCODE(sexp, code.get());
             SET_PRENV(sexp, environment.robj.get());
             SET_PRVALUE(sexp, R_UnboundValue);
             Ok(Promise { robj })
-        })
+        }
     }
 
     /// Get the code to be executed from the promise.

--- a/extendr-api/src/wrapper/raw.rs
+++ b/extendr-api/src/wrapper/raw.rs
@@ -34,7 +34,7 @@ impl Raw {
     /// }
     /// ```
     pub fn from_bytes(bytes: &[u8]) -> Self {
-        single_threaded(|| unsafe {
+        unsafe {
             let sexp = Rf_allocVector(RAWSXP, bytes.len() as R_xlen_t);
             let robj = Robj::from_sexp(sexp);
             let ptr = RAW(sexp);
@@ -42,7 +42,7 @@ impl Raw {
                 *ptr.add(i) = v;
             }
             Raw { robj }
-        })
+        }
     }
 
     /// Get a slice of bytes from the Raw object.

--- a/extendr-api/src/wrapper/s4.rs
+++ b/extendr-api/src/wrapper/s4.rs
@@ -90,10 +90,10 @@ impl S4 {
     {
         let name = name.into();
         let value = value.into();
-        single_threaded(|| unsafe {
+        unsafe {
             catch_r_error(|| R_do_slot_assign(self.get(), name.get(), value.get()))
                 .map(|_| self.clone())
-        })
+        }
     }
 
     /// Check if a named slot exists.

--- a/extendr-api/src/wrapper/strings.rs
+++ b/extendr-api/src/wrapper/strings.rs
@@ -44,7 +44,7 @@ impl Strings {
         V::IntoIter: ExactSizeIterator,
         V::Item: AsRef<str>,
     {
-        single_threaded(|| unsafe {
+        unsafe {
             let values = values.into_iter();
             let maxlen = values.len();
             let mut robj = Robj::alloc_vector(STRSXP, maxlen);
@@ -55,7 +55,7 @@ impl Strings {
                 SET_STRING_ELT(sexp, i as R_xlen_t, ch);
             }
             Self { robj }
-        })
+        }
     }
 
     /// This is a relatively expensive operation, so use a variable if using this in a loop.
@@ -80,11 +80,11 @@ impl Strings {
 
     /// Set a single element of this string vector.
     pub fn set_elt(&mut self, i: usize, e: Rstr) {
-        single_threaded(|| unsafe {
+        unsafe {
             if i < self.len() {
                 SET_STRING_ELT(self.robj.get_mut(), i as isize, e.get());
             }
-        });
+        };
     }
 
     /// Get an iterator for this string vector.
@@ -110,12 +110,12 @@ impl<T: AsRef<str>> FromIterator<T> for Strings {
         let len = iter_collect.len();
 
         let mut robj = Strings::alloc_vector(STRSXP, len);
-        crate::single_threaded(|| unsafe {
+        unsafe {
             for (i, v) in iter_collect.into_iter().enumerate() {
                 SET_STRING_ELT(robj.get_mut(), i as isize, str_to_character(v.as_ref()));
             }
             Strings { robj }
-        })
+        }
     }
 }
 

--- a/extendr-api/tests/extendr_macro.rs
+++ b/extendr-api/tests/extendr_macro.rs
@@ -136,7 +136,7 @@ fn tests_with_successful_outcomes() {
 #[test]
 fn tests_with_unsuccessful_outcomes() {
     // Using [single_threaded] here may help with sporadic test failures.
-    single_threaded(|| unsafe {
+    unsafe {
         test! {
             let old_hook = std::panic::take_hook();
 
@@ -156,7 +156,7 @@ fn tests_with_unsuccessful_outcomes() {
             assert!(catch_r_error(|| wrap__test_i16(r!(1234567890).get())).is_err());
             std::panic::set_hook(old_hook);
         }
-    });
+    };
 }
 
 #[test]

--- a/extendr-api/tests/from_iterator_tests.rs
+++ b/extendr-api/tests/from_iterator_tests.rs
@@ -46,7 +46,7 @@ fn test_with_gc_torture_small() {
 #[test]
 fn test_with_gc_torture_large() {
     test!(
-        let x = [0_f64; 150].map(|_|single_threaded(||unsafe {libR_sys::Rf_runif(0., 100.)}));
+        let x = [0_f64; 150].map(|_|unsafe {libR_sys::Rf_runif(0., 100.)});
         R!("gctorture(on = TRUE)")?;
         let list: List = x.into_iter().collect();
         R!("gctorture(on = FALSE)")?;

--- a/extendr-api/tests/rng_tests.rs
+++ b/extendr-api/tests/rng_tests.rs
@@ -19,7 +19,7 @@ fn generate_big_random_vec() -> Vec<f64> {
     let n = 100;
     let param = 10e3;
     (0..n)
-        .map(|_| single_threaded(|| unsafe { libR_sys::R_unif_index(param) }))
+        .map(|_| unsafe { libR_sys::R_unif_index(param) })
         .collect()
 }
 

--- a/extendr-macros/src/wrappers.rs
+++ b/extendr-macros/src/wrappers.rs
@@ -104,17 +104,17 @@ pub fn make_function_wrappers(
     let rng_start = opts
         .use_rng
         .then(|| {
-            quote!(single_threaded(|| unsafe {
+            quote!(unsafe {
                 libR_sys::GetRNGstate();
-            });)
+            };)
         })
         .unwrap_or_default();
     let rng_end = opts
         .use_rng
         .then(|| {
-            quote!(single_threaded(|| unsafe {
+            quote!(unsafe {
                 libR_sys::PutRNGstate();
-            });)
+            };)
         })
         .unwrap_or_default();
     wrappers.push(parse_quote!(


### PR DESCRIPTION

- [x] Remove all usage of `single_threaded`
- [x] Set `--test-threads=1` always
- [ ] No longer rely on `ownership` tracking across threads, i.e. use `thread_local!` for `Ownership`.
