### PR TITLE
Fix a likely regression in new `pwsh` version

### DIFF
--- a/ci-cargo.ps1
+++ b/ci-cargo.ps1
@@ -11,6 +11,7 @@ function ci-cargo {
 
     try {
         Write-Output "::group::$ActionName"
+        $CargoArgs = $CargoArgs | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
         Write-Output "Running cargo $CargoArgs"
         cargo $CargoArgs
         if ($LASTEXITCODE -ne 0) {

--- a/ci-cargo.ps1
+++ b/ci-cargo.ps1
@@ -9,11 +9,11 @@ function ci-cargo {
     )
 
 
-    try {    
-        echo "::group::$ActionName"
-        echo "Running cargo $CargoArgs"
+    try {
+        Write-Output "::group::$ActionName"
+        Write-Output "Running cargo $CargoArgs"
         cargo $CargoArgs
-        if($LASTEXITCODE -ne  0) {
+        if ($LASTEXITCODE -ne 0) {
             throw $LASTEXITCODE
         }
     }
@@ -22,11 +22,11 @@ function ci-cargo {
             $ActionName = "'$ActionName': "
         }
         $err_msg = "$($ActionName)cargo failed with code $LASTEXITCODE (args: $CargoArgs)"
-        echo "::error::$err_msg"
-        Write-Error -Message "$err_msg" -ErrorAction Stop 
+        Write-Output "::error::$err_msg"
+        Write-Error -Message "$err_msg" -ErrorAction Stop
     }
     finally {
-        echo "::endgroup::"
+        Write-Output "::endgroup::"
     }
 
     <#

--- a/ci-cargo.ps1
+++ b/ci-cargo.ps1
@@ -22,9 +22,9 @@ function ci-cargo {
         if ($ActionName -ne $null -and $ActionName -ne "") {
             $ActionName = "'$ActionName': "
         }
-        $err_msg = "$($ActionName)cargo failed with code $LASTEXITCODE (args: $CargoArgs)"
-        Write-Output "::error::$err_msg"
-        Write-Error -Message "$err_msg" -ErrorAction Stop
+        $errMsg = "$($ActionName)cargo failed with code $LASTEXITCODE (args: $CargoArgs)"
+        Write-Output "::error::$errMsg"
+        Write-Error -Message "$errMsg" -ErrorAction Stop
     }
     finally {
         Write-Output "::endgroup::"


### PR DESCRIPTION
Partial conditions (when `else` clause is dropped) passed `''` among parameters instead of nothing, which subsequently led to broken invocations of `cargo`.