### PR TITLE
`extendr-macros`: Accept argument alias with `mut` in front 

### DIFF
--- a/extendr-api/src/wrapper/externalptr.rs
+++ b/extendr-api/src/wrapper/externalptr.rs
@@ -10,7 +10,6 @@
 //! a class in R, you must decorate it with a class-attribute manually.
 //!
 use super::*;
-use std::any::Any;
 use std::fmt::Debug;
 
 /// Wrapper for creating R objects containing any Rust object.

--- a/extendr-macros/src/extendr_module.rs
+++ b/extendr-macros/src/extendr_module.rs
@@ -11,7 +11,7 @@ pub fn extendr_module(item: TokenStream) -> TokenStream {
         implnames,
         usenames,
     } = module;
-    let modname = modname.unwrap();
+    let modname = modname.expect("cannot include unnamed modules");
     let modname_string = modname.to_string();
     let module_init_name = format_ident!("R_init_{}_extendr", modname);
 
@@ -102,10 +102,10 @@ pub fn extendr_module(item: TokenStream) -> TokenStream {
                 use extendr_api::robj::*;
                 use extendr_api::GetSexp;
                 let robj = Robj::from_sexp(use_symbols_sexp);
-                let use_symbols: bool = <bool>::from_robj(&robj).unwrap();
+                let use_symbols: bool = <bool>::try_from(&robj).unwrap();
 
                 let robj = Robj::from_sexp(package_name_sexp);
-                let package_name: &str = <&str>::from_robj(&robj).unwrap();
+                let package_name: &str = <&str>::try_from(&robj).unwrap();
 
                 extendr_api::Robj::from(
                     #module_metadata_name()

--- a/extendr-macros/src/wrappers.rs
+++ b/extendr-macros/src/wrappers.rs
@@ -354,14 +354,13 @@ pub fn translate_formal(input: &FnArg, self_ty: Option<&syn::Type>) -> syn::Resu
         // function argument.
         FnArg::Typed(ref pattype) => {
             let pat = &pattype.pat.as_ref();
-            let pat_ident = match pat {
-                syn::Pat::Ident(ref pat_ident) => &pat_ident.ident,
-                _ => {
-                    return Err(syn::Error::new_spanned(
-                        input,
-                        "failed to translate name of argument",
-                    ))
-                }
+            let pat_ident = if let syn::Pat::Ident(ref pat_ident) = pat {
+                &pat_ident.ident
+            } else {
+                return Err(syn::Error::new_spanned(
+                    input,
+                    "failed to translate name of argument",
+                ));
             };
             Ok(parse_quote! { #pat_ident : extendr_api::SEXP })
         }

--- a/extendr-macros/src/wrappers.rs
+++ b/extendr-macros/src/wrappers.rs
@@ -354,7 +354,16 @@ pub fn translate_formal(input: &FnArg, self_ty: Option<&syn::Type>) -> syn::Resu
         // function argument.
         FnArg::Typed(ref pattype) => {
             let pat = &pattype.pat.as_ref();
-            Ok(parse_quote! { #pat : extendr_api::SEXP })
+            let pat_ident = match pat {
+                syn::Pat::Ident(ref pat_ident) => &pat_ident.ident,
+                _ => {
+                    return Err(syn::Error::new_spanned(
+                        input,
+                        "failed to translate name of argument",
+                    ))
+                }
+            };
+            Ok(parse_quote! { #pat_ident : extendr_api::SEXP })
         }
         // &self / &mut self
         FnArg::Receiver(ref receiver) => {
@@ -381,7 +390,15 @@ fn translate_meta_arg(input: &mut FnArg, self_ty: Option<&syn::Type>) -> syn::Re
         FnArg::Typed(ref mut pattype) => {
             let pat = pattype.pat.as_ref();
             let ty = pattype.ty.as_ref();
-            let name_string = quote! { #pat }.to_string();
+            let pat_ident = if let syn::Pat::Ident(ref pat_ident) = pat {
+                &pat_ident.ident
+            } else {
+                return Err(syn::Error::new_spanned(
+                    input,
+                    "failed to translate name of argument",
+                ));
+            };
+            let name_string = quote! { #pat_ident }.to_string();
             let type_string = type_name(ty);
             let default = if let Some(default) = get_named_lit(&mut pattype.attrs, "default") {
                 quote!(Some(#default))
@@ -433,7 +450,9 @@ fn translate_to_robj(input: &FnArg) -> syn::Result<syn::Stmt> {
             let pat = &pattype.pat.as_ref();
             if let syn::Pat::Ident(ref ident) = pat {
                 let varname = format_ident!("_{}_robj", ident.ident);
-                Ok(parse_quote! { let #varname = extendr_api::robj::Robj::from_sexp(#pat); })
+                let ident = &ident.ident;
+                // TODO: these do not need protection, as they come from R
+                Ok(parse_quote! { let #varname = extendr_api::robj::Robj::from_sexp(#ident); })
             } else {
                 Err(syn::Error::new_spanned(
                     input,

--- a/extendr-macros/src/wrappers.rs
+++ b/extendr-macros/src/wrappers.rs
@@ -354,13 +354,14 @@ pub fn translate_formal(input: &FnArg, self_ty: Option<&syn::Type>) -> syn::Resu
         // function argument.
         FnArg::Typed(ref pattype) => {
             let pat = &pattype.pat.as_ref();
-            let pat_ident = if let syn::Pat::Ident(ref pat_ident) = pat {
-                &pat_ident.ident
-            } else {
-                return Err(syn::Error::new_spanned(
-                    input,
-                    "failed to translate name of argument",
-                ));
+            let pat_ident = match pat {
+                syn::Pat::Ident(ref pat_ident) => &pat_ident.ident,
+                _ => {
+                    return Err(syn::Error::new_spanned(
+                        input,
+                        "failed to translate name of argument",
+                    ));
+                }
             };
             Ok(parse_quote! { #pat_ident : extendr_api::SEXP })
         }
@@ -389,13 +390,14 @@ fn translate_meta_arg(input: &mut FnArg, self_ty: Option<&syn::Type>) -> syn::Re
         FnArg::Typed(ref mut pattype) => {
             let pat = pattype.pat.as_ref();
             let ty = pattype.ty.as_ref();
-            let pat_ident = if let syn::Pat::Ident(ref pat_ident) = pat {
-                &pat_ident.ident
-            } else {
-                return Err(syn::Error::new_spanned(
-                    input,
-                    "failed to translate name of argument",
-                ));
+            let pat_ident = match pat {
+                syn::Pat::Ident(ref pat_ident) => &pat_ident.ident,
+                _ => {
+                    return Err(syn::Error::new_spanned(
+                        input,
+                        "failed to translate name of argument",
+                    ));
+                }
             };
             let name_string = quote! { #pat_ident }.to_string();
             let type_string = type_name(ty);

--- a/extendr-macros/src/wrappers.rs
+++ b/extendr-macros/src/wrappers.rs
@@ -354,6 +354,7 @@ pub fn translate_formal(input: &FnArg, self_ty: Option<&syn::Type>) -> syn::Resu
         // function argument.
         FnArg::Typed(ref pattype) => {
             let pat = &pattype.pat.as_ref();
+            // ensure that `mut` in args are ignored in the wrapper
             let pat_ident = match pat {
                 syn::Pat::Ident(ref pat_ident) => &pat_ident.ident,
                 _ => {
@@ -363,7 +364,7 @@ pub fn translate_formal(input: &FnArg, self_ty: Option<&syn::Type>) -> syn::Resu
                     ));
                 }
             };
-            Ok(parse_quote! { #pat_ident : extendr_api::SEXP })
+            Ok(parse_quote! { #pat_ident: extendr_api::SEXP })
         }
         // &self / &mut self
         FnArg::Receiver(ref receiver) => {
@@ -390,6 +391,8 @@ fn translate_meta_arg(input: &mut FnArg, self_ty: Option<&syn::Type>) -> syn::Re
         FnArg::Typed(ref mut pattype) => {
             let pat = pattype.pat.as_ref();
             let ty = pattype.ty.as_ref();
+            // here the argument name is extracted, without the `mut` keyword,
+            // ensuring the generated r-wrappers, can use these argument names
             let pat_ident = match pat {
                 syn::Pat::Ident(ref pat_ident) => &pat_ident.ident,
                 _ => {

--- a/tests/extendrtests/src/rust/src/altrep.rs
+++ b/tests/extendrtests/src/rust/src/altrep.rs
@@ -47,7 +47,7 @@ fn new_usize(robj: Integers) -> Altrep {
 
 #[cfg(not(use_r_altlist))]
 #[extendr]
-fn new_usize(robj: Integers) -> Robj {
+fn new_usize(_robj: Integers) -> Robj {
     extendr_api::nil_value()
 }
 

--- a/tests/extendrtests/src/rust/src/attributes.rs
+++ b/tests/extendrtests/src/rust/src/attributes.rs
@@ -1,8 +1,7 @@
 use extendr_api::prelude::*;
 
 #[extendr]
-fn dbls_named(x: Doubles) -> Doubles {
-    let mut x = x;
+fn dbls_named(mut x: Doubles) -> Doubles {
     x.set_attrib(
         "names",
         x.iter()
@@ -15,8 +14,7 @@ fn dbls_named(x: Doubles) -> Doubles {
 }
 
 #[extendr]
-fn strings_named(x: Strings) -> Strings {
-    let mut x = x;
+fn strings_named(mut x: Strings) -> Strings {
     x.set_attrib(
         "names",
         x.iter()
@@ -28,8 +26,7 @@ fn strings_named(x: Strings) -> Strings {
 }
 
 #[extendr]
-fn list_named(x: List, nms: Strings) -> List {
-    let mut x = x;
+fn list_named(mut x: List, nms: Strings) -> List {
     let _ = x.set_attrib("names", nms);
     x
 }

--- a/tests/extendrtests/tests/testthat/_snaps/macro-snapshot.md
+++ b/tests/extendrtests/tests/testthat/_snaps/macro-snapshot.md
@@ -509,9 +509,9 @@
                   use extendr_api::robj::*;
                   use extendr_api::GetSexp;
                   let robj = Robj::from_sexp(use_symbols_sexp);
-                  let use_symbols: bool = <bool>::from_robj(&robj).unwrap();
+                  let use_symbols: bool = <bool>::try_from(&robj).unwrap();
                   let robj = Robj::from_sexp(package_name_sexp);
-                  let package_name: &str = <&str>::from_robj(&robj).unwrap();
+                  let package_name: &str = <&str>::try_from(&robj).unwrap();
                   extendr_api::Robj::from(
                           get_altrep_metadata()
                               .make_r_wrappers(use_symbols, package_name)
@@ -528,8 +528,7 @@
       }
       mod attributes {
           use extendr_api::prelude::*;
-          fn dbls_named(x: Doubles) -> Doubles {
-              let mut x = x;
+          fn dbls_named(mut x: Doubles) -> Doubles {
               x.set_attrib(
                       "names",
                       x.iter().map(|xi| xi.inner().to_string()).collect::<Vec<_>>(),
@@ -623,8 +622,7 @@
                       hidden: false,
                   })
           }
-          fn strings_named(x: Strings) -> Strings {
-              let mut x = x;
+          fn strings_named(mut x: Strings) -> Strings {
               x.set_attrib(
                       "names",
                       x.iter().map(|xi| xi.as_str().to_string()).collect::<Vec<_>>(),
@@ -718,8 +716,7 @@
                       hidden: false,
                   })
           }
-          fn list_named(x: List, nms: Strings) -> List {
-              let mut x = x;
+          fn list_named(mut x: List, nms: Strings) -> List {
               let _ = x.set_attrib("names", nms);
               x
           }
@@ -887,9 +884,9 @@
                   use extendr_api::robj::*;
                   use extendr_api::GetSexp;
                   let robj = Robj::from_sexp(use_symbols_sexp);
-                  let use_symbols: bool = <bool>::from_robj(&robj).unwrap();
+                  let use_symbols: bool = <bool>::try_from(&robj).unwrap();
                   let robj = Robj::from_sexp(package_name_sexp);
-                  let package_name: &str = <&str>::from_robj(&robj).unwrap();
+                  let package_name: &str = <&str>::try_from(&robj).unwrap();
                   extendr_api::Robj::from(
                           get_attributes_metadata()
                               .make_r_wrappers(use_symbols, package_name)
@@ -1215,9 +1212,9 @@
                   use extendr_api::robj::*;
                   use extendr_api::GetSexp;
                   let robj = Robj::from_sexp(use_symbols_sexp);
-                  let use_symbols: bool = <bool>::from_robj(&robj).unwrap();
+                  let use_symbols: bool = <bool>::try_from(&robj).unwrap();
                   let robj = Robj::from_sexp(package_name_sexp);
-                  let package_name: &str = <&str>::from_robj(&robj).unwrap();
+                  let package_name: &str = <&str>::try_from(&robj).unwrap();
                   extendr_api::Robj::from(
                           get_dataframe_metadata()
                               .make_r_wrappers(use_symbols, package_name)
@@ -2107,9 +2104,9 @@
                   use extendr_api::robj::*;
                   use extendr_api::GetSexp;
                   let robj = Robj::from_sexp(use_symbols_sexp);
-                  let use_symbols: bool = <bool>::from_robj(&robj).unwrap();
+                  let use_symbols: bool = <bool>::try_from(&robj).unwrap();
                   let robj = Robj::from_sexp(package_name_sexp);
-                  let package_name: &str = <&str>::from_robj(&robj).unwrap();
+                  let package_name: &str = <&str>::try_from(&robj).unwrap();
                   extendr_api::Robj::from(
                           get_memory_leaks_metadata()
                               .make_r_wrappers(use_symbols, package_name)
@@ -2280,9 +2277,9 @@
                   use extendr_api::robj::*;
                   use extendr_api::GetSexp;
                   let robj = Robj::from_sexp(use_symbols_sexp);
-                  let use_symbols: bool = <bool>::from_robj(&robj).unwrap();
+                  let use_symbols: bool = <bool>::try_from(&robj).unwrap();
                   let robj = Robj::from_sexp(package_name_sexp);
-                  let package_name: &str = <&str>::from_robj(&robj).unwrap();
+                  let package_name: &str = <&str>::try_from(&robj).unwrap();
                   extendr_api::Robj::from(
                           get_optional_either_metadata()
                               .make_r_wrappers(use_symbols, package_name)
@@ -2995,9 +2992,9 @@
                   use extendr_api::robj::*;
                   use extendr_api::GetSexp;
                   let robj = Robj::from_sexp(use_symbols_sexp);
-                  let use_symbols: bool = <bool>::from_robj(&robj).unwrap();
+                  let use_symbols: bool = <bool>::try_from(&robj).unwrap();
                   let robj = Robj::from_sexp(package_name_sexp);
-                  let package_name: &str = <&str>::from_robj(&robj).unwrap();
+                  let package_name: &str = <&str>::try_from(&robj).unwrap();
                   extendr_api::Robj::from(
                           get_optional_faer_metadata()
                               .make_r_wrappers(use_symbols, package_name)
@@ -3261,9 +3258,9 @@
                   use extendr_api::robj::*;
                   use extendr_api::GetSexp;
                   let robj = Robj::from_sexp(use_symbols_sexp);
-                  let use_symbols: bool = <bool>::from_robj(&robj).unwrap();
+                  let use_symbols: bool = <bool>::try_from(&robj).unwrap();
                   let robj = Robj::from_sexp(package_name_sexp);
-                  let package_name: &str = <&str>::from_robj(&robj).unwrap();
+                  let package_name: &str = <&str>::try_from(&robj).unwrap();
                   extendr_api::Robj::from(
                           get_optional_ndarray_metadata()
                               .make_r_wrappers(use_symbols, package_name)
@@ -3609,9 +3606,9 @@
                   use extendr_api::robj::*;
                   use extendr_api::GetSexp;
                   let robj = Robj::from_sexp(use_symbols_sexp);
-                  let use_symbols: bool = <bool>::from_robj(&robj).unwrap();
+                  let use_symbols: bool = <bool>::try_from(&robj).unwrap();
                   let robj = Robj::from_sexp(package_name_sexp);
-                  let package_name: &str = <&str>::from_robj(&robj).unwrap();
+                  let package_name: &str = <&str>::try_from(&robj).unwrap();
                   extendr_api::Robj::from(
                           get_raw_identifiers_metadata()
                               .make_r_wrappers(use_symbols, package_name)
@@ -5496,9 +5493,9 @@
                   use extendr_api::robj::*;
                   use extendr_api::GetSexp;
                   let robj = Robj::from_sexp(use_symbols_sexp);
-                  let use_symbols: bool = <bool>::from_robj(&robj).unwrap();
+                  let use_symbols: bool = <bool>::try_from(&robj).unwrap();
                   let robj = Robj::from_sexp(package_name_sexp);
-                  let package_name: &str = <&str>::from_robj(&robj).unwrap();
+                  let package_name: &str = <&str>::try_from(&robj).unwrap();
                   extendr_api::Robj::from(
                           get_submodule_metadata()
                               .make_r_wrappers(use_symbols, package_name)
@@ -10237,9 +10234,9 @@
               use extendr_api::robj::*;
               use extendr_api::GetSexp;
               let robj = Robj::from_sexp(use_symbols_sexp);
-              let use_symbols: bool = <bool>::from_robj(&robj).unwrap();
+              let use_symbols: bool = <bool>::try_from(&robj).unwrap();
               let robj = Robj::from_sexp(package_name_sexp);
-              let package_name: &str = <&str>::from_robj(&robj).unwrap();
+              let package_name: &str = <&str>::try_from(&robj).unwrap();
               extendr_api::Robj::from(
                       get_extendrtests_metadata()
                           .make_r_wrappers(use_symbols, package_name)


### PR DESCRIPTION
Follow-up to #745, this PR fixes the processing of `#[extendr]`-`fn`to allow for

```rs
#[extendr]
fn do_magic_to(mut x: Doubles) {
  // ...
}
```
while prior to this, one had to
```rs
#[extendr]
fn do_magic_to2(x: Doubles) {
  let mut x = x;
  //...
}
```

Thus, this PR is a bug fix, than an expansion of the API. 

Allow me to state what this PR _does not do_:
* You are no more allowed to change passed data from R in-place, before or after this PR.
If extendr-api permitted the manipulation of the internal data, than that is the same, and
this PR does not allow you more capabilities to mutate data.

There is a difference between having a mutable _alias_ and a mutable reference to data.


