### PR TITLE
STANDALONE: `ExternalPtr` is a pointer

### DIFF
--- a/extendr-api/src/wrapper/externalptr.rs
+++ b/extendr-api/src/wrapper/externalptr.rs
@@ -45,7 +45,6 @@ pub struct ExternalPtr<T> {
 /// is not necessary.
 impl<T> PartialEq for ExternalPtr<T> {
     fn eq(&self, other: &Self) -> bool {
-        //TODO: does R_compute_identical handle externalptr properly?
         self.robj == other.robj && self._marker == other._marker
     }
 }

--- a/extendr-api/src/wrapper/externalptr.rs
+++ b/extendr-api/src/wrapper/externalptr.rs
@@ -337,7 +337,7 @@ mod tests {
 
     #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
     struct Wrapper(i32);
-    
+
     #[test]
     fn compare_externalptr_pointee() {
         with_r(|| {


### PR DESCRIPTION
One cannot `PartialEq` or `Clone` the `ExternalPtr<T>` in the traditional sense, by relying on the 
trait on `T`. Instead, we treat `ExternalPtr` like a pointer. This behaviour is now documented, and the
alternative way to perform comparison is also mentioned. 