### PR TITLE
fix ci: r-devel now uses rtools44 by default

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         config:
           - { os: windows-latest, r: 'release', rust-version: 'stable-msvc', rtools-version: '43' }
-          - { os: windows-latest, r: 'devel',   rust-version: 'stable-msvc', rtools-version: '43' }
+          - { os: windows-latest, r: 'devel',   rust-version: 'stable-msvc', rtools-version: '44' }
           - { os: windows-latest, r: 'oldrel',  rust-version: 'stable-msvc', rtools-version: '42' }
 
           - { os: macOS-latest,   r: 'release', rust-version: 'stable' }
@@ -270,7 +270,7 @@ jobs:
           - { os: ubuntu-latest,  r: 'devel',   rust-version: 'stable' }
           - { os: macOS-latest,   r: 'devel',   rust-version: 'stable' }
           - { os: windows-latest, r: 'release', rust-version: 'stable-msvc',  rust-targets: [ 'x86_64-pc-windows-gnu' ], rtools-version: '43' }
-          - { os: windows-latest, r: 'devel',   rust-version: 'stable-msvc',  rust-targets: [ 'x86_64-pc-windows-gnu' ], rtools-version: '43' }
+          - { os: windows-latest, r: 'devel',   rust-version: 'stable-msvc',  rust-targets: [ 'x86_64-pc-windows-gnu' ], rtools-version: '44' }
           # When the MSVC target is used, since it's cross-compilation from MSVC
           # to GNU, the doc tests are usually skipped. Adding `-Zdoctest-xcompile`
           # lets the doctests run, which accordingly require the nightly toolchain.
@@ -327,7 +327,6 @@ jobs:
           $rtools_home = "C:\rtools${{ matrix.config.rtools-version }}"
 
           echo "::group::Setting up x86_64"
-          echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           # c.f. https://github.com/wch/r-source/blob/f1501504df8df1668a57d3a1b6f80167f24441d3/src/library/profile/Rprofile.windows#L70-L71
           echo "${rtools_home}\x86_64-w64-mingw32.static.posix\bin"      | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;
           echo "${rtools_home}\usr\bin"                                  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append ;


### PR DESCRIPTION
Following in the steps of extendr/libR-sys#220. This is affecting CI right now.