### PR TITLE
Use public RSPM in both setup-r workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
           r-version: ${{ matrix.config.r }}
           rtools-version: ${{ matrix.config.rtools-version }}
           # TODO: enable RSPM when all the packages are available
-          use-public-rspm: false
+          use-public-rspm: true
 
       - name: Set up Pandoc
         uses: r-lib/actions/setup-pandoc@v2


### PR DESCRIPTION
This PR changes the use-public-rspm flag to true where it was previously false. 

RSPM will serve binaries when available. Otherwise it will default to source installations. 

Was there a reason why this was set false? 