### PR TITLE
bug: removed `&[u32]` interpretation of `Robj` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,13 +21,17 @@
   place, and then return an untyped owned pointer (Robj). Instead, now we return `&mut Self`.
 - [_Potentially breaking_]: `RArray::from_parts` no longer requires a pointer to the underlying data
   vector [[#657]](https://github.com/extendr/extendr/pull/657)
-- [**Breaking change**]: In `AltRep` the `unserialize_ex`, `set_parent`, `set_envflags` are
-now hidden behind the feature flag `non-api`. Also, `Promise::from_parts` is marked as non-API.
-- [**Breaking change**]: Floating point numbers with decimal part can no longer be converted to integer types via
-  rounding [[#757]](https://github.com/extendr/extendr/pull/757)
-- [**Breaking change**]: You can no longer create an `Robj` from a reference `&T`, where `T` is an `extendr`-impl. [[#759]](https://github.com/extendr/extendr/pull/759)
-- [**Breaking change**]: You can no longer use `from_robj`, as the trait `FromRobj` as been removed. Instead, use `try_from`.
 - `#[extendr(use_try_from = true)` is now the default setting, therefore the option has `use_try_from` has been removed [[#759]](https://github.com/extendr/extendr/pull/759)
+
+#### Breaking changes
+
+- In `AltRep` the `unserialize_ex`, `set_parent`, `set_envflags` are
+now hidden behind the feature flag `non-api`. Also, `Promise::from_parts` is marked as non-API.
+- Floating point numbers with decimal part can no longer be converted to integer types via
+  rounding [[#757]](https://github.com/extendr/extendr/pull/757)
+- You can no longer create an `Robj` from a reference `&T`, where `T` is an `extendr`-impl. [[#759]](https://github.com/extendr/extendr/pull/759)
+- You can no longer use `from_robj`, as the trait `FromRobj` as been removed. Instead, use `try_from`.
+- It is no longer possible to access R integer vector as a `&[u32]
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ now hidden behind the feature flag `non-api`. Also, `Promise::from_parts` is mar
   rounding [[#757]](https://github.com/extendr/extendr/pull/757)
 - You can no longer create an `Robj` from a reference `&T`, where `T` is an `extendr`-impl. [[#759]](https://github.com/extendr/extendr/pull/759)
 - You can no longer use `from_robj`, as the trait `FromRobj` as been removed. Instead, use `try_from`.
-- It is no longer possible to access R integer vector as a `&[u32]
+- It is no longer possible to access an R integer vector as a `&[u32]` [[#767]](https://github.com/extendr/extendr/pull/767)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ now hidden behind the feature flag `non-api`. Also, `Promise::from_parts` is mar
 ### Fixed
 
 - returning `&Self` or `&mut Self` from a method in an `#[extendr]`-impl would
-result in unintended cloning  [[[#614](https://github.com/extendr/extendr/issues/614)]]
+result in unintended cloning  [[#614]](https://github.com/extendr/extendr/issues/614)
 - `TryFrom<&Robj>` and `FromRobj` for integer scalars now correctly handles conversions
   from `f64` [[#757]](https://github.com/extendr/extendr/pull/757)
 

--- a/extendr-api/src/optional/ndarray.rs
+++ b/extendr-api/src/optional/ndarray.rs
@@ -117,7 +117,6 @@ macro_rules! make_array_view_2 {
 make_array_view_1!(Rbool, Error::ExpectedLogical);
 make_array_view_1!(Rint, Error::ExpectedInteger);
 make_array_view_1!(i32, Error::ExpectedInteger);
-make_array_view_1!(u32, Error::ExpectedInteger);
 make_array_view_1!(Rfloat, Error::ExpectedReal);
 make_array_view_1!(f64, Error::ExpectedReal);
 make_array_view_1!(Rcplx, Error::ExpectedComplex);
@@ -127,7 +126,6 @@ make_array_view_1!(Rstr, Error::ExpectedString);
 make_array_view_2!(Rbool, "Not a logical matrix.", Error::ExpectedLogical);
 make_array_view_2!(Rint, "Not an integer matrix.", Error::ExpectedInteger);
 make_array_view_2!(i32, "Not an integer matrix.", Error::ExpectedInteger);
-make_array_view_2!(u32, "Not an integer matrix.", Error::ExpectedInteger);
 make_array_view_2!(Rfloat, "Not a floating point matrix.", Error::ExpectedReal);
 make_array_view_2!(f64, "Not a floating point matrix.", Error::ExpectedReal);
 make_array_view_2!(

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -794,7 +794,6 @@ macro_rules! make_typed_slice {
 
 make_typed_slice!(Rbool, INTEGER, LGLSXP);
 make_typed_slice!(i32, INTEGER, INTSXP);
-make_typed_slice!(u32, INTEGER, INTSXP);
 make_typed_slice!(Rint, INTEGER, INTSXP);
 make_typed_slice!(f64, REAL, REALSXP);
 make_typed_slice!(Rfloat, REAL, REALSXP);

--- a/extendr-api/tests/ndarray_try_from_tests.rs
+++ b/extendr-api/tests/ndarray_try_from_tests.rs
@@ -30,9 +30,6 @@ mod ndarray_try_from_tests {
                  assert_eq!(mapped, expected);
              }
 
-              let view = <ArrayView2<u32>>::try_from(&robj)?;
-             assert_eq!(view.dim(), (4, 2));
-
              for (&mapped, expected) in view.iter().zip(1..=8) {
                  assert_eq!(mapped, expected);
              }


### PR DESCRIPTION
In `AsTypedSlice`, we assume that one may convert a `&[i32]` to a `&[u32]`. That works, unless any of the
`i32` being _reinterpreted_ are negative values. This was done in #763, but then a _mutable slice_ would not work either.
For now, we have to remove these, and only adopt them, when we can only implement a reference access, and said
reference access may only work on non-negative slices.

