### PR TITLE
ci: slide rtools versions since r4.4 was released

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,9 +26,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: windows-latest, r: 'release', rust-version: 'stable-msvc', rtools-version: '43' }
+          - { os: windows-latest, r: 'release', rust-version: 'stable-msvc', rtools-version: '44' }
           - { os: windows-latest, r: 'devel',   rust-version: 'stable-msvc', rtools-version: '44' }
-          - { os: windows-latest, r: 'oldrel',  rust-version: 'stable-msvc', rtools-version: '42' }
+          - { os: windows-latest, r: 'oldrel',  rust-version: 'stable-msvc', rtools-version: '43' }
 
           - { os: macOS-latest,   r: 'release', rust-version: 'stable' }
           # - {os: macOS-latest,   r: 'release', rust-version: 'nightly'}
@@ -275,13 +275,13 @@ jobs:
         config:
           - { os: ubuntu-latest,  r: 'devel',   rust-version: 'stable' }
           - { os: macOS-latest,   r: 'devel',   rust-version: 'stable' }
-          - { os: windows-latest, r: 'release', rust-version: 'stable-msvc',  rust-targets: [ 'x86_64-pc-windows-gnu' ], rtools-version: '43' }
+          - { os: windows-latest, r: 'release', rust-version: 'stable-msvc',  rust-targets: [ 'x86_64-pc-windows-gnu' ], rtools-version: '44' }
           - { os: windows-latest, r: 'devel',   rust-version: 'stable-msvc',  rust-targets: [ 'x86_64-pc-windows-gnu' ], rtools-version: '44' }
           # When the MSVC target is used, since it's cross-compilation from MSVC
           # to GNU, the doc tests are usually skipped. Adding `-Zdoctest-xcompile`
           # lets the doctests run, which accordingly require the nightly toolchain.
-          - { os: windows-latest, r: 'release', rust-version: 'nightly-msvc', rust-targets: [ 'x86_64-pc-windows-gnu' ], rtools-version: '43', extra-args: [ '-Zdoctest-xcompile' ] }
-          - { os: windows-latest, r: 'oldrel',  rust-version: 'nightly-msvc', rust-targets: [ 'x86_64-pc-windows-gnu' ], rtools-version: '42', extra-args: [ '-Zdoctest-xcompile' ] }
+          - { os: windows-latest, r: 'release', rust-version: 'nightly-msvc', rust-targets: [ 'x86_64-pc-windows-gnu' ], rtools-version: '44', extra-args: [ '-Zdoctest-xcompile' ] }
+          - { os: windows-latest, r: 'oldrel',  rust-version: 'nightly-msvc', rust-targets: [ 'x86_64-pc-windows-gnu' ], rtools-version: '43', extra-args: [ '-Zdoctest-xcompile' ] }
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true


### PR DESCRIPTION
Failure observed in various PRs are due to incorrect version of Rtools being used in CI script. These weren't updated with the release of R 4.4. 

On `libR-sys`, we've made a change on this, but it still requires manual updating after each new release. We should find a solution for this going forward...

This was made by advice of @yutannihilation 