### PR TITLE
ci: Upload results of r-cmd-check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -208,11 +208,11 @@ jobs:
         id: id_cargo_r_cmd_check
         run: |
           cargo extendr r-cmd-check --error-on ${{ steps.error-on.outputs.level }} --check-dir extendrtests_check
-      - name: Upload results if it failed
+      - name: Upload `check-dir` if r-cmd-check failed on `{extendrtests}`
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: "Results from r-cmd-check of {extendrtests}"
+          name: ${{ format('{0}-{1}-r{2}-rust-version{3}-{4}-results', runner.os, runner.arch, matrix.config.r, matrix.config.rust-version, matrix.config.id || strategy.job-index) }}
           path: extendrtests_check
       # With https://github.com/extendr/rextendr/pull/31
       # rextendr can be configured using environment variables.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -205,9 +205,15 @@ jobs:
         shell: Rscript {0}
 
       - name: Run R integration tests using {extendrtests} and `cargo extendr r-cmd-check`
+        id: id_cargo_r_cmd_check
         run: |
           cargo extendr r-cmd-check --error-on ${{ steps.error-on.outputs.level }} --check-dir extendrtests_check
-
+      - name: Upload results if it failed
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: "Results from r-cmd-check of {extendrtests}"
+          path: extendrtests_check
       # With https://github.com/extendr/rextendr/pull/31
       # rextendr can be configured using environment variables.
       # 'patch.crates_io' is used to point libraries to local copies of


### PR DESCRIPTION
We continue to see sporadic errors on ci.

The logs from r-cmd-check are not uploaded, when it fails.

We use our own custom invocation of `r-cmd-check` due to path issues or something or another I've never understood why we even have to be bogged down by rstudio path-nonsense.

Anyways, upload scheme adapted from https://github.com/r-lib/actions/blob/v2/check-r-package/action.yaml

Let us see if it works.
