### PR TITLE
No "as" for basic cases

### DIFF
--- a/extendr-api/src/deserializer.rs
+++ b/extendr-api/src/deserializer.rs
@@ -726,9 +726,9 @@ impl<'de> Visitor<'de> for RobjVisitor {
         E: serde::de::Error,
     {
         if v > i64::from(i32::MIN) && v <= i64::from(i32::MAX) {
-            i32::try_from(v)
+            i32::try_from(v)?.try_into()
         } else {
-            f64::try_from(v)
+            f64::try_from(v)?.try_into()
         }
     }
 
@@ -737,9 +737,9 @@ impl<'de> Visitor<'de> for RobjVisitor {
         E: serde::de::Error,
     {
         if v <= u64::from(i32::MAX) {
-            i32::try_from(v)
+            i32::try_from(v)?.try_into()
         } else {
-            f64::try_from(v)
+            f64::try_from(v)?.try_into()
         }
     }
 

--- a/extendr-api/src/deserializer.rs
+++ b/extendr-api/src/deserializer.rs
@@ -361,7 +361,7 @@ impl<'de> Deserializer<'de> for &'de Robj {
     where
         V: Visitor<'de>,
     {
-        visitor.visit_i128(i64::try_from(self.clone())? as i128)
+        visitor.visit_i128(i64::try_from(self.clone())?.try_into()?)
     }
 
     fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value>
@@ -396,7 +396,7 @@ impl<'de> Deserializer<'de> for &'de Robj {
     where
         V: Visitor<'de>,
     {
-        visitor.visit_u128(u64::try_from(self.clone())? as u128)
+        visitor.visit_u128(u64::try_from(self.clone())?.try_into()?)
     }
 
     fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value>
@@ -725,10 +725,9 @@ impl<'de> Visitor<'de> for RobjVisitor {
     where
         E: serde::de::Error,
     {
-        if v > i32::MIN as i64 && v <= i32::MAX as i64 {
-            Ok((v as i32).into())
-        } else {
-            Ok((v as f64).into())
+        match i32::try_from(v) {
+            Ok(x) => x,
+            Err(_) => f64::try_from(v)?
         }
     }
 
@@ -736,10 +735,9 @@ impl<'de> Visitor<'de> for RobjVisitor {
     where
         E: serde::de::Error,
     {
-        if v <= i32::MAX as u64 {
-            Ok((v as i32).into())
-        } else {
-            Ok((v as f64).into())
+        match i32::try_from(v) {
+            Ok(x) => x,
+            Err(_) => f64::try_from(v)?
         }
     }
 
@@ -853,10 +851,9 @@ impl<'de> Visitor<'de> for IntegersVisitor {
     where
         E: serde::de::Error,
     {
-        if v > i32::MIN as i64 && v <= i32::MAX as i64 {
-            Ok(Integers::from_values([v as i32]))
-        } else {
-            Err(serde::de::Error::custom("out of range for Integers"))
+        match i32::try_from(v) {
+            Ok(x) => Integers::from_values(x),
+            Err(_) => Err(serde::de::Error::custom("out of range for Integers"))
         }
     }
 
@@ -864,10 +861,9 @@ impl<'de> Visitor<'de> for IntegersVisitor {
     where
         E: serde::de::Error,
     {
-        if v <= i32::MAX as u64 {
-            Ok(Integers::from_values([v as i32]))
-        } else {
-            Err(serde::de::Error::custom("out of range for Integers"))
+        match i32::try_from(v) {
+            Ok(x) => Integers::from_values(x),
+            Err(_) => Err(serde::de::Error::custom("out of range for Integers"))
         }
     }
 
@@ -926,14 +922,14 @@ impl<'de> Visitor<'de> for DoublesVisitor {
     where
         E: serde::de::Error,
     {
-        Ok(Doubles::from_values([v as f64]))
+        Ok(Doubles::from_values([f64::try_from(v).unwrap()]))
     }
 
     fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
     where
         E: serde::de::Error,
     {
-        Ok(Doubles::from_values([v as f64]))
+        Ok(Doubles::from_values([f64::try_from(v).unwrap()]))
     }
 
     fn visit_f64<E>(self, v: f64) -> std::result::Result<Self::Value, E>

--- a/extendr-api/src/deserializer.rs
+++ b/extendr-api/src/deserializer.rs
@@ -926,14 +926,14 @@ impl<'de> Visitor<'de> for DoublesVisitor {
     where
         E: serde::de::Error,
     {
-        Ok(Doubles::from_values([f64::try_from(v).unwrap()]))
+        Ok(Doubles::from_values([f64::try_from(v)?]))
     }
 
     fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
     where
         E: serde::de::Error,
     {
-        Ok(Doubles::from_values([f64::try_from(v).unwrap()]))
+        Ok(Doubles::from_values([f64::try_from(v)?]))
     }
 
     fn visit_f64<E>(self, v: f64) -> std::result::Result<Self::Value, E>

--- a/extendr-api/src/deserializer.rs
+++ b/extendr-api/src/deserializer.rs
@@ -725,9 +725,10 @@ impl<'de> Visitor<'de> for RobjVisitor {
     where
         E: serde::de::Error,
     {
-        match i32::try_from(v) {
-            Ok(x) => x,
-            Err(_) => f64::try_from(v)?
+        if v > i64::from(i32::MIN) && v <= i64::from(i32::MAX) {
+            i32::try_from(v)
+        } else {
+            f64::try_from(v)
         }
     }
 
@@ -735,9 +736,10 @@ impl<'de> Visitor<'de> for RobjVisitor {
     where
         E: serde::de::Error,
     {
-        match i32::try_from(v) {
-            Ok(x) => x,
-            Err(_) => f64::try_from(v)?
+        if v <= u64::from(i32::MAX) {
+            i32::try_from(v)
+        } else {
+            f64::try_from(v)
         }
     }
 
@@ -851,9 +853,10 @@ impl<'de> Visitor<'de> for IntegersVisitor {
     where
         E: serde::de::Error,
     {
-        match i32::try_from(v) {
-            Ok(x) => Integers::from_values(x),
-            Err(_) => Err(serde::de::Error::custom("out of range for Integers"))
+        if v > i64::from(i32::MIN) && v <= i64::from(i32::MAX) {
+            Ok(Integers::from_values([i32::try_from(v)?]))
+        } else {
+            Err(serde::de::Error::custom("out of range for Integers"))
         }
     }
 
@@ -861,9 +864,10 @@ impl<'de> Visitor<'de> for IntegersVisitor {
     where
         E: serde::de::Error,
     {
-        match i32::try_from(v) {
-            Ok(x) => Integers::from_values(x),
-            Err(_) => Err(serde::de::Error::custom("out of range for Integers"))
+        if v <= u64::from(i32::MAX) {
+            Ok(Integers::from_values([i32::try_from(v)?]))
+        } else {
+            Err(serde::de::Error::custom("out of range for Integers"))
         }
     }
 

--- a/extendr-api/src/functions.rs
+++ b/extendr-api/src/functions.rs
@@ -117,7 +117,7 @@ pub fn empty_env() -> Environment {
 #[cfg(use_r_newenv)]
 pub fn new_env(parent: Environment, hash: bool, capacity: i32) -> Environment {
     single_threaded(|| unsafe {
-        let env = R_NewEnv(parent.robj.get(), i32::try_from(hash).unwrap(), capacity);
+        let env = R_NewEnv(parent.robj.get(), i32::from(hash), capacity);
         Robj::from_sexp(env).try_into().unwrap()
     })
 }

--- a/extendr-api/src/functions.rs
+++ b/extendr-api/src/functions.rs
@@ -117,7 +117,7 @@ pub fn empty_env() -> Environment {
 #[cfg(use_r_newenv)]
 pub fn new_env(parent: Environment, hash: bool, capacity: i32) -> Environment {
     single_threaded(|| unsafe {
-        let env = R_NewEnv(parent.robj.get(), hash as i32, capacity);
+        let env = R_NewEnv(parent.robj.get(), i32::try_from(hash).unwrap(), capacity);
         Robj::from_sexp(env).try_into().unwrap()
     })
 }

--- a/extendr-api/src/graphics/color.rs
+++ b/extendr-api/src/graphics/color.rs
@@ -12,7 +12,7 @@ impl Color {
         let red = (hex >> 16) & 0xff;
         let green = (hex >> 8) & 0xff;
         let blue = hex & 0xff;
-        Color(red as i32 | (green as i32) << 8 | (blue as i32) << 16 | 0xff << 24)
+        Color(i32::from(red) | i32::from(green) << 8 | i32::from(blue) << 16 | 0xff << 24)
     }
 
     /// Generate a color from a 3 digit CSS-like hex number.
@@ -21,17 +21,17 @@ impl Color {
         let red = ((hex >> 8) & 0xf) * 0xff / 0x0f;
         let green = ((hex >> 4) & 0xf) * 0xff / 0x0f;
         let blue = (hex & 0xf) * 0xff / 0x0f;
-        Color(red as i32 | (green as i32) << 8 | (blue as i32) << 16 | 0xff << 24)
+        Color(i32::from(red) | i32::from(green) << 8 | i32::from(blue) << 16 | 0xff << 24)
     }
 
     /// Generate a color from rgb components (0-255).
     pub fn rgb(red: u8, green: u8, blue: u8) -> Color {
-        Color(red as i32 | (green as i32) << 8 | (blue as i32) << 16 | 0xff << 24)
+        Color(i32::from(red) | i32::from(green) << 8 | i32::from(blue) << 16 | 0xff << 24)
     }
 
     /// Generate a color from rgba components (0-255).
     pub fn rgba(red: u8, green: u8, blue: u8, alpha: u8) -> Color {
-        Color(red as i32 | (green as i32) << 8 | (blue as i32) << 16 | (alpha as i32) << 24)
+        Color(i32::from(red) | i32::from(green) << 8 | i32::from(blue) << 16 | i32::from(alpha) << 24)
     }
 }
 

--- a/extendr-api/src/graphics/device_driver.rs
+++ b/extendr-api/src/graphics/device_driver.rs
@@ -470,7 +470,7 @@ pub trait DeviceDriver: std::marker::Sized {
         ) {
             let nper = slice::from_raw_parts(nper, npoly as _);
             // TODO: This isn't very efficient as we need to iterate over nper at least twice.
-            let n = nper.iter().sum::<i32>() as usize;
+            let n = usize::try_from(nper.iter().sum::<i32>()).unwrap();
             let x = slice::from_raw_parts(x, n as _).iter();
             let y = slice::from_raw_parts(y, n as _).iter();
             // TODO: does this map has some overhead? If so, maybe we should change the interface?

--- a/extendr-api/src/graphics/mod.rs
+++ b/extendr-api/src/graphics/mod.rs
@@ -272,7 +272,7 @@ impl Context {
                 .fontfamily
                 .iter_mut()
                 .zip(b"Helvetica".iter())
-                .for_each(|(d, s)| *d = *s as i8);
+                .for_each(|(d, s)| *d = i8::try_from(*s).unwrap());
 
             Self {
                 context,
@@ -389,7 +389,7 @@ impl Context {
         }
 
         for (i, b) in fontfamily.bytes().enumerate().take(maxlen) {
-            self.context.fontfamily[i] = b as std::os::raw::c_char;
+            self.context.fontfamily[i] = std::os::raw::c_char::try_from(b).unwrap();
         }
         self
     }
@@ -581,7 +581,7 @@ impl Device {
         let yptr = y.as_mut_slice().as_mut_ptr();
         unsafe {
             GEPolyline(
-                x.len() as std::os::raw::c_int,
+                std::os::raw::c_int::try_from(x.len()).unwrap(),
                 xptr,
                 yptr,
                 gc.context(),
@@ -599,7 +599,7 @@ impl Device {
         let yptr = y.as_mut_slice().as_mut_ptr();
         unsafe {
             GEPolygon(
-                x.len() as std::os::raw::c_int,
+                std::os::raw::c_int::try_from(x.len()).unwrap(),
                 xptr,
                 yptr,
                 gc.context(),
@@ -691,7 +691,7 @@ impl Device {
             GEPath(
                 xptr,
                 yptr,
-                nper.len() as std::os::raw::c_int,
+                std::os::raw::c_int::try_from(nper.len()).unwrap(),
                 nperptr,
                 if winding { 1 } else { 0 },
                 gc.context(),
@@ -722,8 +722,8 @@ impl Device {
         let h = pixels.len() / w;
         unsafe {
             let raster = pixels.as_ptr() as *mut u32;
-            let w = w as i32;
-            let h = h as i32;
+            let w = i32::try_from(w).unwrap();
+            let h = i32::try_from(h).unwrap();
             let interpolate = if interpolate { 1 } else { 0 };
             GERaster(
                 raster,
@@ -788,7 +788,7 @@ impl Device {
                 width: 0.0,
             };
             GEMetricInfo(
-                c as i32,
+                i32::try_from(c).unwrap(),
                 gc.context(),
                 &mut res.ascent as *mut f64,
                 &mut res.descent as *mut f64,

--- a/extendr-api/src/io/load.rs
+++ b/extendr-api/src/io/load.rs
@@ -41,7 +41,7 @@ pub trait Load {
             arg3: ::std::os::raw::c_int,
         ) {
             let reader = &mut *((*arg1).data as *mut R);
-            let buf = std::slice::from_raw_parts_mut(arg2 as *mut u8, arg3 as usize);
+            let buf = std::slice::from_raw_parts_mut(arg2 as *mut u8, usize::try_from(arg3).unwrap());
             reader.read_exact(buf).unwrap();
         }
 

--- a/extendr-api/src/io/save.rs
+++ b/extendr-api/src/io/save.rs
@@ -26,7 +26,7 @@ impl<W: Write> OutStream<W> {
     ) -> Box<OutStream<W>> {
         unsafe extern "C" fn outchar<W: Write>(arg1: R_outpstream_t, arg2: ::std::os::raw::c_int) {
             let writer = &mut *((*arg1).data as *mut W);
-            let b = [arg2 as u8];
+            let b = [u8::try_from(arg2).unwrap()];
             writer.write_all(&b).unwrap();
         }
 
@@ -36,7 +36,7 @@ impl<W: Write> OutStream<W> {
             arg3: ::std::os::raw::c_int,
         ) {
             let writer = &mut *((*arg1).data as *mut W);
-            let b = std::slice::from_raw_parts(arg2 as *mut u8, arg3 as usize);
+            let b = std::slice::from_raw_parts(arg2 as *mut u8, usize::try_from(arg3).unwrap());
             writer.write_all(b).unwrap();
         }
 

--- a/extendr-api/src/iter.rs
+++ b/extendr-api/src/iter.rs
@@ -64,9 +64,9 @@ fn str_from_strsxp<'a>(sexp: SEXP, index: isize) -> &'a str {
             let charsxp = STRING_ELT(sexp, index);
             if charsxp == R_NaString {
                 <&str>::na()
-            } else if TYPEOF(charsxp) == CHARSXP as i32 {
+            } else if TYPEOF(charsxp) == i32::try_from(CHARSXP).unwrap() {
                 let ptr = R_CHAR(charsxp) as *const u8;
-                let slice = std::slice::from_raw_parts(ptr, Rf_xlength(charsxp) as usize);
+                let slice = std::slice::from_raw_parts(ptr, usize::try_from(Rf_xlength(charsxp)).unwrap());
                 std::str::from_utf8_unchecked(slice)
             } else {
                 <&str>::na()
@@ -89,12 +89,12 @@ impl Iterator for StrIter {
             let vector = self.vector.get();
             if i >= self.len {
                 None
-            } else if TYPEOF(vector) as u32 == STRSXP {
-                Some(str_from_strsxp(vector, i as isize))
-            } else if TYPEOF(vector) as u32 == INTSXP && TYPEOF(self.levels) as u32 == STRSXP {
+            } else if u32::try_from(TYPEOF(vector)).unwrap() == STRSXP {
+                Some(str_from_strsxp(vector, isize::try_from(i).unwrap()))
+            } else if u32::try_from(TYPEOF(vector)).unwrap() == INTSXP && u32::try_from(TYPEOF(self.levels)).unwrap() == STRSXP {
                 let j = *(INTEGER(vector).add(i));
-                Some(str_from_strsxp(self.levels, j as isize - 1))
-            } else if TYPEOF(vector) as u32 == NILSXP {
+                Some(str_from_strsxp(self.levels, isize::try_from(j).unwrap() - 1))
+            } else if u32::try_from(TYPEOF(vector)).unwrap() == NILSXP {
                 Some(<&str>::na())
             } else {
                 None

--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -451,7 +451,7 @@ unsafe fn make_method_def(
     rmethods.push(libR_sys::R_CallMethodDef {
         name: cstrings.last().unwrap().as_ptr(),
         fun: Some(std::mem::transmute(func.func_ptr)),
-        numArgs: func.args.len() as i32,
+        numArgs: func.args.len().try_into().unwrap(),
     });
 }
 
@@ -584,13 +584,13 @@ pub fn rtype_to_sxp(rtype: Rtype) -> i32 {
         Raw => RAWSXP,
         S4 => S4SXP,
         Unknown => panic!("attempt to use Unknown Rtype"),
-    }) as i32
+    }).try_into().unwrap()
 }
 
 /// Convert R's SEXPTYPE to extendr's Rtype.
 pub fn sxp_to_rtype(sxptype: i32) -> Rtype {
     use Rtype::*;
-    match sxptype as u32 {
+    match u32::try_from(sxptype).unwrap() {
         NILSXP => Null,
         SYMSXP => Symbol,
         LISTSXP => Pairlist,
@@ -841,8 +841,8 @@ mod tests {
                 wrap__floattypes(Robj::from(1).get(), Robj::from(2).get());
                 wrap__strtypes(Robj::from("abc").get(), Robj::from("def").get());
                 wrap__vectortypes(
-                    Robj::from(&[1, 2, 3] as &[i32]).get(),
-                    Robj::from(&[4., 5., 6.] as &[f64]).get(),
+                    Robj::from(&[1_i32, 2_i32, 3_i32]).get(),
+                    Robj::from(&[4_f64, 5_f64, 6_f64]).get(),
                 );
                 wrap__robjtype(Robj::from(1).get());
 

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -12,7 +12,7 @@ pub(crate) fn str_to_character(s: &str) -> SEXP {
             single_threaded(|| {
                 Rf_mkCharLenCE(
                     s.as_ptr() as *const raw::c_char,
-                    s.len() as i32,
+                    i32::try_from(s.len()).unwrap(),
                     cetype_t_CE_UTF8,
                 )
             })
@@ -500,7 +500,7 @@ where
                 }
                 STRSXP => {
                     for (i, v) in iter.enumerate() {
-                        SET_STRING_ELT(sexp, i as isize, v.to_sexp());
+                        SET_STRING_ELT(sexp, isize::try_from(i).unwrap(), v.to_sexp());
                     }
                 }
                 RAWSXP => {

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -167,7 +167,7 @@ pub trait Slices: GetSexp {
     /// Unless the type is correct, this will cause undefined behaviour.
     /// Creating this slice will also instatiate and Altrep objects.
     unsafe fn as_typed_slice_raw<T>(&self) -> &[T] {
-        let len = XLENGTH(self.get()) as usize;
+        let len = usize::try_from(XLENGTH(self.get())).unwrap();
         let data = DATAPTR_RO(self.get()) as *const T;
         std::slice::from_raw_parts(data, len)
     }
@@ -180,7 +180,7 @@ pub trait Slices: GetSexp {
     /// Creating this slice will also instatiate and Altrep objects.
     /// Not all obejects (especially not list and strings) support this.
     unsafe fn as_typed_slice_raw_mut<T>(&mut self) -> &mut [T] {
-        let len = XLENGTH(self.get()) as usize;
+        let len = usize::try_from(XLENGTH(self.get())).unwrap();
         let data = DATAPTR(self.get_mut()) as *mut T;
         std::slice::from_raw_parts_mut(data, len)
     }
@@ -199,7 +199,7 @@ pub trait Length: GetSexp {
     /// }
     /// ```
     fn len(&self) -> usize {
-        unsafe { Rf_xlength(self.get()) as usize }
+        unsafe { usize::try_from(Rf_xlength(self.get())).unwrap() }
     }
 
     /// Returns `true` if the `Robj` contains no elements.
@@ -237,7 +237,7 @@ pub trait Types: GetSexp {
     #[doc(hidden)]
     /// Get the XXXSXP type of the object.
     fn sexptype(&self) -> u32 {
-        unsafe { TYPEOF(self.get()) as u32 }
+        unsafe { u32::try_from(TYPEOF(self.get())).unwrap() }
     }
 
     /// Get the type of an R object.
@@ -1083,7 +1083,7 @@ pub(crate) unsafe fn to_str<'a>(ptr: *const u8) -> &'a str {
         }
         len += 1;
     }
-    let slice = std::slice::from_raw_parts(ptr, len as usize);
+    let slice = std::slice::from_raw_parts(ptr, usize::try_from(len).unwrap());
     std::str::from_utf8_unchecked(slice)
 }
 

--- a/extendr-api/src/robj/rinternals.rs
+++ b/extendr-api/src/robj/rinternals.rs
@@ -67,7 +67,7 @@ pub trait Rinternals: Types + Conversions {
 
     /// Get the source ref.
     fn get_current_srcref(val: i32) -> Robj {
-        unsafe { Robj::from_sexp(R_GetCurrentSrcref(val as raw::c_int)) }
+        unsafe { Robj::from_sexp(R_GetCurrentSrcref(raw::c_int::try_from(val).unwrap())) }
     }
 
     /// Get the source filename.
@@ -83,7 +83,7 @@ pub trait Rinternals: Types + Conversions {
     /// Convert to vectors of many kinds.
     fn coerce_vector(&self, sexptype: u32) -> Robj {
         single_threaded(|| unsafe {
-            Robj::from_sexp(Rf_coerceVector(self.get(), sexptype as SEXPTYPE))
+            Robj::from_sexp(Rf_coerceVector(self.get(), SEXPTYPE::try_from(sexptype).unwrap()))
         })
     }
 
@@ -231,12 +231,12 @@ pub trait Rinternals: Types + Conversions {
 
     /// Number of columns of a matrix
     fn ncols(&self) -> usize {
-        unsafe { Rf_ncols(self.get()) as usize }
+        unsafe { Rf_ncols(self.get()).try_into().unwrap() }
     }
 
     /// Number of rows of a matrix
     fn nrows(&self) -> usize {
-        unsafe { Rf_nrows(self.get()) as usize }
+        unsafe { Rf_nrows(self.get()).try_into().unwrap() }
     }
 
     /// Internal function used to implement `#[extendr]` impl
@@ -283,7 +283,7 @@ pub trait Rinternals: Types + Conversions {
         unsafe {
             if self.is_vector() {
                 Ok(single_threaded(|| {
-                    Robj::from_sexp(Rf_xlengthgets(self.get(), new_len as R_xlen_t))
+                    Robj::from_sexp(Rf_xlengthgets(self.get(), R_xlen_t::try_from(new_len).unwrap()))
                 }))
             } else {
                 Err(Error::ExpectedVector(self.as_robj().clone()))
@@ -293,7 +293,7 @@ pub trait Rinternals: Types + Conversions {
 
     /// Allocated an owned object of a certain type.
     fn alloc_vector(sexptype: u32, len: usize) -> Robj {
-        single_threaded(|| unsafe { Robj::from_sexp(Rf_allocVector(sexptype, len as R_xlen_t)) })
+        single_threaded(|| unsafe { Robj::from_sexp(Rf_allocVector(sexptype, R_xlen_t::try_from(len).unwrap())) })
     }
 
     /// Return true if two arrays have identical dims.
@@ -450,33 +450,33 @@ pub trait Rinternals: Types + Conversions {
 
     /// Returns `true` if this is an integer ALTREP object.
     fn is_altinteger(&self) -> bool {
-        unsafe { ALTREP(self.get()) != 0 && TYPEOF(self.get()) == INTSXP as i32 }
+        unsafe { ALTREP(self.get()) != 0 && TYPEOF(self.get()) == i32::try_from(INTSXP).unwrap() }
     }
 
     /// Returns `true` if this is an real ALTREP object.
     fn is_altreal(&self) -> bool {
-        unsafe { ALTREP(self.get()) != 0 && TYPEOF(self.get()) == REALSXP as i32 }
+        unsafe { ALTREP(self.get()) != 0 && TYPEOF(self.get()) == i32::try_from(REALSXP).unwrap() }
     }
 
     /// Returns `true` if this is an logical ALTREP object.
     fn is_altlogical(&self) -> bool {
-        unsafe { ALTREP(self.get()) != 0 && TYPEOF(self.get()) == LGLSXP as i32 }
+        unsafe { ALTREP(self.get()) != 0 && TYPEOF(self.get()) == i32::try_from(LGLSXP).unwrap() }
     }
 
     /// Returns `true` if this is a raw ALTREP object.
     fn is_altraw(&self) -> bool {
-        unsafe { ALTREP(self.get()) != 0 && TYPEOF(self.get()) == RAWSXP as i32 }
+        unsafe { ALTREP(self.get()) != 0 && TYPEOF(self.get()) == i32::try_from(RAWSXP).unwrap() }
     }
 
     /// Returns `true` if this is an integer ALTREP object.
     fn is_altstring(&self) -> bool {
-        unsafe { ALTREP(self.get()) != 0 && TYPEOF(self.get()) == STRSXP as i32 }
+        unsafe { ALTREP(self.get()) != 0 && TYPEOF(self.get()) == i32::try_from(STRSXP).unwrap() }
     }
 
     /// Returns `true` if this is an integer ALTREP object.
     #[cfg(use_r_altlist)]
     fn is_altlist(&self) -> bool {
-        unsafe { ALTREP(self.get()) != 0 && TYPEOF(self.get()) == VECSXP as i32 }
+        unsafe { ALTREP(self.get()) != 0 && TYPEOF(self.get()) == i32::try_from(VECSXP).unwrap() }
     }
 
     /// Generate a text representation of this object.

--- a/extendr-api/src/robj/tests.rs
+++ b/extendr-api/src/robj/tests.rs
@@ -295,7 +295,7 @@ fn output_iterator_test() {
         let robj = [TRUE, FALSE, TRUE].iter().collect_robj();
         assert_eq!(robj.as_logical_vector().unwrap(), vec![TRUE, FALSE, TRUE]);
 
-        let robj = (0..3).map(|x| x as f64).collect_robj();
+        let robj = (0..3).map(|x| f64::try_from(x).unwrap()).collect_robj();
         assert_eq!(robj.as_real_vector().unwrap(), vec![0., 1., 2.]);
 
         let robj = [0., 1., 2.].iter().collect_robj();
@@ -311,7 +311,7 @@ fn output_iterator_test() {
         let robj = (0..3).filter(|&x| x != 1).collect_robj();
         assert_eq!(robj.as_integer_vector().unwrap(), vec![0, 2]);
 
-        let robj = (0..3).filter(|&x| x != 1).map(|x| x as f64).collect_robj();
+        let robj = (0..3).filter(|&x| x != 1).map(|x| f64::try_from(x).unwrap()).collect_robj();
         assert_eq!(robj.as_real_vector().unwrap(), vec![0., 2.]);
 
         let robj = (0..3)

--- a/extendr-api/src/robj/try_from_robj.rs
+++ b/extendr-api/src/robj/try_from_robj.rs
@@ -372,7 +372,7 @@ impl TryFrom<&Robj> for Rcplx {
         // Any integer (32 bit) can be represented as f64,
         // this always works.
         if let Some(v) = robj.as_integer() {
-            return Ok(Rcplx::from(v as f64));
+            return Ok(Rcplx::from(f64::from(v)));
         }
 
         // Complex slices return their first element.

--- a/extendr-api/src/scalar/rbool.rs
+++ b/extendr-api/src/scalar/rbool.rs
@@ -56,7 +56,7 @@ impl Rbool {
 
     /// Convert this construct a `Rbool` from a rust boolean.
     pub fn from_bool(val: bool) -> Self {
-        Rbool(val as i32)
+        Rbool(i32::from(val))
     }
 }
 

--- a/extendr-api/src/scalar/rfloat.rs
+++ b/extendr-api/src/scalar/rfloat.rs
@@ -165,7 +165,7 @@ gen_unop!(Rfloat, Neg, |lhs: f64| Some(-lhs), "Negate a Rfloat value.");
 
 impl From<i32> for Rfloat {
     fn from(value: i32) -> Self {
-        Rfloat::from(value as f64)
+        Rfloat::from(f64::from(value))
     }
 }
 
@@ -203,7 +203,7 @@ impl TryFrom<&Robj> for Rfloat {
         // Any integer (32 bit) can be represented as f64,
         // this always works.
         if let Some(v) = robj.as_integer() {
-            return Ok(Rfloat::from(v as f64));
+            return Ok(Rfloat::from(f64::from(v)));
         }
 
         Err(Error::ExpectedNumeric(robj.clone()))

--- a/extendr-api/src/wrapper/altrep.rs
+++ b/extendr-api/src/wrapper/altrep.rs
@@ -565,8 +565,8 @@ impl Altrep {
                 Robj::from_sexp(class),
                 Robj::from_sexp(state),
                 Robj::from_sexp(attr),
-                i32::try_from(objf).unwrap(),
-                i32::try_from(levs).unwrap(),
+                objf,
+                levs,
             )
             .get()
         }
@@ -716,7 +716,7 @@ impl Altrep {
                 x: SEXP,
                 i: R_xlen_t,
             ) -> c_int {
-                Altrep::get_state::<StateType>(x).elt(usize::try_from(i).unwrap()).inner().try_into().unwrap()
+                Altrep::get_state::<StateType>(x).elt(usize::try_from(i).unwrap()).inner()
             }
 
             unsafe extern "C" fn altinteger_Get_region<StateType: AltIntegerImpl + 'static>(
@@ -732,7 +732,7 @@ impl Altrep {
             unsafe extern "C" fn altinteger_Is_sorted<StateType: AltIntegerImpl + 'static>(
                 x: SEXP,
             ) -> c_int {
-                Altrep::get_state::<StateType>(x).is_sorted().inner().try_into().unwrap()
+                Altrep::get_state::<StateType>(x).is_sorted().inner()
             }
 
             unsafe extern "C" fn altinteger_No_NA<StateType: AltIntegerImpl + 'static>(
@@ -806,7 +806,7 @@ impl Altrep {
             unsafe extern "C" fn altreal_Is_sorted<StateType: AltRealImpl + 'static>(
                 x: SEXP,
             ) -> c_int {
-                Altrep::get_state::<StateType>(x).is_sorted().inner().try_into().unwrap()
+                Altrep::get_state::<StateType>(x).is_sorted().inner()
             }
 
             unsafe extern "C" fn altreal_No_NA<StateType: AltRealImpl + 'static>(x: SEXP) -> c_int {
@@ -861,7 +861,7 @@ impl Altrep {
                 x: SEXP,
                 i: R_xlen_t,
             ) -> c_int {
-                Altrep::get_state::<StateType>(x).elt(usize::try_from(i).unwrap()).inner().try_into().unwrap()
+                Altrep::get_state::<StateType>(x).elt(usize::try_from(i).unwrap()).inner()
             }
 
             unsafe extern "C" fn altlogical_Get_region<StateType: AltLogicalImpl + 'static>(
@@ -877,7 +877,7 @@ impl Altrep {
             unsafe extern "C" fn altlogical_Is_sorted<StateType: AltLogicalImpl + 'static>(
                 x: SEXP,
             ) -> c_int {
-                Altrep::get_state::<StateType>(x).is_sorted().inner().try_into().unwrap()
+                Altrep::get_state::<StateType>(x).is_sorted().inner()
             }
 
             unsafe extern "C" fn altlogical_No_NA<StateType: AltLogicalImpl + 'static>(
@@ -918,7 +918,7 @@ impl Altrep {
                 x: SEXP,
                 i: R_xlen_t,
             ) -> Rbyte {
-                Altrep::get_state::<StateType>(x).elt(usize::try_from(i).unwrap()).try_into().unwrap()
+                Altrep::get_state::<StateType>(x).elt(usize::try_from(i).unwrap())
             }
 
             unsafe extern "C" fn altraw_Get_region<StateType: AltRawImpl + 'static>(
@@ -1004,7 +1004,7 @@ impl Altrep {
             unsafe extern "C" fn altstring_Is_sorted<StateType: AltStringImpl + 'static>(
                 x: SEXP,
             ) -> c_int {
-                Altrep::get_state::<StateType>(x).is_sorted().inner().try_into().unwrap()
+                Altrep::get_state::<StateType>(x).is_sorted().inner()
             }
 
             unsafe extern "C" fn altstring_No_NA<StateType: AltStringImpl + 'static>(
@@ -1046,7 +1046,7 @@ impl Altrep {
                 v: SEXP,
             ) {
                 Altrep::get_state_mut::<StateType>(x)
-                    .set_elt(usize::try_from(i).unwrap(), Robj::from_sexp(v).try_into().unwrap())
+                    .set_elt(usize::try_from(i).unwrap(), Robj::from_sexp(v))
             }
 
             R_set_altlist_Elt_method(class_ptr, Some(altlist_Elt::<StateType>));

--- a/extendr-api/src/wrapper/altrep.rs
+++ b/extendr-api/src/wrapper/altrep.rs
@@ -190,7 +190,7 @@ pub trait AltIntegerImpl: AltrepImpl {
         for i in 0..len {
             let val = self.elt(i);
             if !val.is_na() {
-                tot += i64::try_from(val.inner()).unwrap();
+                tot += i64::from(val.inner());
                 min = min.min(val.inner());
                 max = max.max(val.inner());
                 nas += 1;
@@ -350,7 +350,7 @@ pub trait AltLogicalImpl: AltrepImpl {
         for i in 0..len {
             let val = self.elt(i);
             if !val.is_na() {
-                tot += i64::try_from(val.inner()).unwrap();
+                tot += i64::from(val.inner());
                 nas += 1;
             }
         }

--- a/extendr-api/src/wrapper/complexes.rs
+++ b/extendr-api/src/wrapper/complexes.rs
@@ -32,7 +32,7 @@ impl Complexes {
     pub fn get_region(&self, index: usize, dest: &mut [Rcplx]) -> usize {
         unsafe {
             let ptr: *mut Rcomplex = dest.as_mut_ptr() as *mut Rcomplex;
-            COMPLEX_GET_REGION(self.get(), index as R_xlen_t, dest.len() as R_xlen_t, ptr) as usize
+            COMPLEX_GET_REGION(self.get(), R_xlen_t::try_from(index).unwrap() , R_xlen_t::try_from(dest.len()).unwrap(), ptr).try_into().unwrap()
         }
     }
 }

--- a/extendr-api/src/wrapper/doubles.rs
+++ b/extendr-api/src/wrapper/doubles.rs
@@ -35,7 +35,7 @@ impl Doubles {
     pub fn get_region(&self, index: usize, dest: &mut [Rfloat]) -> usize {
         unsafe {
             let ptr: *mut f64 = dest.as_mut_ptr() as *mut f64;
-            REAL_GET_REGION(self.get(), index as R_xlen_t, dest.len() as R_xlen_t, ptr) as usize
+            REAL_GET_REGION(self.get(), R_xlen_t::try_from(index).unwrap(), R_xlen_t::try_from(dest.len()).unwrap(), ptr).try_into().unwrap()
         }
     }
 
@@ -54,7 +54,7 @@ impl Doubles {
 impl Doubles {
     pub fn set_elt(&mut self, index: usize, val: Rfloat) {
         single_threaded(|| unsafe {
-            SET_REAL_ELT(self.get_mut(), index as R_xlen_t, val.inner());
+            SET_REAL_ELT(self.get_mut(), R_xlen_t::try_from(index).unwrap(), val.inner());
         })
     }
 }

--- a/extendr-api/src/wrapper/environment.rs
+++ b/extendr-api/src/wrapper/environment.rs
@@ -38,7 +38,7 @@ impl Environment {
             new_env(parent, false, 0)
         } else {
             // Hashed environment for larger hashmaps.
-            new_env(parent, true, capacity as i32 * 2 + 1)
+            new_env(parent, true, i32::try_from(capacity).unwrap() * 2 + 1)
         }
     }
 

--- a/extendr-api/src/wrapper/integers.rs
+++ b/extendr-api/src/wrapper/integers.rs
@@ -35,7 +35,7 @@ impl Integers {
     pub fn get_region(&self, index: usize, dest: &mut [Rint]) -> usize {
         unsafe {
             let ptr: *mut i32 = dest.as_mut_ptr() as *mut i32;
-            INTEGER_GET_REGION(self.get(), index as R_xlen_t, dest.len() as R_xlen_t, ptr) as usize
+            INTEGER_GET_REGION(self.get(), R_xlen_t::try_from(index).unwrap(), R_xlen_t::try_from(dest.len()).unwrap(), ptr).try_into().unwrap()
         }
     }
 
@@ -54,7 +54,7 @@ impl Integers {
 impl Integers {
     pub fn set_elt(&mut self, index: usize, val: Rint) {
         single_threaded(|| unsafe {
-            SET_INTEGER_ELT(self.get(), index as R_xlen_t, val.inner());
+            SET_INTEGER_ELT(self.get(), R_xlen_t::try_from(index).unwrap(), val.inner());
         })
     }
 }

--- a/extendr-api/src/wrapper/list.rs
+++ b/extendr-api/src/wrapper/list.rs
@@ -157,7 +157,7 @@ impl List {
             Err(Error::OutOfRange(self.robj.clone()))
         } else {
             unsafe {
-                let sexp = VECTOR_ELT(self.robj.get(), i as R_xlen_t);
+                let sexp = VECTOR_ELT(self.robj.get(), R_xlen_t::try_from(i).unwrap());
                 Ok(Robj::from_sexp(sexp))
             }
         }
@@ -169,7 +169,7 @@ impl List {
             if i >= self.robj.len() {
                 Err(Error::OutOfRange(self.robj.clone()))
             } else {
-                SET_VECTOR_ELT(self.robj.get_mut(), i as R_xlen_t, value.get());
+                SET_VECTOR_ELT(self.robj.get_mut(), R_xlen_t::try_from(i).unwrap(), value.get());
                 Ok(())
             }
         })
@@ -267,7 +267,7 @@ impl Iterator for ListIter {
         if i >= self.len {
             None
         } else {
-            Some(unsafe { Robj::from_sexp(VECTOR_ELT(self.robj.get(), i as isize)) })
+            Some(unsafe { Robj::from_sexp(VECTOR_ELT(self.robj.get(), isize::try_from(i).unwrap())) })
         }
     }
 
@@ -392,7 +392,7 @@ impl<T: Into<Robj>> FromIterator<T> for List {
                 // note: Currently, `Robj` automatically registers `v` by the
                 // `ownership`-module, making it protected, even though it isn't necessary to do so.
                 let item: Robj = v.into();
-                SET_VECTOR_ELT(robj.get_mut(), i as isize, item.get());
+                SET_VECTOR_ELT(robj.get_mut(), isize::try_from(i).unwrap(), item.get());
             }
 
             List { robj }

--- a/extendr-api/src/wrapper/logicals.rs
+++ b/extendr-api/src/wrapper/logicals.rs
@@ -36,7 +36,7 @@ impl Logicals {
     pub fn get_region(&self, index: usize, dest: &mut [Rbool]) -> usize {
         unsafe {
             let ptr: *mut i32 = dest.as_mut_ptr() as *mut i32;
-            LOGICAL_GET_REGION(self.get(), index as R_xlen_t, dest.len() as R_xlen_t, ptr) as usize
+            LOGICAL_GET_REGION(self.get(), R_xlen_t::try_from(index).unwrap(), R_xlen_t::try_from(dest.len()).unwrap(), ptr).try_into().unwrap()
         }
     }
 }
@@ -45,7 +45,7 @@ impl Logicals {
 impl Logicals {
     pub fn set_elt(&mut self, index: usize, val: Rbool) {
         single_threaded(|| unsafe {
-            SET_INTEGER_ELT(self.get_mut(), index as R_xlen_t, val.inner());
+            SET_INTEGER_ELT(self.get_mut(), R_xlen_t::try_from(index).unwrap(), val.inner());
         })
     }
 }

--- a/extendr-api/src/wrapper/macros.rs
+++ b/extendr-api/src/wrapper/macros.rs
@@ -96,7 +96,7 @@ macro_rules! gen_vector_wrapper_impl {
                     if(index >= self.len()) {
                         <$scalar_type>::na()
                     } else {
-                        unsafe { [<$r_prefix _ELT>](self.get(), index as R_xlen_t).into() }
+                        unsafe { [<$r_prefix _ELT>](self.get(), R_xlen_t::try_from(index).unwrap()).into() }
                     }
                 }
             }

--- a/extendr-api/src/wrapper/matrix.rs
+++ b/extendr-api/src/wrapper/matrix.rs
@@ -281,7 +281,7 @@ where
             Err(Error::ExpectedMatrix(robj))
         } else if let Some(_slice) = robj.as_typed_slice_mut() {
             if let Some(dim) = robj.dim() {
-                let dim: Vec<_> = dim.iter().map(|d| d.inner() as usize).collect();
+                let dim: Vec<_> = dim.iter().map(|d| usize::try_from(d.inner()).unwrap()).collect();
                 if dim.len() != 2 {
                     Err(Error::ExpectedMatrix(robj))
                 } else {
@@ -308,7 +308,7 @@ where
                 if dim.len() != 3 {
                     Err(Error::ExpectedMatrix3D(robj))
                 } else {
-                    let dim: Vec<_> = dim.iter().map(|d| d.inner() as usize).collect();
+                    let dim: Vec<_> = dim.iter().map(|d| usize::try_from(d.inner()).unwrap()).collect();
                     Ok(RArray::from_parts(robj, [dim[0], dim[1], dim[2]]))
                 }
             } else {

--- a/extendr-api/src/wrapper/mod.rs
+++ b/extendr-api/src/wrapper/mod.rs
@@ -73,7 +73,7 @@ where
         let mut res = Robj::alloc_vector(sexptype, values.len());
         let sexp = res.get_mut();
         for (i, val) in values.enumerate() {
-            SET_VECTOR_ELT(sexp, i as R_xlen_t, val.into().get());
+            SET_VECTOR_ELT(sexp, R_xlen_t::try_from(i).unwrap(), val.into().get());
         }
         res
     })

--- a/extendr-api/src/wrapper/pairlist.rs
+++ b/extendr-api/src/wrapper/pairlist.rs
@@ -137,9 +137,9 @@ impl Iterator for PairlistIter {
                 let tag = TAG(sexp);
                 let value = Robj::from_sexp(CAR(sexp));
                 self.list_elem = CDR(sexp);
-                if TYPEOF(tag) == SYMSXP as i32 {
+                if TYPEOF(tag) == i32::try_from(SYMSXP).unwrap() {
                     let printname = PRINTNAME(tag);
-                    assert!(TYPEOF(printname) as u32 == CHARSXP);
+                    assert!(u32::try_from(TYPEOF(printname)).unwrap() == CHARSXP);
                     let name = to_str(R_CHAR(printname) as *const u8);
                     Some((std::mem::transmute(name), value))
                 } else {

--- a/extendr-api/src/wrapper/strings.rs
+++ b/extendr-api/src/wrapper/strings.rs
@@ -52,7 +52,7 @@ impl Strings {
             for (i, v) in values.into_iter().take(maxlen).enumerate() {
                 let v = v.as_ref();
                 let ch = str_to_character(v);
-                SET_STRING_ELT(sexp, i as R_xlen_t, ch);
+                SET_STRING_ELT(sexp, R_xlen_t::try_from(i).unwrap(), ch);
             }
             Self { robj }
         })
@@ -72,7 +72,7 @@ impl Strings {
         if i >= self.len() {
             Rstr::na()
         } else {
-            Robj::from_sexp(unsafe { STRING_ELT(self.get(), i as R_xlen_t) })
+            Robj::from_sexp(unsafe { STRING_ELT(self.get(), R_xlen_t::try_from(i).unwrap()) })
                 .try_into()
                 .unwrap()
         }
@@ -82,7 +82,7 @@ impl Strings {
     pub fn set_elt(&mut self, i: usize, e: Rstr) {
         single_threaded(|| unsafe {
             if i < self.len() {
-                SET_STRING_ELT(self.robj.get_mut(), i as isize, e.get());
+                SET_STRING_ELT(self.robj.get_mut(), isize::try_from(i).unwrap(), e.get());
             }
         });
     }
@@ -112,7 +112,7 @@ impl<T: AsRef<str>> FromIterator<T> for Strings {
         let mut robj = Strings::alloc_vector(STRSXP, len);
         crate::single_threaded(|| unsafe {
             for (i, v) in iter_collect.into_iter().enumerate() {
-                SET_STRING_ELT(robj.get_mut(), i as isize, str_to_character(v.as_ref()));
+                SET_STRING_ELT(robj.get_mut(), isize::try_from(i).unwrap(), str_to_character(v.as_ref()));
             }
             Strings { robj }
         })

--- a/extendr-api/src/wrapper/symbol.rs
+++ b/extendr-api/src/wrapper/symbol.rs
@@ -35,7 +35,7 @@ impl Symbol {
     // Internal conversion for constant symbols.
     fn from_sexp(sexp: SEXP) -> Symbol {
         unsafe {
-            assert!(TYPEOF(sexp) == SYMSXP as i32);
+            assert!(TYPEOF(sexp) == i32::try_from(SYMSXP).unwrap());
         }
         Symbol {
             robj: Robj::from_sexp(sexp),
@@ -53,7 +53,7 @@ impl Symbol {
         unsafe {
             let sexp = self.robj.get();
             let printname = PRINTNAME(sexp);
-            assert!(TYPEOF(printname) as u32 == CHARSXP);
+            assert!(u32::try_from(TYPEOF(printname)).unwrap() == CHARSXP);
             to_str(R_CHAR(printname) as *const u8)
         }
     }


### PR DESCRIPTION
Actually, the ```as``` keywords has a lot of effects, and one particular aspect of it is not to be exactly a way to convert between types, for example a i64 to i32 can be truncated, also will convert even if we lacks of the right traits to use ```TryFrom```/```Try```, which is not safe.

This PR will only handle basic cases of ```as``` and be replaced with the right trait.

Also, I have skip to use ```try_into```, that should be talked first, because use that in a lot of places also means to infer the type, which is great at some extent, but do it in each place could be complicated, and also means a less maintainable code.

You will notice there is a lot of ```unwrap``` around, as a simple fix is the right tool, because the code actually used ```as``` and does not considerate with it that the conversions could fail, so not all the functions has the ability to handle errors.
To not use ```unwrap``` and propagate the errors, there is a need of bigger changes.