### PR TITLE
Stick to published `libR-sys`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,4 @@
 [alias]
 extendr = "run --package xtask --"
+[patch.crates-io]
+# libR-sys = { git = "https://github.com/extendr/libR-sys", branch = "master" }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -232,7 +232,7 @@ jobs:
                 "\" }"),
 
               # uncomment this line when we need to depend on the dev version of libR-sys
-              'libR-sys = { git = "https://github.com/extendr/libR-sys" }',
+              #'libR-sys = { git = "https://github.com/extendr/libR-sys" }',
 
               sep = ";")
           

--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,4 @@
 extendr.Rproj
 **/extendrtests.Rcheck/
 **/extendrtests_[0-9].[0-9].[0-9].tar.gz
-**/.cargo/*
 .vscode/settings.json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,4 @@ rust-version = "1.60"
 [workspace.dependencies]
 # When updating extendr's version, this version also needs to be updated
 extendr-macros = { path = "./extendr-macros", version = "0.6.0" }
-
 libR-sys = "0.6.0"
-
-[patch.crates-io]
-# When uncommenting this, do not forget to uncomment the same line in
-# ./tests/extendrtests/src/rust/Cargo.toml, and "Run R integration tests using
-# {rextendr}" on .github/workflows/test.yml !
-libR-sys = { git = "https://github.com/extendr/libR-sys" }

--- a/tests/extendrtests/src/rust/Cargo.toml
+++ b/tests/extendrtests/src/rust/Cargo.toml
@@ -21,4 +21,4 @@ libR-sys = "*"
 
 [patch.crates-io]
 # root is `tests/extendrtests/src/rust`
-extendr-api = { path = "C:/Users/minin/Documents/GitHub/extendr/extendr-api" }
+extendr-api = { path = "../../../../extendr-api/" }

--- a/tests/extendrtests/src/rust/Cargo.toml
+++ b/tests/extendrtests/src/rust/Cargo.toml
@@ -18,3 +18,7 @@ crate-type = ["staticlib"]
 [dependencies]
 extendr-api = { version = "*", features = ["graphics", "ndarray", "either"] }
 libR-sys = "*"
+
+[patch.crates-io]
+# root is `tests/extendrtests/src/rust`
+extendr-api = { path = "C:/Users/minin/Documents/GitHub/extendr/extendr-api" }

--- a/tests/extendrtests/src/rust/Cargo.toml
+++ b/tests/extendrtests/src/rust/Cargo.toml
@@ -17,23 +17,4 @@ crate-type = ["staticlib"]
 
 [dependencies]
 extendr-api = { version = "*", features = ["graphics", "ndarray", "either"] }
-
-# TODO: I couldn't find any nice way to add the condition based on the R version
-# except for using libR-sys just for "DEP_R_*" envvars.
-libR-sys = "*"
-
-[patch.crates-io]
-## This is configured to work with RStudio features.
-## Replace by absolute path to simplify testing.
-## CI overrides this path.
-extendr-api = { path = "../../../../../../../extendr/extendr-api" }
-## This allows to run `rcmdcheck` from `./tests/extendrtests/`
-# extendr-api = { path = "../../../../../../../../../extendr/extendr-api"}
-
-
-## Build against current extendr version on github. Not recommended
-## for development work.
-#extendr-api = { git = "https://github.com/extendr/extendr"}
-
-# Build against current libR-sys version on github
-libR-sys = { git = "https://github.com/extendr/libR-sys" }
+libR-sys = "0.6.0"

--- a/tests/extendrtests/src/rust/Cargo.toml
+++ b/tests/extendrtests/src/rust/Cargo.toml
@@ -17,4 +17,4 @@ crate-type = ["staticlib"]
 
 [dependencies]
 extendr-api = { version = "*", features = ["graphics", "ndarray", "either"] }
-libR-sys = "0.6.0"
+libR-sys = "*"


### PR DESCRIPTION
There are too many hacks for setting the `libR-sys` version used.
It could be beneficial to simply stick to default behaviour, and then provide one single
mechanism for changing that, instead of relying on changing the used `libR-sys` in three different places.
(1) extendr-crates, (2) extendrtests, (3) extendr CI.

Background: This comes by way of `extendrtests`, using `libR-sys` to test specific R-features available, and this wasn't being set. 

In CI, we can use ` --config 'patch.crates-io.libR-sys= { git = "https://github.com/extendr/libR-sys", branch = "master"}'`

Adding the following to `.cargo/config.toml`
```toml
[patch.crates-io]
libR-sys = { git = "https://github.com/extendr/libR-sys", branch = "master" }
```
also works. You can test this by running `cargo tree` in both `extendr/` and `extendr/tests/extendrtests/src/rust`, and check the version / path of the used `libR-sys`.
 