### PR TITLE
Implement IntoRobj for Dataframe<T>

### DIFF
--- a/extendr-api/src/wrapper/dataframe.rs
+++ b/extendr-api/src/wrapper/dataframe.rs
@@ -62,3 +62,9 @@ where
         )
     }
 }
+
+impl<T> IntoRobj for Dataframe<T> {
+    fn into_robj(self) -> Robj {
+        self.robj
+    }
+}

--- a/extendr-api/tests/dataframe_tests.rs
+++ b/extendr-api/tests/dataframe_tests.rs
@@ -29,3 +29,25 @@ fn test_derive_into_dataframe() {
         assert_eq!(list[1], r!(["0", "1"]));
     }
 }
+
+#[test]
+fn test_into_robj_dataframe() {
+    test! {
+        use extendr_api::prelude::*;
+
+        #[derive(Clone, Debug, IntoDataFrameRow)]
+        struct MyStruct {
+            x: Rint,
+            y: Rstr,
+        }
+
+        let v = vec![MyStruct { x: 0.into(), y: "abc".into() }, MyStruct { x: 1.into(), y: "xyz".into() }];
+        let df = v.into_dataframe()?;
+
+        assert_eq!(
+            df.clone().as_robj().clone(),
+            df.into_robj()
+        );
+
+    }
+}


### PR DESCRIPTION
This PR closes https://github.com/extendr/extendr/issues/710

It implements `IntoRobj` by returning the inner `Robj`. The associate test asserts that the returned Robj is equal to the Robj provided by `df.as_robj().clone()`.