### PR TITLE
STANDALONE: Re-use `ExternalPtr` creation method

### DIFF
--- a/extendr-api/src/wrapper/externalptr.rs
+++ b/extendr-api/src/wrapper/externalptr.rs
@@ -248,21 +248,8 @@ impl<T> TryFrom<&Robj> for ExternalPtr<T> {
     type Error = Error;
 
     fn try_from(robj: &Robj) -> Result<Self> {
-        let clone = robj.clone();
-        if clone.rtype() != Rtype::ExternalPtr {
-            Err(Error::ExpectedExternalPtr(clone))
-        } else if clone.check_external_ptr_type::<T>() {
-            let res = ExternalPtr::<T> {
-                robj: clone,
-                _marker: std::marker::PhantomData,
-            };
-            Ok(res)
-        } else {
-            Err(Error::ExpectedExternalPtrType(
-                clone,
-                std::any::type_name::<T>().into(),
-            ))
-        }
+        let result: &Self = robj.try_into()?;
+        Ok(result.clone())
     }
 }
 


### PR DESCRIPTION
This PR cleans up the creation of `ExternalPtr<T>` from `Robj`.
First, we are following @yutannihilation's advice, and no longer doing the insufficient,
stringly-typed type-checking. Second, we are re-using the definitions that is also used in `#[extendr]`-impl.

This depends on merging of

- [x] #765 