### PR TITLE
Clarify .inherits() behavior

### DIFF
--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -1001,7 +1001,8 @@ pub trait Attributes: Types + Length {
         self.set_attrib(wrapper::symbol::class_symbol(), iter.collect_robj())
     }
 
-    /// Return true if this class inherits this class.
+    /// Return true if this object has this class attribute.
+    /// Implicit classes are not supported.
     /// ```
     /// use extendr_api::prelude::*;
     /// test! {


### PR DESCRIPTION
This PR improves the documentation for the `.inherits()` method to clarify that the method does not support implicit classes.

Closes https://github.com/extendr/extendr/issues/68