### PR TITLE
Attribute takes `Self` and return `Self` 

### DIFF
--- a/extendr-api/src/deserializer.rs
+++ b/extendr-api/src/deserializer.rs
@@ -802,9 +802,8 @@ impl<'de> Visitor<'de> for RobjVisitor {
             keys.push(key);
             values.push(value);
         }
-        let mut result = List::from_values(values);
-        result.set_names(keys).unwrap();
-        Ok(result.into())
+
+        Ok(List::from_values(values).set_names(keys).unwrap())
     }
 
     fn visit_unit<E>(self) -> std::result::Result<Self::Value, E>

--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -184,8 +184,7 @@
 //!     let confint1 = R!("confint(lm(weight ~ group - 1, PlantGrowth))")?;
 //!    
 //!     // As many parameterized calls.
-//!     let mut formula = lang!("~", sym!(weight), lang!("-", sym!(group), 1.0));
-//!     formula.set_class(["formula"])?;
+//!     let formula = lang!("~", sym!(weight), lang!("-", sym!(group), 1.0)).set_class(["formula"])?;
 //!     let plant_growth = global!(PlantGrowth)?;
 //!     let model = call!("lm", formula, plant_growth)?;
 //!     let confint2 = call!("confint", model)?;

--- a/extendr-api/src/metadata.rs
+++ b/extendr-api/src/metadata.rs
@@ -75,17 +75,16 @@ impl From<&Arg> for RArg {
 
 impl From<Arg> for Robj {
     fn from(val: Arg) -> Self {
-        let mut result = List::from_values(&[r!(val.name), r!(val.arg_type)]);
-        result
+        List::from_values(&[r!(val.name), r!(val.arg_type)])
+            .into_robj()
             .set_names(&["name", "arg_type"])
-            .expect("From<Arg> failed");
-        result.into()
+            .expect("From<Arg> failed")
     }
 }
 
 impl From<Func> for Robj {
     fn from(val: Func) -> Self {
-        let mut result = List::from_values(&[
+        List::from_values(&[
             r!(val.doc),
             r!(val.rust_name),
             r!(val.mod_name),
@@ -93,47 +92,44 @@ impl From<Func> for Robj {
             r!(List::from_values(val.args)),
             r!(val.return_type),
             r!(val.hidden),
-        ]);
-        result
-            .set_names(&[
-                "doc",
-                "rust_name",
-                "mod_name",
-                "r_name",
-                "args",
-                "return.type",
-                "hidden",
-            ])
-            .expect("From<Func> failed");
-        result.into()
+        ])
+        .into_robj()
+        .set_names(&[
+            "doc",
+            "rust_name",
+            "mod_name",
+            "r_name",
+            "args",
+            "return.type",
+            "hidden",
+        ])
+        .expect("From<Func> failed")
     }
 }
 
 impl From<Impl> for Robj {
     fn from(val: Impl) -> Self {
-        let mut result = List::from_values(&[
+        List::from_values(&[
             r!(val.doc),
             r!(val.name),
             r!(List::from_values(val.methods)),
-        ]);
-        result
-            .set_names(&["doc", "name", "methods"])
-            .expect("From<Impl> failed");
-        result.into()
+        ])
+        .into_robj()
+        .set_names(&["doc", "name", "methods"])
+        .expect("From<Impl> failed")
     }
 }
 
 impl From<Metadata> for Robj {
     fn from(val: Metadata) -> Self {
-        let mut result = List::from_values(&[
+        List::from_values(&[
             r!(val.name),
             r!(List::from_values(val.functions)),
             r!(List::from_values(val.impls)),
-        ]);
-        result
-            .set_names(&["name", "functions", "impls"])
-            .expect("From<Metadata> failed");
-        result.into()
+        ])
+        .into_robj()
+        .set_names(&["name", "functions", "impls"])
+        .expect("From<Metadata> failed")
     }
 }
 

--- a/extendr-api/src/optional/ndarray.rs
+++ b/extendr-api/src/optional/ndarray.rs
@@ -176,26 +176,25 @@ where
 
         // In general, transposing and then iterating an ndarray in C-order (`iter()`) is exactly
         // equivalent to iterating that same array in Fortan-order (which `ndarray` doesn't currently support)
-        let mut result = value
+        value
             .t()
             .iter()
             // Since we only have a reference, we have to copy all elements so that we can own the entire R array
             .copied()
-            .collect_robj();
-        result.set_attrib(
-            dim_symbol(),
-            value
-                .shape()
-                .iter()
-                .map(|x| i32::try_from(*x))
-                .collect::<std::result::Result<Vec<i32>, <i32 as TryFrom<usize>>::Error>>()
-                .map_err(|_err| {
-                    Error::Other(String::from(
-                        "One or more array dimensions were too large to be handled by R.",
-                    ))
-                })?,
-        )?;
-        Ok(result)
+            .collect_robj()
+            .set_attrib(
+                dim_symbol(),
+                value
+                    .shape()
+                    .iter()
+                    .map(|x| i32::try_from(*x))
+                    .collect::<std::result::Result<Vec<i32>, <i32 as TryFrom<usize>>::Error>>()
+                    .map_err(|_err| {
+                        Error::Other(String::from(
+                            "One or more array dimensions were too large to be handled by R.",
+                        ))
+                    })?,
+            )
     }
 }
 

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -83,12 +83,9 @@ where
         use crate as extendr_api;
         match res {
             Ok(x) => x.into(),
-            Err(x) => {
-                let mut err = list!(message = "extendr_err", value = x.into());
-                err.set_class(["extendr_error", "error", "condition"])
-                    .expect("internal error: failed to set class");
-                err.into()
-            }
+            Err(x) => { list!(message = "extendr_err", value = x.into()) }
+                .set_class(["extendr_error", "error", "condition"])
+                .expect("internal error: failed to set class"),
         }
     }
 }
@@ -107,7 +104,7 @@ where
 {
     fn from(res: std::result::Result<T, E>) -> Self {
         use crate as extendr_api;
-        let mut result = match res {
+        match res {
             Ok(x) => list!(ok = x.into(), err = NULL),
             Err(x) => {
                 let err_robj = x.into();
@@ -116,11 +113,10 @@ where
                 }
                 list!(ok = NULL, err = err_robj)
             }
-        };
-        result
-            .set_class(&["extendr_result"])
-            .expect("Internal error: failed to set class");
-        result.into()
+        }
+        .set_class(&["extendr_result"])
+        .expect("Internal error: failed to set class")
+        .into()
     }
 }
 
@@ -586,7 +582,7 @@ pub trait RobjItertools: Iterator {
         Robj: AsTypedSlice<'a, Self::Item>,
         Self::Item: 'a,
     {
-        let mut vector = self.collect_robj();
+        let vector = self.collect_robj();
         let prod = dims.iter().product::<usize>();
         if prod != vector.len() {
             return Err(Error::Other(format!(
@@ -595,11 +591,11 @@ pub trait RobjItertools: Iterator {
                 prod
             )));
         }
-        vector.set_attrib(wrapper::symbol::dim_symbol(), dims.iter().collect_robj())?;
-        let _data = vector.as_typed_slice().ok_or(Error::Other(
+        let robj = vector.set_attrib(wrapper::symbol::dim_symbol(), dims.iter().collect_robj())?;
+        let _data = robj.as_typed_slice().ok_or(Error::Other(
             "Unknown error in converting to slice".to_string(),
         ))?;
-        Ok(RArray::from_parts(vector, dims))
+        Ok(RArray::from_parts(robj, dims))
     }
 }
 

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -860,10 +860,11 @@ pub trait Attributes: Types + Length {
     ///    assert_eq!(robj.get_attrib(sym!(xyz)), Some(r!(1)));
     /// }
     /// ```
-    fn set_attrib<N, V>(&mut self, name: N, value: V) -> Result<&mut Self>
+    fn set_attrib<N, V>(mut self, name: N, value: V) -> Result<Self>
     where
         N: Into<Robj>,
         V: Into<Robj>,
+        Self: Sized,
     {
         let name = name.into();
         let value = value.into();
@@ -912,11 +913,12 @@ pub trait Attributes: Types + Length {
     ///     assert_eq!(r!([1, 2, 3]).set_names(&["a", "b"]), Err(Error::NamesLengthMismatch(r!(["a", "b"]))));
     /// }
     /// ```
-    fn set_names<T>(&mut self, names: T) -> Result<&mut Self>
+    fn set_names<T>(self, names: T) -> Result<Self>
     where
         T: IntoIterator,
         T::IntoIter: ExactSizeIterator,
         T::Item: ToVectorValue + AsRef<str>,
+        Self: Sized,
     {
         let iter = names.into_iter();
         let robj = iter.collect_robj();
@@ -994,11 +996,12 @@ pub trait Attributes: Types + Length {
     ///     assert_eq!(obj.inherits("a"), true);
     /// }
     /// ```
-    fn set_class<T>(&mut self, class: T) -> Result<&mut Self>
+    fn set_class<T>(self, class: T) -> Result<Self>
     where
         T: IntoIterator,
         T::IntoIter: ExactSizeIterator,
         T::Item: ToVectorValue + AsRef<str>,
+        Self: Sized,
     {
         let iter = class.into_iter();
         self.set_attrib(wrapper::symbol::class_symbol(), iter.collect_robj())

--- a/extendr-api/src/wrapper/list.rs
+++ b/extendr-api/src/wrapper/list.rs
@@ -62,8 +62,7 @@ impl List {
             names.push(pair.key());
             values.push(pair.value());
         }
-        let mut res = List::from_values(values);
-        res.as_robj_mut()
+        List::from_values(values)
             .set_names(names)
             .unwrap()
             .as_list()
@@ -92,9 +91,7 @@ impl List {
     where
         K: Into<String>,
     {
-        let mut res: Self = Self::from_values(val.values());
-        res.set_names(val.into_keys().map(|k| k.into()))?;
-        Ok(res)
+        Self::from_values(val.values()).set_names(val.into_keys().map(|k| k.into()))
     }
 
     /// Build a list using separate names and values iterators.
@@ -108,9 +105,7 @@ impl List {
         V::IntoIter: ExactSizeIterator,
         V::Item: Into<Robj>,
     {
-        let mut list = List::from_values(values);
-        list.set_names(names)?;
-        Ok(list)
+        List::from_values(values).set_names(names)
     }
 
     /// Return an iterator over the values of this list.

--- a/extendr-api/src/wrapper/matrix.rs
+++ b/extendr-api/src/wrapper/matrix.rs
@@ -160,9 +160,9 @@ where
 {
     /// Make a new column type.
     pub fn new_column<F: FnMut(usize) -> T>(nrows: usize, f: F) -> Self {
-        let mut robj = (0..nrows).map(f).collect_robj();
+        let robj = (0..nrows).map(f).collect_robj();
         let dim = [nrows];
-        robj.set_attrib(wrapper::symbol::dim_symbol(), dim).unwrap();
+        let robj = robj.set_attrib(wrapper::symbol::dim_symbol(), dim).unwrap();
         RArray::from_parts(robj, dim)
     }
 
@@ -192,14 +192,14 @@ where
         ncols: usize,
         f: F,
     ) -> Self {
-        let mut robj = (0..ncols)
+        let robj = (0..ncols)
             .flat_map(|c| {
                 let mut g = f.clone();
                 (0..nrows).map(move |r| g(r, c))
             })
             .collect_robj();
         let dim = [nrows, ncols];
-        robj.set_attrib(wrapper::symbol::dim_symbol(), dim).unwrap();
+        let robj = robj.set_attrib(wrapper::symbol::dim_symbol(), dim).unwrap();
         RArray::from_parts(robj, dim)
     }
 
@@ -224,7 +224,7 @@ where
         nmatrix: usize,
         f: F,
     ) -> Self {
-        let mut robj = (0..nmatrix)
+        let robj = (0..nmatrix)
             .flat_map(|m| {
                 let h = f.clone();
                 (0..ncols).flat_map(move |c| {
@@ -234,7 +234,7 @@ where
             })
             .collect_robj();
         let dim = [nrows, ncols, nmatrix];
-        robj.set_attrib(wrapper::symbol::dim_symbol(), dim).unwrap();
+        let robj = robj.set_attrib(wrapper::symbol::dim_symbol(), dim).unwrap();
         RArray::from_parts(robj, dim)
     }
 

--- a/extendr-api/tests/call_tests.rs
+++ b/extendr-api/tests/call_tests.rs
@@ -7,8 +7,7 @@ fn formula_test() {
         let confint1 = R!("confint(lm(weight ~ group - 1, PlantGrowth))")?;
 
         // As many parameterized calls.
-        let mut formula = lang!("~", sym!(weight), lang!("-", sym!(group), 1.0));
-        formula.set_class(["formula"])?;
+        let formula = lang!("~", sym!(weight), lang!("-", sym!(group), 1.0)).set_class(["formula"])?;
         let plant_growth = global!(PlantGrowth)?;
         let model = call!("lm", formula, plant_growth)?;
         let confint2 = call!("confint", model)?;

--- a/extendr-api/tests/issue-397-memory-allocation.rs
+++ b/extendr-api/tests/issue-397-memory-allocation.rs
@@ -14,11 +14,11 @@ fn test_allocation() {
             assert_eq!(Some((ix + 1) as f64), v.as_real())
         }
 
-        let mut obj: Robj = List::from_names_and_values(&["A"], vec![data]).into();
-        obj.set_attrib(
+        let obj: Robj = List::from_names_and_values(&["A"], vec![data]).into();
+        let obj = obj.set_attrib(
             row_names_symbol(),
             (1i32..=COUNT as i32).collect_robj(),
         )?;
-        obj.set_class(&["data.frame"])?;
+        let _obj = obj.set_class(&["data.frame"])?;
     }
 }

--- a/extendr-macros/src/extendr_impl.rs
+++ b/extendr-macros/src/extendr_impl.rs
@@ -263,7 +263,7 @@ pub fn extendr_impl(mut item_impl: ItemImpl, opts: &ExtendrOptions) -> syn::Resu
                     unsafe {
                         let ptr = Box::into_raw(Box::new(value));
                         let mut res = Robj::make_external_ptr(ptr, Robj::from(()));
-                        res.set_attrib(class_symbol(), #self_ty_name).unwrap();
+                        let res = res.set_attrib(class_symbol(), #self_ty_name).unwrap();
                         res.register_c_finalizer(Some(#finalizer_name));
                         res
                     }
@@ -287,7 +287,7 @@ pub fn extendr_impl(mut item_impl: ItemImpl, opts: &ExtendrOptions) -> syn::Resu
                 unsafe {
                     let ptr = Box::into_raw(Box::new(value));
                     let mut res = Robj::make_external_ptr(ptr, Robj::from(()));
-                    res.set_attrib(class_symbol(), #self_ty_name).unwrap();
+                    let res = res.set_attrib(class_symbol(), #self_ty_name).unwrap();
                     res.register_c_finalizer(Some(#finalizer_name));
                     res
                 }

--- a/tests/extendrtests/src/rust/src/attributes.rs
+++ b/tests/extendrtests/src/rust/src/attributes.rs
@@ -2,36 +2,25 @@ use extendr_api::prelude::*;
 
 #[extendr]
 fn dbls_named(x: Doubles) -> Doubles {
-    let mut x = x;
-    x.set_attrib(
-        "names",
-        x.iter()
-            .map(|xi| xi.inner().to_string())
-            .collect::<Vec<_>>(),
-    )
-    .unwrap();
-
-    x
+    let names = x
+        .iter()
+        .map(|xi| xi.inner().to_string())
+        .collect::<Vec<_>>();
+    x.set_attrib("names", names).unwrap()
 }
 
 #[extendr]
 fn strings_named(x: Strings) -> Strings {
-    let mut x = x;
-    x.set_attrib(
-        "names",
-        x.iter()
-            .map(|xi| xi.as_str().to_string())
-            .collect::<Vec<_>>(),
-    )
-    .unwrap();
-    x
+    let names = x
+        .iter()
+        .map(|xi| xi.as_str().to_string())
+        .collect::<Vec<_>>();
+    x.set_attrib("names", names).unwrap()
 }
 
 #[extendr]
 fn list_named(x: List, nms: Strings) -> List {
-    let mut x = x;
-    let _ = x.set_attrib("names", nms);
-    x
+    x.set_attrib("names", nms).unwrap()
 }
 
 extendr_module! {

--- a/tests/extendrtests/tests/testthat/_snaps/macro-snapshot.md
+++ b/tests/extendrtests/tests/testthat/_snaps/macro-snapshot.md
@@ -58,7 +58,7 @@
                   unsafe {
                       let ptr = Box::into_raw(Box::new(value));
                       let mut res = Robj::make_external_ptr(ptr, Robj::from(()));
-                      res.set_attrib(class_symbol(), "VecUsize").unwrap();
+                      let res = res.set_attrib(class_symbol(), "VecUsize").unwrap();
                       res.register_c_finalizer(Some(__finalize__VecUsize));
                       res
                   }
@@ -69,7 +69,7 @@
                   unsafe {
                       let ptr = Box::into_raw(Box::new(value));
                       let mut res = Robj::make_external_ptr(ptr, Robj::from(()));
-                      res.set_attrib(class_symbol(), "VecUsize").unwrap();
+                      let res = res.set_attrib(class_symbol(), "VecUsize").unwrap();
                       res.register_c_finalizer(Some(__finalize__VecUsize));
                       res
                   }
@@ -528,19 +528,9 @@
       }
       mod attributes {
           use extendr_api::prelude::*;
-          /// Adds an attribute to a vector of doubles
-          ///
-          /// @param x Vector of doubles
-          ///
-          /// @export
           fn dbls_named(x: Doubles) -> Doubles {
-              let mut x = x;
-              x.set_attrib(
-                      "names",
-                      x.iter().map(|xi| xi.inner().to_string()).collect::<Vec<_>>(),
-                  )
-                  .unwrap();
-              x
+              let names = x.iter().map(|xi| xi.inner().to_string()).collect::<Vec<_>>();
+              x.set_attrib("names", names).unwrap()
           }
           #[no_mangle]
           #[allow(non_snake_case, clippy::not_unsafe_ptr_arg_deref)]
@@ -618,7 +608,7 @@
               );
               metadata
                   .push(extendr_api::metadata::Func {
-                      doc: " Adds an attribute to a vector of doubles\n \n @param x Vector of doubles \n \n @export",
+                      doc: "",
                       rust_name: "dbls_named",
                       r_name: "dbls_named",
                       mod_name: "dbls_named",
@@ -629,13 +619,8 @@
                   })
           }
           fn strings_named(x: Strings) -> Strings {
-              let mut x = x;
-              x.set_attrib(
-                      "names",
-                      x.iter().map(|xi| xi.as_str().to_string()).collect::<Vec<_>>(),
-                  )
-                  .unwrap();
-              x
+              let names = x.iter().map(|xi| xi.as_str().to_string()).collect::<Vec<_>>();
+              x.set_attrib("names", names).unwrap()
           }
           #[no_mangle]
           #[allow(non_snake_case, clippy::not_unsafe_ptr_arg_deref)]
@@ -724,9 +709,7 @@
                   })
           }
           fn list_named(x: List, nms: Strings) -> List {
-              let mut x = x;
-              let _ = x.set_attrib("names", nms);
-              x
+              x.set_attrib("names", nms).unwrap()
           }
           #[no_mangle]
           #[allow(non_snake_case, clippy::not_unsafe_ptr_arg_deref)]
@@ -3808,7 +3791,7 @@
                   unsafe {
                       let ptr = Box::into_raw(Box::new(value));
                       let mut res = Robj::make_external_ptr(ptr, Robj::from(()));
-                      res.set_attrib(class_symbol(), "MySubmoduleClass").unwrap();
+                      let res = res.set_attrib(class_symbol(), "MySubmoduleClass").unwrap();
                       res.register_c_finalizer(Some(__finalize__MySubmoduleClass));
                       res
                   }
@@ -3819,7 +3802,7 @@
                   unsafe {
                       let ptr = Box::into_raw(Box::new(value));
                       let mut res = Robj::make_external_ptr(ptr, Robj::from(()));
-                      res.set_attrib(class_symbol(), "MySubmoduleClass").unwrap();
+                      let res = res.set_attrib(class_symbol(), "MySubmoduleClass").unwrap();
                       res.register_c_finalizer(Some(__finalize__MySubmoduleClass));
                       res
                   }
@@ -4687,7 +4670,9 @@
                   unsafe {
                       let ptr = Box::into_raw(Box::new(value));
                       let mut res = Robj::make_external_ptr(ptr, Robj::from(()));
-                      res.set_attrib(class_symbol(), "MySubmoduleClassTryFrom").unwrap();
+                      let res = res
+                          .set_attrib(class_symbol(), "MySubmoduleClassTryFrom")
+                          .unwrap();
                       res.register_c_finalizer(Some(__finalize__MySubmoduleClassTryFrom));
                       res
                   }
@@ -7600,7 +7585,7 @@
               unsafe {
                   let ptr = Box::into_raw(Box::new(value));
                   let mut res = Robj::make_external_ptr(ptr, Robj::from(()));
-                  res.set_attrib(class_symbol(), "MyClass").unwrap();
+                  let res = res.set_attrib(class_symbol(), "MyClass").unwrap();
                   res.register_c_finalizer(Some(__finalize__MyClass));
                   res
               }
@@ -7611,7 +7596,7 @@
               unsafe {
                   let ptr = Box::into_raw(Box::new(value));
                   let mut res = Robj::make_external_ptr(ptr, Robj::from(()));
-                  res.set_attrib(class_symbol(), "MyClass").unwrap();
+                  let res = res.set_attrib(class_symbol(), "MyClass").unwrap();
                   res.register_c_finalizer(Some(__finalize__MyClass));
                   res
               }
@@ -8263,7 +8248,7 @@
               unsafe {
                   let ptr = Box::into_raw(Box::new(value));
                   let mut res = Robj::make_external_ptr(ptr, Robj::from(()));
-                  res.set_attrib(class_symbol(), "MyClassTryFrom").unwrap();
+                  let res = res.set_attrib(class_symbol(), "MyClassTryFrom").unwrap();
                   res.register_c_finalizer(Some(__finalize__MyClassTryFrom));
                   res
               }
@@ -8503,7 +8488,7 @@
               unsafe {
                   let ptr = Box::into_raw(Box::new(value));
                   let mut res = Robj::make_external_ptr(ptr, Robj::from(()));
-                  res.set_attrib(class_symbol(), "__MyClass").unwrap();
+                  let res = res.set_attrib(class_symbol(), "__MyClass").unwrap();
                   res.register_c_finalizer(Some(__finalize____MyClass));
                   res
               }
@@ -8514,7 +8499,7 @@
               unsafe {
                   let ptr = Box::into_raw(Box::new(value));
                   let mut res = Robj::make_external_ptr(ptr, Robj::from(()));
-                  res.set_attrib(class_symbol(), "__MyClass").unwrap();
+                  let res = res.set_attrib(class_symbol(), "__MyClass").unwrap();
                   res.register_c_finalizer(Some(__finalize____MyClass));
                   res
               }
@@ -8762,7 +8747,7 @@
               unsafe {
                   let ptr = Box::into_raw(Box::new(value));
                   let mut res = Robj::make_external_ptr(ptr, Robj::from(()));
-                  res.set_attrib(class_symbol(), "__MyClassTryFrom").unwrap();
+                  let res = res.set_attrib(class_symbol(), "__MyClassTryFrom").unwrap();
                   res.register_c_finalizer(Some(__finalize____MyClassTryFrom));
                   res
               }
@@ -9014,7 +8999,7 @@
               unsafe {
                   let ptr = Box::into_raw(Box::new(value));
                   let mut res = Robj::make_external_ptr(ptr, Robj::from(()));
-                  res.set_attrib(class_symbol(), "MyClassUnexported").unwrap();
+                  let res = res.set_attrib(class_symbol(), "MyClassUnexported").unwrap();
                   res.register_c_finalizer(Some(__finalize__MyClassUnexported));
                   res
               }
@@ -9025,7 +9010,7 @@
               unsafe {
                   let ptr = Box::into_raw(Box::new(value));
                   let mut res = Robj::make_external_ptr(ptr, Robj::from(()));
-                  res.set_attrib(class_symbol(), "MyClassUnexported").unwrap();
+                  let res = res.set_attrib(class_symbol(), "MyClassUnexported").unwrap();
                   res.register_c_finalizer(Some(__finalize__MyClassUnexported));
                   res
               }
@@ -9286,7 +9271,9 @@
               unsafe {
                   let ptr = Box::into_raw(Box::new(value));
                   let mut res = Robj::make_external_ptr(ptr, Robj::from(()));
-                  res.set_attrib(class_symbol(), "MyClassUnexportedTryFrom").unwrap();
+                  let res = res
+                      .set_attrib(class_symbol(), "MyClassUnexportedTryFrom")
+                      .unwrap();
                   res.register_c_finalizer(Some(__finalize__MyClassUnexportedTryFrom));
                   res
               }


### PR DESCRIPTION
Since we are already using the word breaking, we might as well explore this strategy:
Instead of taking `&mut Self` and turning `Self `, what if we took `Self` anyways?

It makes a bit of since, because R-objects (and its wrappers) are pointers to begin with, meaning they are references to begin with. 