### PR TITLE
Various maintenance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,7 @@ jobs:
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      REXTENDR_SKIP_DEV_TESTS: TRUE
 
       # This environment variable enables support for pseudo multi-target cargo builds.
       # Current stable Rust does not support multi-targeting,
@@ -286,6 +287,7 @@ jobs:
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      REXTENDR_SKIP_DEV_TESTS: TRUE
 
     # PowerShell core is available on all platforms and can be used to unify scripts
     defaults:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -239,7 +239,7 @@ jobs:
                 "\" }"),
 
               # uncomment this line when we need to depend on the dev version of libR-sys
-              'libR-sys = { git = "https://github.com/extendr/libR-sys", features = array("non-api", 1) }',
+              # 'libR-sys = { git = "https://github.com/extendr/libR-sys", features = array("non-api", 1) }',
 
               sep = ";")
           

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -238,7 +238,7 @@ jobs:
                 "\" }"),
 
               # uncomment this line when we need to depend on the dev version of libR-sys
-              'libR-sys = { git = "https://github.com/extendr/libR-sys", features = ["non-api"] }',
+              'libR-sys = { git = "https://github.com/extendr/libR-sys", features = list("non-api") }',
 
               sep = ";")
           

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -247,7 +247,6 @@ jobs:
 
           github_env_file <- Sys.getenv("GITHUB_ENV")
           cat(patch.crates_io, file = github_env_file, append = TRUE)
-          cat("REXTENDR_SKIP_DEV_TESTS=TRUE", file = github_env_file, append = TRUE)
 
           cat("::endgroup::\n")
         shell: Rscript {0}
@@ -287,7 +286,6 @@ jobs:
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      REXTENDR_SKIP_DEV_TESTS: TRUE
 
     # PowerShell core is available on all platforms and can be used to unify scripts
     defaults:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -238,7 +238,7 @@ jobs:
                 "\" }"),
 
               # uncomment this line when we need to depend on the dev version of libR-sys
-              'libR-sys = { git = "https://github.com/extendr/libR-sys" }',
+              'libR-sys = { git = "https://github.com/extendr/libR-sys", features = array("non-api", 1) }',
 
               sep = ";")
           

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -238,7 +238,7 @@ jobs:
                 "\" }"),
 
               # uncomment this line when we need to depend on the dev version of libR-sys
-              'libR-sys = { git = "https://github.com/extendr/libR-sys", features = list("non-api") }',
+              'libR-sys = { git = "https://github.com/extendr/libR-sys" }',
 
               sep = ";")
           

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -246,6 +246,7 @@ jobs:
 
           github_env_file <- Sys.getenv("GITHUB_ENV")
           cat(patch.crates_io, file = github_env_file, append = TRUE)
+          cat("REXTENDR_SKIP_DEV_TESTS=TRUE", file = github_env_file, append = TRUE)
 
           cat("::endgroup::\n")
         shell: Rscript {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -238,7 +238,7 @@ jobs:
                 "\" }"),
 
               # uncomment this line when we need to depend on the dev version of libR-sys
-              'libR-sys = { git = "https://github.com/extendr/libR-sys" }',
+              'libR-sys = { git = "https://github.com/extendr/libR-sys", features = ["non-api"] }',
 
               sep = ";")
           

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ rust-version = "1.70"
 # When updating extendr's version, this version also needs to be updated
 extendr-macros = { path = "./extendr-macros", version = "0.6.0" }
 
-libR-sys = { version = "0.7.0", features = ["non-api"] }
+libR-sys = { version = "0.7.0" }
 
 [patch.crates-io]
 # When uncommenting this, do not forget to uncomment the same line in

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ rust-version = "1.70"
 # When updating extendr's version, this version also needs to be updated
 extendr-macros = { path = "./extendr-macros", version = "0.6.0" }
 
-libR-sys = "0.7.0"
+libR-sys = { version = "0.7.0", features = ["non-api"] }
 
 [patch.crates-io]
 # When uncommenting this, do not forget to uncomment the same line in

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,6 @@ rust-version = "1.70"
 # When updating extendr's version, this version also needs to be updated
 extendr-macros = { path = "./extendr-macros", version = "0.6.0" }
 
-libR-sys = "0.7.0"
-
-[patch.crates-io]
 # When uncommenting this, do not forget to uncomment the same line in
 # ./tests/extendrtests/src/rust/Cargo.toml, and "Run R integration tests using
 # {rextendr}" on .github/workflows/test.yml !

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ rust-version = "1.70"
 # When updating extendr's version, this version also needs to be updated
 extendr-macros = { path = "./extendr-macros", version = "0.6.0" }
 
-libR-sys = { version = "0.7.0" }
+libR-sys = "0.7.0"
 
 [patch.crates-io]
 # When uncommenting this, do not forget to uncomment the same line in

--- a/extendr-api/Cargo.toml
+++ b/extendr-api/Cargo.toml
@@ -39,6 +39,11 @@ result_condition = []
 # but do not add functionality (such as `libR-sys/use-bindgen`) are excluded
 full-functionality = ["graphics", "either", "ndarray", "faer", "num-complex", "serde"]
 
+# Parts of the R-API are locked behind non-API, as CRAN frowns upon the presence
+# of non-API items in packages. You may enable this feature, to generate
+# bindings to these non-API items, and their usage in extendr
+non-api = ["libR-sys/non-api"]
+
 # libc is needed to allocate a DevDesc (c.f., https://bugs.r-project.org/show_bug.cgi?id=18292)
 graphics = ["libc"]
 

--- a/extendr-api/src/wrapper/altrep.rs
+++ b/extendr-api/src/wrapper/altrep.rs
@@ -49,8 +49,9 @@ pub struct Altrep {
 /// Implement one or more of these methods to generate an Altrep class.
 /// This is likely to be unstable for a while.
 pub trait AltrepImpl: Clone + std::fmt::Debug {
+    #[cfg(feature = "non-api")]
     /// Constructor that is called when loading an Altrep object from a file.
-    fn unserialize_ex(
+    unsafe fn unserialize_ex(
         class: Robj,
         state: Robj,
         attributes: Robj,
@@ -557,6 +558,7 @@ impl Altrep {
         use std::os::raw::c_int;
         use std::os::raw::c_void;
 
+        #[cfg(feature = "non-api")]
         unsafe extern "C" fn altrep_UnserializeEX<StateType: AltrepImpl>(
             class: SEXP,
             state: SEXP,
@@ -680,6 +682,7 @@ impl Altrep {
                 _ => panic!("expected Altvec compatible type"),
             };
 
+            #[cfg(feature = "non-api")]
             R_set_altrep_UnserializeEX_method(class_ptr, Some(altrep_UnserializeEX::<StateType>));
             R_set_altrep_Unserialize_method(class_ptr, Some(altrep_Unserialize::<StateType>));
             R_set_altrep_Serialized_state_method(

--- a/extendr-api/src/wrapper/environment.rs
+++ b/extendr-api/src/wrapper/environment.rs
@@ -80,6 +80,7 @@ impl Environment {
         }
     }
 
+    #[cfg(feature = "non-api")]
     /// Set the enclosing (parent) environment.
     pub fn set_parent(&mut self, parent: Environment) -> &mut Self {
         single_threaded(|| unsafe {
@@ -97,6 +98,7 @@ impl Environment {
         }
     }
 
+    #[cfg(feature = "non-api")]
     /// Set the environment flags.
     pub fn set_envflags(&mut self, flags: i32) -> &mut Self {
         single_threaded(|| unsafe {

--- a/extendr-api/src/wrapper/environment.rs
+++ b/extendr-api/src/wrapper/environment.rs
@@ -100,7 +100,7 @@ impl Environment {
 
     #[cfg(feature = "non-api")]
     /// Set the environment flags.
-    pub fn set_envflags(&mut self, flags: i32) -> &mut Self {
+    pub unsafe fn set_envflags(&mut self, flags: i32) -> &mut Self {
         single_threaded(|| unsafe {
             let sexp = self.robj.get_mut();
             SET_ENVFLAGS(sexp, flags);

--- a/extendr-api/src/wrapper/promise.rs
+++ b/extendr-api/src/wrapper/promise.rs
@@ -17,6 +17,7 @@ impl Promise {
     ///     assert_eq!(promise.value(), r!(1));
     /// }
     /// ```
+    #[cfg(feature = "non-api")]
     pub fn from_parts(code: Robj, environment: Environment) -> Result<Self> {
         single_threaded(|| unsafe {
             let sexp = Rf_allocSExp(SEXPTYPE::PROMSXP);

--- a/extendr-api/tests/debug_tests.rs
+++ b/extendr-api/tests/debug_tests.rs
@@ -19,6 +19,7 @@ fn test_debug() {
         assert_eq!(format!("{:?}", r), "base_env()");
         let r = Environment::new_with_parent(global_env());
         assert_eq!(format!("{:?}", r), "<environment>");
+        #[cfg(feature = "non-api")]
         let r = Promise::from_parts(r!(1), global_env())?;
         assert_eq!(format!("{:?}", r), "Promise { code: 1, environment: global_env() }");
         let r : Language = lang!("x").try_into()?;

--- a/extendr-api/tests/debug_tests.rs
+++ b/extendr-api/tests/debug_tests.rs
@@ -21,6 +21,7 @@ fn test_debug() {
         assert_eq!(format!("{:?}", r), "<environment>");
         #[cfg(feature = "non-api")]
         let r = Promise::from_parts(r!(1), global_env())?;
+        #[cfg(feature = "non-api")]
         assert_eq!(format!("{:?}", r), "Promise { code: 1, environment: global_env() }");
         let r : Language = lang!("x").try_into()?;
         assert_eq!(format!("{:?}", r), "lang!(sym!(x))");

--- a/tests/extendrtests/README.md
+++ b/tests/extendrtests/README.md
@@ -12,6 +12,26 @@ The wrapper scripts calling the Rust functions are located here:
 
 The test functions that verify that the wrapper and Rust functions work correctly are located here: <https://github.com/extendr/extendr/blob/master/tests/extendrtests/tests/testthat/test-wrappers.R>
 
+## Using local extendr packages
+
+While testing new features, you may want to explore these features using
+`rextendr::rust_function` / `rextendr::rust_source`, you may run this
+
+```r
+options(
+    rextendr.patch.crates_io =
+        list(
+            `extendr-api` = list(path = "extendr-api" |> normalizePath()),
+            `extendr-macros` = list(path = "extendr-macros" |> normalizePath()),
+            `extendr-engine` = list(path = "extendr-engine" |> normalizePath())
+            # uncomment this, if you have locally sourced libR-sys crate..
+            # ,`libR-sys` = list(path = "libR-sys" |> normalizePath())
+        )
+)
+```
+
+to ensure that the R-session knows about local extendr.
+
 ## Running tests locally
 
 The `Cargo.toml` file hard-codes the relative path of the `extendr` libraries. You can build and install `extendrtests` from RStudio as normal using the menu items in the "Build" menu. However, "Check" does not work. To check this project locally you need to run:

--- a/tests/extendrtests/src/Makevars
+++ b/tests/extendrtests/src/Makevars
@@ -8,7 +8,7 @@ all: C_clean
 $(SHLIB): $(STATLIB)
 
 $(STATLIB):
-	cargo build --lib --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) --color=always
+	cargo build --lib --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) --color=auto
 
 C_clean:
 	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)

--- a/xtask/src/commands/r_cmd_check.rs
+++ b/xtask/src/commands/r_cmd_check.rs
@@ -103,7 +103,6 @@ fn run_r_cmd_check(
             requireNamespace("rcmdcheck");\
             requireNamespace("patrick");\
             requireNamespace("lobstr");\
-            requireNamespace("lobstrs");\
             requireNamespace("rextendr")"#,
         ])
         .run()

--- a/xtask/src/commands/r_cmd_check.rs
+++ b/xtask/src/commands/r_cmd_check.rs
@@ -99,10 +99,10 @@ fn run_r_cmd_check(
         .cmd("Rscript")
         .args([
             "-e",
-            r#"requireNamespace("devtools");\
-            requireNamespace("rcmdcheck");\
-            requireNamespace("patrick");\
-            requireNamespace("lobstr");\
+            r#"requireNamespace("devtools");
+            requireNamespace("rcmdcheck");
+            requireNamespace("patrick");
+            requireNamespace("lobstr");
             requireNamespace("rextendr")"#,
         ])
         .run()


### PR DESCRIPTION
- [x] Added `non-api` option that exposes functionality that was considered API prior to R 4.4. We are marking these `unsafe`. This is considered a breaking change.
- [x] As we are now testing multiple versions of R, actively, we may switch to R environments that does not have all the necessary packages for development.
This PR adds a check and prints a message with the useful command-line instruction to install missing packages.
- [x] I've also added instructions for using development versions of extendr, with rextendr in `tests/extendrtests/README.md`. 
- [x] This PR became contingent on this https://github.com/extendr/rextendr/pull/352