### PR TITLE
extendr-impl: Support returning `&Self` and `&mut Self`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,18 @@
 
 ## Unreleased
 
-## Added
+### Added
 
 - `RArray::data_mut` provides a mutable slice to the underlying array data [[#657]](https://github.com/extendr/extendr/pull/657)
 
-## Changed
+### Changed
 
 - Potentially breaking: `RArray::from_parts` no longer requires a pointer to the underlying data vector [[#657]](https://github.com/extendr/extendr/pull/657)
+
+### Fixed
+
+- returning `&Self` or `&mut Self` from a method in an `#[extendr]`-impl would
+result in unintended cloning  [[[#614](https://github.com/extendr/extendr/issues/614)]]
 
 ## 0.6.0
 

--- a/extendr-macros/src/extendr_impl.rs
+++ b/extendr-macros/src/extendr_impl.rs
@@ -5,35 +5,104 @@ use syn::{ItemFn, ItemImpl};
 
 use crate::wrappers;
 
-/// Handle trait implementations.
+/// Make inherent implementations available to R
+///
+/// The extendr_impl function is used to make inherent implementations
+/// avaialble to R as an environment. By adding the [`extendr`] attribute
+/// macro to an `impl` block (supported with `enum`s and `struct`s), the
+/// methods in the imple block are made available as functions in an
+/// environment.
+///
+/// On the R side, an environment with the same name of the inherent
+/// implementation is created. The environment has functions within it
+/// that correspond to each method in the impl block. Note that in order
+/// for an impl block to be compatible with extendr (and thus R), its return
+/// type must be able to be returned to R. For example, any struct that might
+/// be returned must _also_ have an `#[extendr]` annotated impl block.
 ///
 /// Example:
-/// ```ignore
+/// ```
 /// use extendr_api::prelude::*;
-/// #[derive(Debug)]
+///
+/// // a struct that will be used internal the People struct
+/// #[derive(Clone, Debug, IntoDataFrameRow)]
 /// struct Person {
-///     pub name: String,
+///     name: String,
+///     age: i32,
 /// }
+///
+/// // This will collect people in the struct
 /// #[extendr]
-/// impl Person {
+/// #[derive(Clone, Debug)]
+/// struct People(Vec<Person>);
+///
+/// #[extendr]
+/// /// @export
+/// impl People {
+///
+///     // instantiate a new struct with an empty vector
 ///     fn new() -> Self {
-///         Self { name: "".to_string() }
+///         let vec: Vec<Person> = Vec::new();
+///         Self(vec)
 ///     }
-///     fn set_name(&mut self, name: &str) {
-///         self.name = name.to_string();
+///
+///     // add a person to the internal vector
+///     fn add_person(&mut self, name: &str, age: i32) -> &mut Self {
+///         let person = Person {
+///             name: String::from(name),
+///             age: age,
+///         };
+///
+///         self.0.push(person);
+///
+///         // return self
+///         self
 ///     }
-///     fn name(&self) -> &str {
-///         self.name.as_str()
+///     
+///     // Convert the struct into a data.frame
+///     fn into_df(&self) -> Robj {
+///         let df = self.0.clone().into_dataframe();
+///
+///         match df {
+///             Ok(df) => df.as_robj().clone(),
+///             Err(_) => data_frame!(),
+///         }
 ///     }
+///
+///     // add another `People` struct to self
+///     fn add_people(&mut self, others: &People) -> &mut Self {
+///         self.0.extend(others.0.clone().into_iter());
+///         self
+///     }
+///
+///     // create a function to print the self which can be called
+///     // from an R print method
+///     fn print_self(&self) -> String {
+///         format!("{:?}", self.0)
+///     }
+///
 /// }
-/// #[extendr]
-/// fn aux_func() {
-/// }
-/// // Macro to generate exports
+///
+/// // Macro to generate exports.
+/// // This ensures exported functions are registered with R.
+/// // See corresponding C code in `entrypoint.c`.
 /// extendr_module! {
-///     mod classes;
-///     impl Person;
-///     fn aux_func;
+///     mod testself;
+///     impl People;
+/// }
+/// ```
+///     
+/// **Known limitation**: if you return `&self` or `&mut Self` or a reference
+/// to the same type, the resultant R object will _always_ be the original
+/// self. For example the below method **will not** return `other`.
+///
+/// ```ignore
+///  // This is not possible today
+/// #[extendr]
+/// impl People {
+///   fn return_other(&self, other: &'static T) -> &Self {
+///     other
+///   }
 /// }
 /// ```
 pub fn extendr_impl(mut item_impl: ItemImpl) -> syn::Result<TokenStream> {

--- a/extendr-macros/src/extendr_impl.rs
+++ b/extendr-macros/src/extendr_impl.rs
@@ -10,7 +10,7 @@ use crate::wrappers;
 /// The extendr_impl function is used to make inherent implementations
 /// avaialble to R as an environment. By adding the [`extendr`] attribute
 /// macro to an `impl` block (supported with `enum`s and `struct`s), the
-/// methods in the imple block are made available as functions in an
+/// methods in the impl block are made available as functions in an
 /// environment.
 ///
 /// On the R side, an environment with the same name of the inherent
@@ -92,7 +92,7 @@ use crate::wrappers;
 /// }
 /// ```
 ///     
-/// **Known limitation**: if you return `&self` or `&mut Self` or a reference
+/// **Known limitation**: if you return `&Self` or `&mut Self` or a reference
 /// to the same type, the resultant R object will _always_ be the original
 /// self. For example the below method **will not** return `other`.
 ///

--- a/extendr-macros/src/extendr_impl.rs
+++ b/extendr-macros/src/extendr_impl.rs
@@ -21,7 +21,7 @@ use crate::wrappers;
 /// be returned must _also_ have an `#[extendr]` annotated impl block.
 ///
 /// Example:
-/// ```
+/// ```ignore
 /// use extendr_api::prelude::*;
 ///
 /// // a struct that will be used internal the People struct

--- a/extendr-macros/src/wrappers.rs
+++ b/extendr-macros/src/wrappers.rs
@@ -1,3 +1,28 @@
+//! This is responsible for generating the C functions that act as wrappers of
+//! the exported Rust functions.
+//!
+//! extendr relies on the [`.Call`-interface](https://cran.r-project.org/doc/manuals/R-exts.html#Calling-_002eCall)
+//! In short, it is necessary the the signature of the C-function have [`SEXP`]
+//! as the type for return type, and argument types.
+//!
+//! For instance, if your function returns nothing, the return type is not
+//! allowed to be `void`, instead `SEXP` must be used, and one should return
+//! [`R_NilValue`].
+//!
+//! ## R wrappers
+//!
+//! Within R, you may call `rextendr::document()` to generate R functions,
+//! that use the `.Call`-interface, to call the wrapped Rust functions.
+//!
+//! You may also manually implement these wrappers, in order to do special
+//! type-checking, or other annotation, that could be more convenient to do
+//! on the R-side. The C-functions are named according to `"{WRAP_PREFIX}{prefix}{mod_name}"`.
+//! See [`WRAP_PREFIX`], and note that `prefix` is set specifically for methods in
+//! `extendr`-impl blocks, while for functions have no prefix.
+//!
+//! [`R_NilValue`]: ::libR_sys::R_NilValue
+//! [`SEXP`]: ::libR_sys::SEXP
+
 use proc_macro2::Ident;
 use quote::{format_ident, quote};
 use syn::{parse_quote, punctuated::Punctuated, Expr, ExprLit, FnArg, ItemFn, Token, Type};
@@ -50,7 +75,7 @@ pub fn make_function_wrappers(
 
     let call_name = if has_self {
         let is_mut = match inputs.iter().next() {
-            Some(FnArg::Receiver(ref reciever)) => reciever.mutability.is_some(),
+            Some(FnArg::Receiver(ref receiver)) => receiver.mutability.is_some(),
             _ => false,
         };
         if is_mut {
@@ -120,6 +145,43 @@ pub fn make_function_wrappers(
             });)
         })
         .unwrap_or_default();
+
+    // figure out if &Self / &mut Self / inside of impl block &ImplType / &mut ImplType is used!
+    let return_is_ref_self = {
+        match sig.output {
+            syn::ReturnType::Default => false,
+            syn::ReturnType::Type(_, ref return_type) => match return_type.as_ref() {
+                // matches `-> Self`
+                // Type::Path(type_path) => type_path.path.is_ident("Self"),
+                // matches `-> &Self` / `-> &mut Self`
+                Type::Reference(ref reference_type) => {
+                    if let Type::Path(path) = reference_type.elem.as_ref() {
+                        path.path.is_ident("Self")
+                            || self_ty
+                                .map(|x| x == reference_type.elem.as_ref())
+                                .unwrap_or(false)
+                    } else {
+                        false
+                    }
+                }
+                _ => false,
+            },
+        }
+    };
+
+    let return_type_conversion = if !return_is_ref_self {
+        quote!(Ok(extendr_api::Robj::from(#call_name(#actual_args))))
+    } else {
+        // instead of converting &Self / &mut Self, pass on the passed
+        // ExternalPtr<Self>
+        quote!(
+            let _return_ref_to_self = #call_name(#actual_args);
+            //FIXME: find a less hardcoded way to write `_self_robj`
+            Ok(_self_robj)
+        )
+    };
+
+    // TODO: the unsafe in here is unnecessary
     wrappers.push(parse_quote!(
         #[no_mangle]
         #[allow(non_snake_case, clippy::not_unsafe_ptr_arg_deref)]
@@ -135,7 +197,7 @@ pub fn make_function_wrappers(
             > = unsafe {
                 #( #convert_args )*
                 std::panic::catch_unwind(||-> std::result::Result<Robj, extendr_api::Error> {
-                    Ok(extendr_api::Robj::from(#call_name(#actual_args)))
+                    #return_type_conversion
                 })
             };
 
@@ -147,7 +209,7 @@ pub fn make_function_wrappers(
                 Ok(Ok(zz)) => {
                     return unsafe { zz.get() };
                 }
-                // any conversion error bubbled from #actual_args conversions of incomming args from R.
+                // any conversion error bubbled from #actual_args conversions of incoming args from R.
                 Ok(Err(conversion_err)) => {
                     let err_string = conversion_err.to_string();
                     drop(conversion_err); // try_from=true errors contain Robj, this must be dropped to not leak
@@ -241,7 +303,7 @@ pub fn mangled_type_name(type_: &Type) -> String {
     res
 }
 
-// Return a simplified type name that will be meaningful to R. Defaults to a digest.
+/// Return a simplified type name that will be meaningful to R. Defaults to a digest.
 // For example:
 // & Fred -> Fred
 // * Fred -> Fred
@@ -277,9 +339,9 @@ pub fn translate_formal(input: &FnArg, self_ty: Option<&syn::Type>) -> syn::Resu
             let pat = &pattype.pat.as_ref();
             Ok(parse_quote! { #pat : extendr_api::SEXP })
         }
-        // &self
-        FnArg::Receiver(ref reciever) => {
-            if !reciever.attrs.is_empty() || reciever.reference.is_none() {
+        // &self / &mut self
+        FnArg::Receiver(ref receiver) => {
+            if !receiver.attrs.is_empty() || receiver.reference.is_none() {
                 return Err(syn::Error::new_spanned(
                     input,
                     "expected &self or &mut self",
@@ -318,8 +380,8 @@ fn translate_meta_arg(input: &mut FnArg, self_ty: Option<&syn::Type>) -> syn::Re
             })
         }
         // &self
-        FnArg::Receiver(ref reciever) => {
-            if !reciever.attrs.is_empty() || reciever.reference.is_none() {
+        FnArg::Receiver(ref receiver) => {
+            if !receiver.attrs.is_empty() || receiver.reference.is_none() {
                 return Err(syn::Error::new_spanned(
                     input,
                     "expected &self or &mut self",
@@ -346,6 +408,8 @@ fn translate_meta_arg(input: &mut FnArg, self_ty: Option<&syn::Type>) -> syn::Re
 
 /// Convert `SEXP` arguments into `Robj`.
 /// This maintains the lifetime of references.
+///
+/// These conversions are from R into Rust
 fn translate_to_robj(input: &FnArg) -> syn::Result<syn::Stmt> {
     match input {
         FnArg::Typed(ref pattype) => {

--- a/extendr-macros/src/wrappers.rs
+++ b/extendr-macros/src/wrappers.rs
@@ -150,11 +150,11 @@ pub fn make_function_wrappers(
     let return_is_ref_self = {
         match sig.output {
             syn::ReturnType::Default => false,
+             // matches `-> Self`
             syn::ReturnType::Type(_, ref return_type) => match return_type.as_ref() {
-                // matches `-> Self`
-                // Type::Path(type_path) => type_path.path.is_ident("Self"),
-                // matches `-> &Self` / `-> &mut Self`
                 Type::Reference(ref reference_type) => {
+                    // Type::Path(type_path) => type_path.path.is_ident("Self"),
+                    // matches `-> &Self` / `-> &mut Self`
                     if let Type::Path(path) = reference_type.elem.as_ref() {
                         path.path.is_ident("Self")
                             || self_ty

--- a/extendr-macros/src/wrappers.rs
+++ b/extendr-macros/src/wrappers.rs
@@ -169,16 +169,16 @@ pub fn make_function_wrappers(
         }
     };
 
-    let return_type_conversion = if !return_is_ref_self {
-        quote!(Ok(extendr_api::Robj::from(#call_name(#actual_args))))
-    } else {
-        // instead of converting &Self / &mut Self, pass on the passed
+    let return_type_conversion = if return_is_ref_self {
+         // instead of converting &Self / &mut Self, pass on the passed
         // ExternalPtr<Self>
         quote!(
             let _return_ref_to_self = #call_name(#actual_args);
             //FIXME: find a less hardcoded way to write `_self_robj`
             Ok(_self_robj)
         )
+    } else {
+      quote!(Ok(extendr_api::Robj::from(#call_name(#actual_args))))
     };
 
     // TODO: the unsafe in here is unnecessary

--- a/extendr-macros/tests/extendr_impl/extendr_impl_fail.rs
+++ b/extendr-macros/tests/extendr_impl/extendr_impl_fail.rs
@@ -1,0 +1,40 @@
+#![allow(unused_imports)]
+
+#[allow(unused_imports)]
+use extendr_api::prelude::*;
+
+struct Foo;
+
+#[extendr]
+impl Foo {
+    fn take_ownership(self) {}
+}
+
+struct Foo2;
+
+#[extendr]
+impl Foo2 {
+    fn take_ownership(self: Self) {}
+}
+
+struct Foo3;
+
+#[extendr]
+impl Foo3 {
+    fn take_ownership(self: Foo3) {}
+}
+struct Foo4;
+
+#[extendr]
+impl Foo4 {
+    fn return_ownership(self) -> Self {}
+}
+
+struct Foo5;
+
+#[extendr]
+impl Foo5 {
+    fn take_ownership(self: Self) -> Foo5 {}
+}
+
+fn main() {}

--- a/extendr-macros/tests/extendr_impl/extendr_impl_fail.stderr
+++ b/extendr-macros/tests/extendr_impl/extendr_impl_fail.stderr
@@ -1,0 +1,29 @@
+error: expected &self or &mut self
+  --> tests/extendr_impl/extendr_impl_fail.rs:10:23
+   |
+10 |     fn take_ownership(self) {}
+   |                       ^^^^
+
+error: expected &self or &mut self
+  --> tests/extendr_impl/extendr_impl_fail.rs:17:23
+   |
+17 |     fn take_ownership(self: Self) {}
+   |                       ^^^^^^^^^^
+
+error: expected &self or &mut self
+  --> tests/extendr_impl/extendr_impl_fail.rs:24:23
+   |
+24 |     fn take_ownership(self: Foo3) {}
+   |                       ^^^^^^^^^^
+
+error: expected &self or &mut self
+  --> tests/extendr_impl/extendr_impl_fail.rs:30:25
+   |
+30 |     fn return_ownership(self) -> Self {}
+   |                         ^^^^
+
+error: expected &self or &mut self
+  --> tests/extendr_impl/extendr_impl_fail.rs:37:23
+   |
+37 |     fn take_ownership(self: Self) -> Foo5 {}
+   |                       ^^^^^^^^^^

--- a/extendr-macros/tests/trybuild.rs
+++ b/extendr-macros/tests/trybuild.rs
@@ -2,4 +2,5 @@
 fn test_macro_failures() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/cases/*.rs");
+    t.compile_fail("tests/extendr_impl/extendr_impl_fail.rs");
 }

--- a/tests/extendrtests/R/extendr-wrappers.R
+++ b/tests/extendrtests/R/extendr-wrappers.R
@@ -196,7 +196,15 @@ MySubmoduleClass$set_a <- function(x) invisible(.Call(wrap__MySubmoduleClass__se
 
 MySubmoduleClass$a <- function() .Call(wrap__MySubmoduleClass__a, self)
 
-MySubmoduleClass$me <- function() .Call(wrap__MySubmoduleClass__me, self)
+MySubmoduleClass$me_owned <- function() .Call(wrap__MySubmoduleClass__me_owned, self)
+
+MySubmoduleClass$me_ref <- function() .Call(wrap__MySubmoduleClass__me_ref, self)
+
+MySubmoduleClass$me_mut <- function() .Call(wrap__MySubmoduleClass__me_mut, self)
+
+MySubmoduleClass$me_explicit_ref <- function() .Call(wrap__MySubmoduleClass__me_explicit_ref, self)
+
+MySubmoduleClass$me_explicit_mut <- function() .Call(wrap__MySubmoduleClass__me_explicit_mut, self)
 
 #' @rdname MySubmoduleClass
 #' @usage NULL

--- a/tests/extendrtests/man/MySubmoduleClass.Rd
+++ b/tests/extendrtests/man/MySubmoduleClass.Rd
@@ -6,7 +6,7 @@
 \alias{$.MySubmoduleClass}
 \title{Class for testing (exported)}
 \format{
-An object of class \code{environment} of length 4.
+An object of class \code{environment} of length 8.
 }
 \usage{
 MySubmoduleClass

--- a/tests/extendrtests/src/rust/src/submodule.rs
+++ b/tests/extendrtests/src/rust/src/submodule.rs
@@ -8,7 +8,7 @@ fn hello_submodule() -> &'static str {
 }
 
 // Class for testing
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone, Copy)]
 struct MySubmoduleClass {
     a: i32,
 }
@@ -26,24 +26,50 @@ impl MySubmoduleClass {
     fn new() -> Self {
         Self { a: 0 }
     }
-    
+
     /// Method for setting stuff.
     /// @param x a number
-    fn set_a(& mut self, x: i32) {
+    fn set_a(&mut self, x: i32) {
         self.a = x;
     }
-    
+
     /// Method for getting stuff.
     fn a(&self) -> i32 {
         self.a
     }
-    
-    /// Method for getting one's self.
-    fn me(&self) -> &Self {
+
+    // NOTE: Cannot move ownership, as that concept is incompatible with bridging
+    // data from R to Rust
+    // fn myself(self) -> Self {
+    //     self
+    // }
+
+    /// Method for getting one's (by way of a copy) self.
+    fn me_owned(&self) -> Self {
+        // only possible due to `derive(Clone, Copy)`
+        *self
+    }
+
+    /// Method for getting one's (ref) self.
+    fn me_ref(&self) -> &Self {
+        self
+    }
+
+    /// Method for getting one's (ref mut) self.
+    fn me_mut(&mut self) -> &mut Self {
+        self
+    }
+
+    /// Method for getting one's ref (explicit) self.
+    fn me_explicit_ref(&self) -> &MySubmoduleClass {
+        self
+    }
+
+    /// Method for getting one's ref mut (explicit) self.
+    fn me_explicit_mut(&mut self) -> &mut MySubmoduleClass {
         self
     }
 }
-
 
 // Macro to generate exports
 extendr_module! {

--- a/tests/extendrtests/tests/testthat/_snaps/macro-snapshot.md
+++ b/tests/extendrtests/tests/testthat/_snaps/macro-snapshot.md
@@ -107,6 +107,16 @@
                   )
               }
           }
+          #[automatically_derived]
+          impl ::core::clone::Clone for MySubmoduleClass {
+              #[inline]
+              fn clone(&self) -> MySubmoduleClass {
+                  let _: ::core::clone::AssertParamIsClone<i32>;
+                  *self
+              }
+          }
+          #[automatically_derived]
+          impl ::core::marker::Copy for MySubmoduleClass {}
           /// Class for testing (exported)
           /// @examples
           /// x <- MySubmoduleClass$new()
@@ -128,8 +138,24 @@
               fn a(&self) -> i32 {
                   self.a
               }
-              /// Method for getting one's self.
-              fn me(&self) -> &Self {
+              /// Method for getting one's (by way of a copy) self.
+              fn me_owned(&self) -> Self {
+                  *self
+              }
+              /// Method for getting one's (ref) self.
+              fn me_ref(&self) -> &Self {
+                  self
+              }
+              /// Method for getting one's (ref mut) self.
+              fn me_mut(&mut self) -> &mut Self {
+                  self
+              }
+              /// Method for getting one's ref (explicit) self.
+              fn me_explicit_ref(&self) -> &MySubmoduleClass {
+                  self
+              }
+              /// Method for getting one's ref mut (explicit) self.
+              fn me_explicit_mut(&mut self) -> &mut MySubmoduleClass {
                   self
               }
           }
@@ -381,7 +407,7 @@
           }
           #[no_mangle]
           #[allow(non_snake_case, clippy::not_unsafe_ptr_arg_deref)]
-          pub extern "C" fn wrap__MySubmoduleClass__me(
+          pub extern "C" fn wrap__MySubmoduleClass__me_owned(
               _self: extendr_api::SEXP,
           ) -> extendr_api::SEXP {
               use extendr_api::robj::*;
@@ -396,7 +422,7 @@
                               extendr_api::unwrap_or_throw(
                                       <&MySubmoduleClass>::from_robj(&_self_robj),
                                   )
-                                  .me(),
+                                  .me_owned(),
                           ),
                       )
                   })
@@ -414,7 +440,7 @@
                       drop(unwind_err);
                       let err_string = {
                           let res = ::alloc::fmt::format(
-                              format_args!("user function panicked: {0}", "me"),
+                              format_args!("user function panicked: {0}", "me_owned"),
                           );
                           res
                       };
@@ -442,7 +468,9 @@
               }
           }
           #[allow(non_snake_case)]
-          fn meta__MySubmoduleClass__me(metadata: &mut Vec<extendr_api::metadata::Func>) {
+          fn meta__MySubmoduleClass__me_owned(
+              metadata: &mut Vec<extendr_api::metadata::Func>,
+          ) {
               let mut args = <[_]>::into_vec(
                   #[rustc_box]
                   ::alloc::boxed::Box::new([
@@ -455,13 +483,349 @@
               );
               metadata
                   .push(extendr_api::metadata::Func {
-                      doc: " Method for getting one's self.",
-                      rust_name: "me",
-                      r_name: "me",
-                      mod_name: "me",
+                      doc: " Method for getting one's (by way of a copy) self.",
+                      rust_name: "me_owned",
+                      r_name: "me_owned",
+                      mod_name: "me_owned",
                       args: args,
                       return_type: "Self",
-                      func_ptr: wrap__MySubmoduleClass__me as *const u8,
+                      func_ptr: wrap__MySubmoduleClass__me_owned as *const u8,
+                      hidden: false,
+                  })
+          }
+          #[no_mangle]
+          #[allow(non_snake_case, clippy::not_unsafe_ptr_arg_deref)]
+          pub extern "C" fn wrap__MySubmoduleClass__me_ref(
+              _self: extendr_api::SEXP,
+          ) -> extendr_api::SEXP {
+              use extendr_api::robj::*;
+              let wrap_result_state: std::result::Result<
+                  std::result::Result<Robj, extendr_api::Error>,
+                  Box<dyn std::any::Any + Send>,
+              > = unsafe {
+                  let mut _self_robj = extendr_api::robj::Robj::from_sexp(_self);
+                  std::panic::catch_unwind(|| -> std::result::Result<Robj, extendr_api::Error> {
+                      let _return_ref_to_self = extendr_api::unwrap_or_throw(
+                              <&MySubmoduleClass>::from_robj(&_self_robj),
+                          )
+                          .me_ref();
+                      Ok(_self_robj)
+                  })
+              };
+              match wrap_result_state {
+                  Ok(Ok(zz)) => {
+                      return unsafe { zz.get() };
+                  }
+                  Ok(Err(conversion_err)) => {
+                      let err_string = conversion_err.to_string();
+                      drop(conversion_err);
+                      extendr_api::throw_r_error(&err_string);
+                  }
+                  Err(unwind_err) => {
+                      drop(unwind_err);
+                      let err_string = {
+                          let res = ::alloc::fmt::format(
+                              format_args!("user function panicked: {0}", "me_ref"),
+                          );
+                          res
+                      };
+                      extendr_api::handle_panic(
+                          err_string.as_str(),
+                          || {
+                              #[cold]
+                              #[track_caller]
+                              #[inline(never)]
+                              const fn panic_cold_explicit() -> ! {
+                                  ::core::panicking::panic_explicit()
+                              }
+                              panic_cold_explicit();
+                          },
+                      );
+                  }
+              }
+              {
+                  ::core::panicking::panic_fmt(
+                      format_args!(
+                          "internal error: entered unreachable code: {0}",
+                          format_args!("internal extendr error, this should never happen."),
+                      ),
+                  );
+              }
+          }
+          #[allow(non_snake_case)]
+          fn meta__MySubmoduleClass__me_ref(metadata: &mut Vec<extendr_api::metadata::Func>) {
+              let mut args = <[_]>::into_vec(
+                  #[rustc_box]
+                  ::alloc::boxed::Box::new([
+                      extendr_api::metadata::Arg {
+                          name: "self",
+                          arg_type: "MySubmoduleClass",
+                          default: None,
+                      },
+                  ]),
+              );
+              metadata
+                  .push(extendr_api::metadata::Func {
+                      doc: " Method for getting one's (ref) self.",
+                      rust_name: "me_ref",
+                      r_name: "me_ref",
+                      mod_name: "me_ref",
+                      args: args,
+                      return_type: "Self",
+                      func_ptr: wrap__MySubmoduleClass__me_ref as *const u8,
+                      hidden: false,
+                  })
+          }
+          #[no_mangle]
+          #[allow(non_snake_case, clippy::not_unsafe_ptr_arg_deref)]
+          pub extern "C" fn wrap__MySubmoduleClass__me_mut(
+              _self: extendr_api::SEXP,
+          ) -> extendr_api::SEXP {
+              use extendr_api::robj::*;
+              let wrap_result_state: std::result::Result<
+                  std::result::Result<Robj, extendr_api::Error>,
+                  Box<dyn std::any::Any + Send>,
+              > = unsafe {
+                  let mut _self_robj = extendr_api::robj::Robj::from_sexp(_self);
+                  std::panic::catch_unwind(|| -> std::result::Result<Robj, extendr_api::Error> {
+                      let _return_ref_to_self = extendr_api::unwrap_or_throw(
+                              <&mut MySubmoduleClass>::from_robj(&_self_robj),
+                          )
+                          .me_mut();
+                      Ok(_self_robj)
+                  })
+              };
+              match wrap_result_state {
+                  Ok(Ok(zz)) => {
+                      return unsafe { zz.get() };
+                  }
+                  Ok(Err(conversion_err)) => {
+                      let err_string = conversion_err.to_string();
+                      drop(conversion_err);
+                      extendr_api::throw_r_error(&err_string);
+                  }
+                  Err(unwind_err) => {
+                      drop(unwind_err);
+                      let err_string = {
+                          let res = ::alloc::fmt::format(
+                              format_args!("user function panicked: {0}", "me_mut"),
+                          );
+                          res
+                      };
+                      extendr_api::handle_panic(
+                          err_string.as_str(),
+                          || {
+                              #[cold]
+                              #[track_caller]
+                              #[inline(never)]
+                              const fn panic_cold_explicit() -> ! {
+                                  ::core::panicking::panic_explicit()
+                              }
+                              panic_cold_explicit();
+                          },
+                      );
+                  }
+              }
+              {
+                  ::core::panicking::panic_fmt(
+                      format_args!(
+                          "internal error: entered unreachable code: {0}",
+                          format_args!("internal extendr error, this should never happen."),
+                      ),
+                  );
+              }
+          }
+          #[allow(non_snake_case)]
+          fn meta__MySubmoduleClass__me_mut(metadata: &mut Vec<extendr_api::metadata::Func>) {
+              let mut args = <[_]>::into_vec(
+                  #[rustc_box]
+                  ::alloc::boxed::Box::new([
+                      extendr_api::metadata::Arg {
+                          name: "self",
+                          arg_type: "MySubmoduleClass",
+                          default: None,
+                      },
+                  ]),
+              );
+              metadata
+                  .push(extendr_api::metadata::Func {
+                      doc: " Method for getting one's (ref mut) self.",
+                      rust_name: "me_mut",
+                      r_name: "me_mut",
+                      mod_name: "me_mut",
+                      args: args,
+                      return_type: "Self",
+                      func_ptr: wrap__MySubmoduleClass__me_mut as *const u8,
+                      hidden: false,
+                  })
+          }
+          #[no_mangle]
+          #[allow(non_snake_case, clippy::not_unsafe_ptr_arg_deref)]
+          pub extern "C" fn wrap__MySubmoduleClass__me_explicit_ref(
+              _self: extendr_api::SEXP,
+          ) -> extendr_api::SEXP {
+              use extendr_api::robj::*;
+              let wrap_result_state: std::result::Result<
+                  std::result::Result<Robj, extendr_api::Error>,
+                  Box<dyn std::any::Any + Send>,
+              > = unsafe {
+                  let mut _self_robj = extendr_api::robj::Robj::from_sexp(_self);
+                  std::panic::catch_unwind(|| -> std::result::Result<Robj, extendr_api::Error> {
+                      let _return_ref_to_self = extendr_api::unwrap_or_throw(
+                              <&MySubmoduleClass>::from_robj(&_self_robj),
+                          )
+                          .me_explicit_ref();
+                      Ok(_self_robj)
+                  })
+              };
+              match wrap_result_state {
+                  Ok(Ok(zz)) => {
+                      return unsafe { zz.get() };
+                  }
+                  Ok(Err(conversion_err)) => {
+                      let err_string = conversion_err.to_string();
+                      drop(conversion_err);
+                      extendr_api::throw_r_error(&err_string);
+                  }
+                  Err(unwind_err) => {
+                      drop(unwind_err);
+                      let err_string = {
+                          let res = ::alloc::fmt::format(
+                              format_args!("user function panicked: {0}", "me_explicit_ref"),
+                          );
+                          res
+                      };
+                      extendr_api::handle_panic(
+                          err_string.as_str(),
+                          || {
+                              #[cold]
+                              #[track_caller]
+                              #[inline(never)]
+                              const fn panic_cold_explicit() -> ! {
+                                  ::core::panicking::panic_explicit()
+                              }
+                              panic_cold_explicit();
+                          },
+                      );
+                  }
+              }
+              {
+                  ::core::panicking::panic_fmt(
+                      format_args!(
+                          "internal error: entered unreachable code: {0}",
+                          format_args!("internal extendr error, this should never happen."),
+                      ),
+                  );
+              }
+          }
+          #[allow(non_snake_case)]
+          fn meta__MySubmoduleClass__me_explicit_ref(
+              metadata: &mut Vec<extendr_api::metadata::Func>,
+          ) {
+              let mut args = <[_]>::into_vec(
+                  #[rustc_box]
+                  ::alloc::boxed::Box::new([
+                      extendr_api::metadata::Arg {
+                          name: "self",
+                          arg_type: "MySubmoduleClass",
+                          default: None,
+                      },
+                  ]),
+              );
+              metadata
+                  .push(extendr_api::metadata::Func {
+                      doc: " Method for getting one's ref (explicit) self.",
+                      rust_name: "me_explicit_ref",
+                      r_name: "me_explicit_ref",
+                      mod_name: "me_explicit_ref",
+                      args: args,
+                      return_type: "MySubmoduleClass",
+                      func_ptr: wrap__MySubmoduleClass__me_explicit_ref as *const u8,
+                      hidden: false,
+                  })
+          }
+          #[no_mangle]
+          #[allow(non_snake_case, clippy::not_unsafe_ptr_arg_deref)]
+          pub extern "C" fn wrap__MySubmoduleClass__me_explicit_mut(
+              _self: extendr_api::SEXP,
+          ) -> extendr_api::SEXP {
+              use extendr_api::robj::*;
+              let wrap_result_state: std::result::Result<
+                  std::result::Result<Robj, extendr_api::Error>,
+                  Box<dyn std::any::Any + Send>,
+              > = unsafe {
+                  let mut _self_robj = extendr_api::robj::Robj::from_sexp(_self);
+                  std::panic::catch_unwind(|| -> std::result::Result<Robj, extendr_api::Error> {
+                      let _return_ref_to_self = extendr_api::unwrap_or_throw(
+                              <&mut MySubmoduleClass>::from_robj(&_self_robj),
+                          )
+                          .me_explicit_mut();
+                      Ok(_self_robj)
+                  })
+              };
+              match wrap_result_state {
+                  Ok(Ok(zz)) => {
+                      return unsafe { zz.get() };
+                  }
+                  Ok(Err(conversion_err)) => {
+                      let err_string = conversion_err.to_string();
+                      drop(conversion_err);
+                      extendr_api::throw_r_error(&err_string);
+                  }
+                  Err(unwind_err) => {
+                      drop(unwind_err);
+                      let err_string = {
+                          let res = ::alloc::fmt::format(
+                              format_args!("user function panicked: {0}", "me_explicit_mut"),
+                          );
+                          res
+                      };
+                      extendr_api::handle_panic(
+                          err_string.as_str(),
+                          || {
+                              #[cold]
+                              #[track_caller]
+                              #[inline(never)]
+                              const fn panic_cold_explicit() -> ! {
+                                  ::core::panicking::panic_explicit()
+                              }
+                              panic_cold_explicit();
+                          },
+                      );
+                  }
+              }
+              {
+                  ::core::panicking::panic_fmt(
+                      format_args!(
+                          "internal error: entered unreachable code: {0}",
+                          format_args!("internal extendr error, this should never happen."),
+                      ),
+                  );
+              }
+          }
+          #[allow(non_snake_case)]
+          fn meta__MySubmoduleClass__me_explicit_mut(
+              metadata: &mut Vec<extendr_api::metadata::Func>,
+          ) {
+              let mut args = <[_]>::into_vec(
+                  #[rustc_box]
+                  ::alloc::boxed::Box::new([
+                      extendr_api::metadata::Arg {
+                          name: "self",
+                          arg_type: "MySubmoduleClass",
+                          default: None,
+                      },
+                  ]),
+              );
+              metadata
+                  .push(extendr_api::metadata::Func {
+                      doc: " Method for getting one's ref mut (explicit) self.",
+                      rust_name: "me_explicit_mut",
+                      r_name: "me_explicit_mut",
+                      mod_name: "me_explicit_mut",
+                      args: args,
+                      return_type: "MySubmoduleClass",
+                      func_ptr: wrap__MySubmoduleClass__me_explicit_mut as *const u8,
                       hidden: false,
                   })
           }
@@ -526,7 +890,11 @@
               meta__MySubmoduleClass__new(&mut methods);
               meta__MySubmoduleClass__set_a(&mut methods);
               meta__MySubmoduleClass__a(&mut methods);
-              meta__MySubmoduleClass__me(&mut methods);
+              meta__MySubmoduleClass__me_owned(&mut methods);
+              meta__MySubmoduleClass__me_ref(&mut methods);
+              meta__MySubmoduleClass__me_mut(&mut methods);
+              meta__MySubmoduleClass__me_explicit_ref(&mut methods);
+              meta__MySubmoduleClass__me_explicit_mut(&mut methods);
               impls
                   .push(extendr_api::metadata::Impl {
                       doc: " Class for testing (exported)\n @examples\n x <- MySubmoduleClass$new()\n x$a()\n x$set_a(10)\n x$a()\n @export",
@@ -5144,11 +5512,11 @@
           > = unsafe {
               let mut _self_robj = extendr_api::robj::Robj::from_sexp(_self);
               std::panic::catch_unwind(|| -> std::result::Result<Robj, extendr_api::Error> {
-                  Ok(
-                      extendr_api::Robj::from(
-                          extendr_api::unwrap_or_throw(<&MyClass>::from_robj(&_self_robj)).me(),
-                      ),
-                  )
+                  let _return_ref_to_self = extendr_api::unwrap_or_throw(
+                          <&MyClass>::from_robj(&_self_robj),
+                      )
+                      .me();
+                  Ok(_self_robj)
               })
           };
           match wrap_result_state {

--- a/tests/extendrtests/tests/testthat/test-classes.R
+++ b/tests/extendrtests/tests/testthat/test-classes.R
@@ -11,7 +11,6 @@ test_that("Exported class works", {
 })
 
 test_that("Exported class self ptr works", {
-  skip("ExternalPtr issue https://github.com/extendr/extendr/issues/614")
   x <- MyClass$new()
   expect_equal(x$me(), x)
   expect_equal(x[["me"]](), x)

--- a/tests/extendrtests/tests/testthat/test-test-submodules.R
+++ b/tests/extendrtests/tests/testthat/test-test-submodules.R
@@ -4,6 +4,19 @@ test_that("Submodule functions can be called", {
 
 test_that("Classes defined in submodules also works", {
   x <- MySubmoduleClass$new()
+  x
+  # TODO: uncomment these pointer check tests when externalptr_address
+  # is implemented
+  # ptr <- \(xptr) Rcpp:::externalptr_address(xptr)
+  # xptr <- ptr(x)
   x$set_a(10)
   expect_equal(x$a(), 10)
+  
+  # expect_equal(ptr(x$me_ref()), xptr)
+  # expect_equal(ptr(x$me_mut()), xptr)
+  # expect_equal(ptr(x$me_explicit_ref()), xptr)
+  # expect_equal(ptr(x$me_explicit_mut()), xptr)
+  # 
+  # # this "copies"
+  # expect_true(ptr(x$me_owned()) != xptr)
 })

--- a/tests/extendrtests/tests/testthat/test-test-submodules.R
+++ b/tests/extendrtests/tests/testthat/test-test-submodules.R
@@ -11,6 +11,11 @@ test_that("Classes defined in submodules also works", {
   expect_equal(x$me_mut(), x)
   expect_equal(x$me_explicit_ref(), x)
   expect_equal(x$me_explicit_mut(), x)
+
+  expect_identical(x$me_ref(), x)
+  expect_identical(x$me_mut(), x)
+  expect_identical(x$me_explicit_ref(), x)
+  expect_identical(x$me_explicit_mut(), x)
   # this "copies"
   expect_false(
     isTRUE(identical(x$me_owned(), x))

--- a/tests/extendrtests/tests/testthat/test-test-submodules.R
+++ b/tests/extendrtests/tests/testthat/test-test-submodules.R
@@ -4,19 +4,15 @@ test_that("Submodule functions can be called", {
 
 test_that("Classes defined in submodules also works", {
   x <- MySubmoduleClass$new()
-  x
-  # TODO: uncomment these pointer check tests when externalptr_address
-  # is implemented
-  # ptr <- \(xptr) Rcpp:::externalptr_address(xptr)
-  # xptr <- ptr(x)
   x$set_a(10)
   expect_equal(x$a(), 10)
-  
-  # expect_equal(ptr(x$me_ref()), xptr)
-  # expect_equal(ptr(x$me_mut()), xptr)
-  # expect_equal(ptr(x$me_explicit_ref()), xptr)
-  # expect_equal(ptr(x$me_explicit_mut()), xptr)
-  # 
-  # # this "copies"
-  # expect_true(ptr(x$me_owned()) != xptr)
+
+  expect_equal(x$me_ref(), x)
+  expect_equal(x$me_mut(), x)
+  expect_equal(x$me_explicit_ref(), x)
+  expect_equal(x$me_explicit_mut(), x)
+  # this "copies"
+  expect_false(
+    isTRUE(identical(x$me_owned(), x))
+  )
 })


### PR DESCRIPTION
Fixes #614 

This allows `extendr-impl` types to return `&Self` / `&mut Self`.
The logic is, that the `Robj` that was provided to the wrapper, is itself a reference-type,
that should be returned to R, instead of recreating the ExternalPtr.

For R users, this unlocks defining pipe-friendly interfaces using `extendr-impl`.

@sorhawell I believe this was a blocker for you, and making a pipe-friendly polars interface, right?
