### PR TITLE
fix: Added range-checking for integer slices

### DIFF
--- a/extendr-api/src/optional/ndarray.rs
+++ b/extendr-api/src/optional/ndarray.rs
@@ -117,20 +117,17 @@ macro_rules! make_array_view_2 {
 make_array_view_1!(Rbool, Error::ExpectedLogical);
 make_array_view_1!(Rint, Error::ExpectedInteger);
 make_array_view_1!(i32, Error::ExpectedInteger);
+make_array_view_1!(u32, Error::ExpectedInteger);
 make_array_view_1!(Rfloat, Error::ExpectedReal);
 make_array_view_1!(f64, Error::ExpectedReal);
 make_array_view_1!(Rcplx, Error::ExpectedComplex);
 make_array_view_1!(c64, Error::ExpectedComplex);
 make_array_view_1!(Rstr, Error::ExpectedString);
 
-// read-only
-make_array_view_1!(u32, Error::ExpectedInteger);
-make_array_view_1!(u64, Error::ExpectedInteger);
-make_array_view_1!(u128, Error::ExpectedInteger);
-
 make_array_view_2!(Rbool, "Not a logical matrix.", Error::ExpectedLogical);
 make_array_view_2!(Rint, "Not an integer matrix.", Error::ExpectedInteger);
 make_array_view_2!(i32, "Not an integer matrix.", Error::ExpectedInteger);
+make_array_view_2!(u32, "Not an integer matrix.", Error::ExpectedInteger);
 make_array_view_2!(Rfloat, "Not a floating point matrix.", Error::ExpectedReal);
 make_array_view_2!(f64, "Not a floating point matrix.", Error::ExpectedReal);
 make_array_view_2!(
@@ -140,11 +137,6 @@ make_array_view_2!(
 );
 make_array_view_2!(c64, "Not a complex number matrix.", Error::ExpectedComplex);
 make_array_view_2!(Rstr, "Not a string matrix.", Error::ExpectedString);
-
-// read-only
-make_array_view_2!(u32, "Not an integer matrix.", Error::ExpectedInteger);
-make_array_view_2!(u64, "Not an integer matrix.", Error::ExpectedInteger);
-make_array_view_2!(u128, "Not an integer matrix.", Error::ExpectedInteger);
 
 impl<A, S, D> TryFrom<&ArrayBase<S, D>> for Robj
 where

--- a/extendr-api/src/optional/ndarray.rs
+++ b/extendr-api/src/optional/ndarray.rs
@@ -4,7 +4,7 @@ Defines conversions between R objects and the [`ndarray`](https://docs.rs/ndarra
 To enable these conversions, you must first enable the `ndarray` feature for extendr:
 ```toml
 [dependencies]
-extendr-api = { version = "0.4", features = ["ndarray"] }
+extendr-api = { version = "0.6", features = ["ndarray"] }
 ```
 
 Specifically, extendr supports the following conversions:
@@ -62,7 +62,7 @@ use crate::prelude::{c64, dim_symbol, Rcplx, Rfloat, Rint};
 use crate::*;
 
 macro_rules! make_array_view_1 {
-    ($type: ty, $error_fn: expr) => {
+    ($type:ty, $error_fn:expr) => {
         impl<'a> TryFrom<&'_ Robj> for ArrayView1<'a, $type> {
             type Error = crate::Error;
 
@@ -86,7 +86,7 @@ macro_rules! make_array_view_1 {
 }
 
 macro_rules! make_array_view_2 {
-    ($type: ty, $error_str: expr, $error_fn: expr) => {
+    ($type:ty, $error_str:expr, $error_fn:expr) => {
         impl<'a> TryFrom<&'_ Robj> for ArrayView2<'a, $type> {
             type Error = crate::Error;
             fn try_from(robj: &Robj) -> Result<Self> {
@@ -117,17 +117,20 @@ macro_rules! make_array_view_2 {
 make_array_view_1!(Rbool, Error::ExpectedLogical);
 make_array_view_1!(Rint, Error::ExpectedInteger);
 make_array_view_1!(i32, Error::ExpectedInteger);
-make_array_view_1!(u32, Error::ExpectedInteger);
 make_array_view_1!(Rfloat, Error::ExpectedReal);
 make_array_view_1!(f64, Error::ExpectedReal);
 make_array_view_1!(Rcplx, Error::ExpectedComplex);
 make_array_view_1!(c64, Error::ExpectedComplex);
 make_array_view_1!(Rstr, Error::ExpectedString);
 
+// read-only
+make_array_view_1!(u32, Error::ExpectedInteger);
+make_array_view_1!(u64, Error::ExpectedInteger);
+make_array_view_1!(u128, Error::ExpectedInteger);
+
 make_array_view_2!(Rbool, "Not a logical matrix.", Error::ExpectedLogical);
 make_array_view_2!(Rint, "Not an integer matrix.", Error::ExpectedInteger);
 make_array_view_2!(i32, "Not an integer matrix.", Error::ExpectedInteger);
-make_array_view_2!(u32, "Not an integer matrix.", Error::ExpectedInteger);
 make_array_view_2!(Rfloat, "Not a floating point matrix.", Error::ExpectedReal);
 make_array_view_2!(f64, "Not a floating point matrix.", Error::ExpectedReal);
 make_array_view_2!(
@@ -137,6 +140,11 @@ make_array_view_2!(
 );
 make_array_view_2!(c64, "Not a complex number matrix.", Error::ExpectedComplex);
 make_array_view_2!(Rstr, "Not a string matrix.", Error::ExpectedString);
+
+// read-only
+make_array_view_2!(u32, "Not an integer matrix.", Error::ExpectedInteger);
+make_array_view_2!(u64, "Not an integer matrix.", Error::ExpectedInteger);
+make_array_view_2!(u128, "Not an integer matrix.", Error::ExpectedInteger);
 
 impl<A, S, D> TryFrom<&ArrayBase<S, D>> for Robj
 where


### PR DESCRIPTION
Second attempt at dealing with the issue brought up in #763, however, this time, we actually remove the ability
to write into unsigned integer slices, as they won't fit in R.

