### PR TITLE
fix: should not use `@docType "package"`

### DIFF
--- a/extendr-api/src/metadata.rs
+++ b/extendr-api/src/metadata.rs
@@ -352,7 +352,6 @@ impl Metadata {
         )?;
 
         if use_symbols {
-            writeln!(w, "#' @docType package")?;
             writeln!(w, "#' @usage NULL")?;
             writeln!(w, "#' @useDynLib {}, .registration = TRUE", package_name)?;
             writeln!(w, "NULL")?;

--- a/tests/extendrtests/R/extendr-wrappers.R
+++ b/tests/extendrtests/R/extendr-wrappers.R
@@ -6,7 +6,6 @@
 # This file was created with the following call:
 #   .Call("wrap__make_extendrtests_wrappers", use_symbols = TRUE, package_name = "extendrtests")
 
-#' @docType package
 #' @usage NULL
 #' @useDynLib extendrtests, .registration = TRUE
 NULL


### PR DESCRIPTION
Fix #684

The existence of this makes it impossible to use `"_PACKAGE"` in packages where extendr-wrapper.R is located, like pola-rs/r-polars#705