### PR TITLE
Replace buggy number conversions with tryfrom

### DIFF
--- a/extendr-api/src/io/load.rs
+++ b/extendr-api/src/io/load.rs
@@ -41,7 +41,8 @@ pub trait Load {
             arg3: ::std::os::raw::c_int,
         ) {
             let reader = &mut *((*arg1).data as *mut R);
-            let buf = std::slice::from_raw_parts_mut(arg2 as *mut u8, arg3 as usize);
+            let buf =
+                std::slice::from_raw_parts_mut(arg2 as *mut u8, usize::try_from(arg3).unwrap());
             reader.read_exact(buf).unwrap();
         }
 

--- a/extendr-api/src/io/save.rs
+++ b/extendr-api/src/io/save.rs
@@ -26,7 +26,7 @@ impl<W: Write> OutStream<W> {
     ) -> Box<OutStream<W>> {
         unsafe extern "C" fn outchar<W: Write>(arg1: R_outpstream_t, arg2: ::std::os::raw::c_int) {
             let writer = &mut *((*arg1).data as *mut W);
-            let b = [arg2 as u8];
+            let b = [u8::try_from(arg2).unwrap()];
             writer.write_all(&b).unwrap();
         }
 
@@ -36,7 +36,7 @@ impl<W: Write> OutStream<W> {
             arg3: ::std::os::raw::c_int,
         ) {
             let writer = &mut *((*arg1).data as *mut W);
-            let b = std::slice::from_raw_parts(arg2 as *mut u8, arg3 as usize);
+            let b = std::slice::from_raw_parts(arg2 as *mut u8, usize::try_from(arg3).unwrap());
             writer.write_all(b).unwrap();
         }
 

--- a/extendr-api/src/iter.rs
+++ b/extendr-api/src/iter.rs
@@ -64,9 +64,10 @@ fn str_from_strsxp<'a>(sexp: SEXP, index: isize) -> &'a str {
             let charsxp = STRING_ELT(sexp, index);
             if charsxp == R_NaString {
                 <&str>::na()
-            } else if TYPEOF(charsxp) == CHARSXP as i32 {
+            } else if TYPEOF(charsxp) == i32::try_from(CHARSXP).unwrap() {
                 let ptr = R_CHAR(charsxp) as *const u8;
-                let slice = std::slice::from_raw_parts(ptr, Rf_xlength(charsxp) as usize);
+                let slice =
+                    std::slice::from_raw_parts(ptr, usize::try_from(Rf_xlength(charsxp)).unwrap());
                 std::str::from_utf8_unchecked(slice)
             } else {
                 <&str>::na()
@@ -87,14 +88,16 @@ impl Iterator for StrIter {
             let i = self.i;
             self.i += 1;
             let vector = self.vector.get();
+            let vector_u32: u32 = TYPEOF(vector).try_into().unwrap();
             if i >= self.len {
                 None
-            } else if TYPEOF(vector) as u32 == STRSXP {
-                Some(str_from_strsxp(vector, i as isize))
-            } else if TYPEOF(vector) as u32 == INTSXP && TYPEOF(self.levels) as u32 == STRSXP {
-                let j = *(INTEGER(vector).add(i));
-                Some(str_from_strsxp(self.levels, j as isize - 1))
-            } else if TYPEOF(vector) as u32 == NILSXP {
+            } else if vector_u32 == STRSXP {
+                Some(str_from_strsxp(vector, isize::try_from(i).unwrap()))
+            } else if vector_u32 == INTSXP && u32::try_from(TYPEOF(self.levels)).unwrap() == STRSXP
+            {
+                let j: isize = (*(INTEGER(vector).add(i))).try_into().unwrap();
+                Some(str_from_strsxp(self.levels, j - 1))
+            } else if vector_u32 == NILSXP {
                 Some(<&str>::na())
             } else {
                 None

--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -451,7 +451,7 @@ unsafe fn make_method_def(
     rmethods.push(libR_sys::R_CallMethodDef {
         name: cstrings.last().unwrap().as_ptr(),
         fun: Some(std::mem::transmute(func.func_ptr)),
-        numArgs: func.args.len() as i32,
+        numArgs: i32::try_from(func.args.len()).unwrap(),
     });
 }
 
@@ -558,7 +558,7 @@ pub enum Rany<'a> {
 /// Panics if the type is Unknown.
 pub fn rtype_to_sxp(rtype: Rtype) -> i32 {
     use Rtype::*;
-    (match rtype {
+    i32::try_from(match rtype {
         Null => NILSXP,
         Symbol => SYMSXP,
         Pairlist => LISTSXP,
@@ -584,13 +584,14 @@ pub fn rtype_to_sxp(rtype: Rtype) -> i32 {
         Raw => RAWSXP,
         S4 => S4SXP,
         Unknown => panic!("attempt to use Unknown Rtype"),
-    }) as i32
+    })
+    .unwrap()
 }
 
 /// Convert R's SEXPTYPE to extendr's Rtype.
 pub fn sxp_to_rtype(sxptype: i32) -> Rtype {
     use Rtype::*;
-    match sxptype as u32 {
+    match u32::try_from(sxptype).unwrap() {
         NILSXP => Null,
         SYMSXP => Symbol,
         LISTSXP => Pairlist,

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -12,7 +12,7 @@ pub(crate) fn str_to_character(s: &str) -> SEXP {
             single_threaded(|| {
                 Rf_mkCharLenCE(
                     s.as_ptr() as *const raw::c_char,
-                    s.len() as i32,
+                    i32::try_from(s.len()).unwrap(),
                     cetype_t_CE_UTF8,
                 )
             })
@@ -500,7 +500,7 @@ where
                 }
                 STRSXP => {
                     for (i, v) in iter.enumerate() {
-                        SET_STRING_ELT(sexp, i as isize, v.to_sexp());
+                        SET_STRING_ELT(sexp, isize::try_from(i).unwrap(), v.to_sexp());
                     }
                 }
                 RAWSXP => {

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -167,7 +167,7 @@ pub trait Slices: GetSexp {
     /// Unless the type is correct, this will cause undefined behaviour.
     /// Creating this slice will also instatiate and Altrep objects.
     unsafe fn as_typed_slice_raw<T>(&self) -> &[T] {
-        let len = XLENGTH(self.get()) as usize;
+        let len = usize::try_from(XLENGTH(self.get())).unwrap();
         let data = DATAPTR_RO(self.get()) as *const T;
         std::slice::from_raw_parts(data, len)
     }
@@ -180,7 +180,7 @@ pub trait Slices: GetSexp {
     /// Creating this slice will also instatiate and Altrep objects.
     /// Not all obejects (especially not list and strings) support this.
     unsafe fn as_typed_slice_raw_mut<T>(&mut self) -> &mut [T] {
-        let len = XLENGTH(self.get()) as usize;
+        let len = usize::try_from(XLENGTH(self.get())).unwrap();
         let data = DATAPTR(self.get_mut()) as *mut T;
         std::slice::from_raw_parts_mut(data, len)
     }
@@ -199,7 +199,7 @@ pub trait Length: GetSexp {
     /// }
     /// ```
     fn len(&self) -> usize {
-        unsafe { Rf_xlength(self.get()) as usize }
+        unsafe { usize::try_from(Rf_xlength(self.get())).unwrap() }
     }
 
     /// Returns `true` if the `Robj` contains no elements.
@@ -237,7 +237,7 @@ pub trait Types: GetSexp {
     #[doc(hidden)]
     /// Get the XXXSXP type of the object.
     fn sexptype(&self) -> u32 {
-        unsafe { TYPEOF(self.get()) as u32 }
+        unsafe { u32::try_from(TYPEOF(self.get())).unwrap() }
     }
 
     /// Get the type of an R object.
@@ -1083,7 +1083,7 @@ pub(crate) unsafe fn to_str<'a>(ptr: *const u8) -> &'a str {
         }
         len += 1;
     }
-    let slice = std::slice::from_raw_parts(ptr, len as usize);
+    let slice = std::slice::from_raw_parts(ptr, usize::try_from(len).unwrap());
     std::str::from_utf8_unchecked(slice)
 }
 

--- a/extendr-api/src/robj/rinternals.rs
+++ b/extendr-api/src/robj/rinternals.rs
@@ -231,12 +231,12 @@ pub trait Rinternals: Types + Conversions {
 
     /// Number of columns of a matrix
     fn ncols(&self) -> usize {
-        unsafe { Rf_ncols(self.get()) as usize }
+        unsafe { usize::try_from(Rf_ncols(self.get())).unwrap() }
     }
 
     /// Number of rows of a matrix
     fn nrows(&self) -> usize {
-        unsafe { Rf_nrows(self.get()) as usize }
+        unsafe { usize::try_from(Rf_nrows(self.get())).unwrap() }
     }
 
     /// Internal function used to implement `#[extendr]` impl
@@ -283,7 +283,10 @@ pub trait Rinternals: Types + Conversions {
         unsafe {
             if self.is_vector() {
                 Ok(single_threaded(|| {
-                    Robj::from_sexp(Rf_xlengthgets(self.get(), new_len as R_xlen_t))
+                    Robj::from_sexp(Rf_xlengthgets(
+                        self.get(),
+                        R_xlen_t::try_from(new_len).unwrap(),
+                    ))
                 }))
             } else {
                 Err(Error::ExpectedVector(self.as_robj().clone()))
@@ -293,7 +296,9 @@ pub trait Rinternals: Types + Conversions {
 
     /// Allocated an owned object of a certain type.
     fn alloc_vector(sexptype: u32, len: usize) -> Robj {
-        single_threaded(|| unsafe { Robj::from_sexp(Rf_allocVector(sexptype, len as R_xlen_t)) })
+        single_threaded(|| unsafe {
+            Robj::from_sexp(Rf_allocVector(sexptype, R_xlen_t::try_from(len).unwrap()))
+        })
     }
 
     /// Return true if two arrays have identical dims.
@@ -450,33 +455,33 @@ pub trait Rinternals: Types + Conversions {
 
     /// Returns `true` if this is an integer ALTREP object.
     fn is_altinteger(&self) -> bool {
-        unsafe { ALTREP(self.get()) != 0 && TYPEOF(self.get()) == INTSXP as i32 }
+        unsafe { ALTREP(self.get()) != 0 && TYPEOF(self.get()) == i32::try_from(INTSXP).unwrap() }
     }
 
     /// Returns `true` if this is an real ALTREP object.
     fn is_altreal(&self) -> bool {
-        unsafe { ALTREP(self.get()) != 0 && TYPEOF(self.get()) == REALSXP as i32 }
+        unsafe { ALTREP(self.get()) != 0 && TYPEOF(self.get()) == i32::try_from(REALSXP).unwrap() }
     }
 
     /// Returns `true` if this is an logical ALTREP object.
     fn is_altlogical(&self) -> bool {
-        unsafe { ALTREP(self.get()) != 0 && TYPEOF(self.get()) == LGLSXP as i32 }
+        unsafe { ALTREP(self.get()) != 0 && TYPEOF(self.get()) == i32::try_from(LGLSXP).unwrap() }
     }
 
     /// Returns `true` if this is a raw ALTREP object.
     fn is_altraw(&self) -> bool {
-        unsafe { ALTREP(self.get()) != 0 && TYPEOF(self.get()) == RAWSXP as i32 }
+        unsafe { ALTREP(self.get()) != 0 && TYPEOF(self.get()) == i32::try_from(RAWSXP).unwrap() }
     }
 
     /// Returns `true` if this is an integer ALTREP object.
     fn is_altstring(&self) -> bool {
-        unsafe { ALTREP(self.get()) != 0 && TYPEOF(self.get()) == STRSXP as i32 }
+        unsafe { ALTREP(self.get()) != 0 && TYPEOF(self.get()) == i32::try_from(STRSXP).unwrap() }
     }
 
     /// Returns `true` if this is an integer ALTREP object.
     #[cfg(use_r_altlist)]
     fn is_altlist(&self) -> bool {
-        unsafe { ALTREP(self.get()) != 0 && TYPEOF(self.get()) == VECSXP as i32 }
+        unsafe { ALTREP(self.get()) != 0 && TYPEOF(self.get()) == i32::try_from(VECSXP).unwrap() }
     }
 
     /// Generate a text representation of this object.

--- a/extendr-api/src/wrapper/complexes.rs
+++ b/extendr-api/src/wrapper/complexes.rs
@@ -32,7 +32,14 @@ impl Complexes {
     pub fn get_region(&self, index: usize, dest: &mut [Rcplx]) -> usize {
         unsafe {
             let ptr: *mut Rcomplex = dest.as_mut_ptr() as *mut Rcomplex;
-            COMPLEX_GET_REGION(self.get(), index as R_xlen_t, dest.len() as R_xlen_t, ptr) as usize
+            COMPLEX_GET_REGION(
+                self.get(),
+                R_xlen_t::try_from(index).unwrap(),
+                R_xlen_t::try_from(dest.len()).unwrap(),
+                ptr,
+            )
+            .try_into()
+            .unwrap()
         }
     }
 }

--- a/extendr-api/src/wrapper/doubles.rs
+++ b/extendr-api/src/wrapper/doubles.rs
@@ -35,7 +35,14 @@ impl Doubles {
     pub fn get_region(&self, index: usize, dest: &mut [Rfloat]) -> usize {
         unsafe {
             let ptr: *mut f64 = dest.as_mut_ptr() as *mut f64;
-            REAL_GET_REGION(self.get(), index as R_xlen_t, dest.len() as R_xlen_t, ptr) as usize
+            REAL_GET_REGION(
+                self.get(),
+                R_xlen_t::try_from(index).unwrap(),
+                R_xlen_t::try_from(dest.len()).unwrap(),
+                ptr,
+            )
+            .try_into()
+            .unwrap()
         }
     }
 
@@ -54,7 +61,11 @@ impl Doubles {
 impl Doubles {
     pub fn set_elt(&mut self, index: usize, val: Rfloat) {
         single_threaded(|| unsafe {
-            SET_REAL_ELT(self.get_mut(), index as R_xlen_t, val.inner());
+            SET_REAL_ELT(
+                self.get_mut(),
+                R_xlen_t::try_from(index).unwrap(),
+                val.inner(),
+            );
         })
     }
 }

--- a/extendr-api/src/wrapper/environment.rs
+++ b/extendr-api/src/wrapper/environment.rs
@@ -38,7 +38,7 @@ impl Environment {
             new_env(parent, false, 0)
         } else {
             // Hashed environment for larger hashmaps.
-            new_env(parent, true, capacity as i32 * 2 + 1)
+            new_env(parent, true, i32::try_from(capacity).unwrap() * 2 + 1)
         }
     }
 

--- a/extendr-api/src/wrapper/integers.rs
+++ b/extendr-api/src/wrapper/integers.rs
@@ -35,7 +35,14 @@ impl Integers {
     pub fn get_region(&self, index: usize, dest: &mut [Rint]) -> usize {
         unsafe {
             let ptr: *mut i32 = dest.as_mut_ptr() as *mut i32;
-            INTEGER_GET_REGION(self.get(), index as R_xlen_t, dest.len() as R_xlen_t, ptr) as usize
+            INTEGER_GET_REGION(
+                self.get(),
+                R_xlen_t::try_from(index).unwrap(),
+                R_xlen_t::try_from(dest.len()).unwrap(),
+                ptr,
+            )
+            .try_into()
+            .unwrap()
         }
     }
 
@@ -54,7 +61,7 @@ impl Integers {
 impl Integers {
     pub fn set_elt(&mut self, index: usize, val: Rint) {
         single_threaded(|| unsafe {
-            SET_INTEGER_ELT(self.get(), index as R_xlen_t, val.inner());
+            SET_INTEGER_ELT(self.get(), R_xlen_t::try_from(index).unwrap(), val.inner());
         })
     }
 }

--- a/extendr-api/src/wrapper/list.rs
+++ b/extendr-api/src/wrapper/list.rs
@@ -157,7 +157,7 @@ impl List {
             Err(Error::OutOfRange(self.robj.clone()))
         } else {
             unsafe {
-                let sexp = VECTOR_ELT(self.robj.get(), i as R_xlen_t);
+                let sexp = VECTOR_ELT(self.robj.get(), R_xlen_t::try_from(i).unwrap());
                 Ok(Robj::from_sexp(sexp))
             }
         }
@@ -169,7 +169,11 @@ impl List {
             if i >= self.robj.len() {
                 Err(Error::OutOfRange(self.robj.clone()))
             } else {
-                SET_VECTOR_ELT(self.robj.get_mut(), i as R_xlen_t, value.get());
+                SET_VECTOR_ELT(
+                    self.robj.get_mut(),
+                    R_xlen_t::try_from(i).unwrap(),
+                    value.get(),
+                );
                 Ok(())
             }
         })
@@ -267,7 +271,9 @@ impl Iterator for ListIter {
         if i >= self.len {
             None
         } else {
-            Some(unsafe { Robj::from_sexp(VECTOR_ELT(self.robj.get(), i as isize)) })
+            Some(unsafe {
+                Robj::from_sexp(VECTOR_ELT(self.robj.get(), isize::try_from(i).unwrap()))
+            })
         }
     }
 
@@ -392,7 +398,7 @@ impl<T: Into<Robj>> FromIterator<T> for List {
                 // note: Currently, `Robj` automatically registers `v` by the
                 // `ownership`-module, making it protected, even though it isn't necessary to do so.
                 let item: Robj = v.into();
-                SET_VECTOR_ELT(robj.get_mut(), i as isize, item.get());
+                SET_VECTOR_ELT(robj.get_mut(), isize::try_from(i).unwrap(), item.get());
             }
 
             List { robj }

--- a/extendr-api/src/wrapper/logicals.rs
+++ b/extendr-api/src/wrapper/logicals.rs
@@ -36,7 +36,14 @@ impl Logicals {
     pub fn get_region(&self, index: usize, dest: &mut [Rbool]) -> usize {
         unsafe {
             let ptr: *mut i32 = dest.as_mut_ptr() as *mut i32;
-            LOGICAL_GET_REGION(self.get(), index as R_xlen_t, dest.len() as R_xlen_t, ptr) as usize
+            LOGICAL_GET_REGION(
+                self.get(),
+                R_xlen_t::try_from(index).unwrap(),
+                R_xlen_t::try_from(dest.len()).unwrap(),
+                ptr,
+            )
+            .try_into()
+            .unwrap()
         }
     }
 }
@@ -45,7 +52,11 @@ impl Logicals {
 impl Logicals {
     pub fn set_elt(&mut self, index: usize, val: Rbool) {
         single_threaded(|| unsafe {
-            SET_INTEGER_ELT(self.get_mut(), index as R_xlen_t, val.inner());
+            SET_INTEGER_ELT(
+                self.get_mut(),
+                R_xlen_t::try_from(index).unwrap(),
+                val.inner(),
+            );
         })
     }
 }

--- a/extendr-api/src/wrapper/matrix.rs
+++ b/extendr-api/src/wrapper/matrix.rs
@@ -48,7 +48,11 @@ where
     /// values, use [`RMatrix::new_with_na`].
     pub fn new(nrow: usize, ncol: usize) -> Self {
         let sexptype = T::sexptype();
-        let matrix = Robj::alloc_matrix(sexptype, nrow as _, ncol as _);
+        let matrix = Robj::alloc_matrix(
+            sexptype,
+            i32::try_from(nrow).unwrap(),
+            i32::try_from(ncol).unwrap(),
+        );
         RArray::from_parts(matrix, [nrow, ncol])
     }
 }
@@ -281,7 +285,10 @@ where
             Err(Error::ExpectedMatrix(robj))
         } else if let Some(_slice) = robj.as_typed_slice_mut() {
             if let Some(dim) = robj.dim() {
-                let dim: Vec<_> = dim.iter().map(|d| d.inner() as usize).collect();
+                let dim: Vec<_> = dim
+                    .iter()
+                    .map(|d| usize::try_from(d.inner()).unwrap())
+                    .collect();
                 if dim.len() != 2 {
                     Err(Error::ExpectedMatrix(robj))
                 } else {
@@ -308,7 +315,10 @@ where
                 if dim.len() != 3 {
                     Err(Error::ExpectedMatrix3D(robj))
                 } else {
-                    let dim: Vec<_> = dim.iter().map(|d| d.inner() as usize).collect();
+                    let dim: Vec<_> = dim
+                        .iter()
+                        .map(|d| usize::try_from(d.inner()).unwrap())
+                        .collect();
                     Ok(RArray::from_parts(robj, [dim[0], dim[1], dim[2]]))
                 }
             } else {

--- a/extendr-api/src/wrapper/mod.rs
+++ b/extendr-api/src/wrapper/mod.rs
@@ -73,7 +73,7 @@ where
         let mut res = Robj::alloc_vector(sexptype, values.len());
         let sexp = res.get_mut();
         for (i, val) in values.enumerate() {
-            SET_VECTOR_ELT(sexp, i as R_xlen_t, val.into().get());
+            SET_VECTOR_ELT(sexp, R_xlen_t::try_from(i).unwrap(), val.into().get());
         }
         res
     })

--- a/extendr-api/src/wrapper/pairlist.rs
+++ b/extendr-api/src/wrapper/pairlist.rs
@@ -137,9 +137,9 @@ impl Iterator for PairlistIter {
                 let tag = TAG(sexp);
                 let value = Robj::from_sexp(CAR(sexp));
                 self.list_elem = CDR(sexp);
-                if TYPEOF(tag) == SYMSXP as i32 {
+                if TYPEOF(tag) == i32::try_from(SYMSXP).unwrap() {
                     let printname = PRINTNAME(tag);
-                    assert!(TYPEOF(printname) as u32 == CHARSXP);
+                    assert!(u32::try_from(TYPEOF(printname)).unwrap() == CHARSXP);
                     let name = to_str(R_CHAR(printname) as *const u8);
                     Some((std::mem::transmute(name), value))
                 } else {

--- a/extendr-api/src/wrapper/strings.rs
+++ b/extendr-api/src/wrapper/strings.rs
@@ -52,7 +52,7 @@ impl Strings {
             for (i, v) in values.into_iter().take(maxlen).enumerate() {
                 let v = v.as_ref();
                 let ch = str_to_character(v);
-                SET_STRING_ELT(sexp, i as R_xlen_t, ch);
+                SET_STRING_ELT(sexp, R_xlen_t::try_from(i).unwrap(), ch);
             }
             Self { robj }
         })
@@ -72,7 +72,7 @@ impl Strings {
         if i >= self.len() {
             Rstr::na()
         } else {
-            Robj::from_sexp(unsafe { STRING_ELT(self.get(), i as R_xlen_t) })
+            Robj::from_sexp(unsafe { STRING_ELT(self.get(), R_xlen_t::try_from(i).unwrap()) })
                 .try_into()
                 .unwrap()
         }
@@ -82,7 +82,7 @@ impl Strings {
     pub fn set_elt(&mut self, i: usize, e: Rstr) {
         single_threaded(|| unsafe {
             if i < self.len() {
-                SET_STRING_ELT(self.robj.get_mut(), i as isize, e.get());
+                SET_STRING_ELT(self.robj.get_mut(), isize::try_from(i).unwrap(), e.get());
             }
         });
     }
@@ -112,7 +112,11 @@ impl<T: AsRef<str>> FromIterator<T> for Strings {
         let mut robj = Strings::alloc_vector(STRSXP, len);
         crate::single_threaded(|| unsafe {
             for (i, v) in iter_collect.into_iter().enumerate() {
-                SET_STRING_ELT(robj.get_mut(), i as isize, str_to_character(v.as_ref()));
+                SET_STRING_ELT(
+                    robj.get_mut(),
+                    isize::try_from(i).unwrap(),
+                    str_to_character(v.as_ref()),
+                );
             }
             Strings { robj }
         })

--- a/extendr-api/src/wrapper/symbol.rs
+++ b/extendr-api/src/wrapper/symbol.rs
@@ -35,7 +35,7 @@ impl Symbol {
     // Internal conversion for constant symbols.
     fn from_sexp(sexp: SEXP) -> Symbol {
         unsafe {
-            assert!(TYPEOF(sexp) == SYMSXP as i32);
+            assert!(TYPEOF(sexp) == i32::try_from(SYMSXP).unwrap());
         }
         Symbol {
             robj: Robj::from_sexp(sexp),
@@ -53,7 +53,7 @@ impl Symbol {
         unsafe {
             let sexp = self.robj.get();
             let printname = PRINTNAME(sexp);
-            assert!(TYPEOF(printname) as u32 == CHARSXP);
+            assert!(u32::try_from(TYPEOF(printname)).unwrap() == CHARSXP);
             to_str(R_CHAR(printname) as *const u8)
         }
     }


### PR DESCRIPTION
This is a first part of replace buggy number conversions, it covers most of cases where we transform between numerical types and the conversion can fails.

There is still some cases like:

extendr-api/src/scalar/rint.rs:189:26
```
let result = v as i32;
```

But will not be included here.