### PR TITLE
`xtask`: Minor documentation addition

### DIFF
--- a/xtask/src/cli/mod.rs
+++ b/xtask/src/cli/mod.rs
@@ -25,7 +25,7 @@ pub(crate) enum Commands {
     Doc,
     #[command(about = "Check that the specified rust-version is MSRV")]
     Msrv,
-    #[command(about = "Run devtools::test() on {extendrtests}")]
+    #[command(about = "Run devtools::test() on {extendrtests} and generate snapshots")]
     DevtoolsTest(DevtoolsTestArg),
     #[command(about = "Generate wrappers by `rextendr::document()`")]
     Document,


### PR DESCRIPTION
A typical workflow for making a PR to extendr may involve


```sh
cargo extendr document
cargo extendr devtools-test
cargo extendr devtools-test -a 
```

(and maybe even `cargo extendr r-cmd-check`)

However, when looking at the overview presented to you by
`cargo extendr`, you won't see "snapshots" anywhere.
Unless of course, you wrote `cargo extendr devtools-test -h`,
where you'd see `--accept-snapshot`.

_But what generates them?_ Well `cargo extendr devtools-test`-invocation does!
