### PR TITLE
`Rstr` as `ToVectorValue`

### DIFF
--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -706,13 +706,6 @@ impl From<Vec<Robj>> for Robj {
     }
 }
 
-impl From<Vec<Rstr>> for Robj {
-    /// Convert a vector of Rstr into strings.
-    fn from(val: Vec<Rstr>) -> Self {
-        Strings::from_values(val).into()
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::*;

--- a/extendr-api/src/robj/into_robj/repeat_into_robj.rs
+++ b/extendr-api/src/robj/into_robj/repeat_into_robj.rs
@@ -86,3 +86,49 @@ impl_synonym_type!(Rfloat, f64);
 impl_synonym_type!(&Rfloat, f64);
 impl_synonym_type!(Rint, i32);
 impl_synonym_type!(&Rint, i32);
+
+// since `Rstr` does not implement `Scalar` (due to lifetime conflicts), 
+// it requires manual implementation
+
+impl ToVectorValue for Rstr {
+    fn sexptype() -> SEXPTYPE {
+        SEXPTYPE::STRSXP
+    }
+
+    fn to_sexp(&self) -> SEXP
+    where
+        Self: Sized,
+    {
+        unsafe { self.robj.get() }
+    }
+}
+
+impl ToVectorValue for &Rstr {
+    fn sexptype() -> SEXPTYPE {
+        SEXPTYPE::STRSXP
+    }
+
+    fn to_sexp(&self) -> SEXP
+    where
+        Self: Sized,
+    {
+        unsafe { self.robj.get() }
+    }
+}
+
+impl ToVectorValue for Option<Rstr> {
+    fn sexptype() -> SEXPTYPE {
+        SEXPTYPE::STRSXP
+    }
+
+    fn to_sexp(&self) -> SEXP
+    where
+        Self: Sized,
+    {
+        if let Some(s) = self {
+            unsafe { s.robj.get() }
+        } else {
+            unsafe { R_NaString }
+        }
+    }
+}

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -248,7 +248,7 @@ pub trait Types: GetSexp {
     ///     assert_eq!(lang!("+", 1, 2).rtype(), Rtype::Language);
     ///     assert_eq!(r!(Primitive::from_string("if")).rtype(), Rtype::Special);
     ///     assert_eq!(r!(Primitive::from_string("+")).rtype(), Rtype::Builtin);
-    ///     assert_eq!(r!(Rstr::from_string("hello")).rtype(), Rtype::Rstr);
+    ///     assert_eq!(Rstr::from_string("hello").rtype(), Rtype::Rstr);
     ///     assert_eq!(r!(TRUE).rtype(), Rtype::Logicals);
     ///     assert_eq!(r!(1).rtype(), Rtype::Integers);
     ///     assert_eq!(r!(1.0).rtype(), Rtype::Doubles);

--- a/extendr-api/src/wrapper/mod.rs
+++ b/extendr-api/src/wrapper/mod.rs
@@ -175,7 +175,7 @@ make_conversions!(
 
 make_conversions!(Raw, ExpectedRaw, is_raw, "Not a raw object");
 
-make_conversions!(Rstr, ExpectedRstr, is_char, "Not a character object");
+make_getsexp!(Rstr, impl);
 
 make_conversions!(
     Environment,


### PR DESCRIPTION
Fixes #770 

- [ ] All `elt`, `set_elt`, even `index` (trait and function) need to be adjusted, as
extracting an element from a stringly-vector requires `STRING_ELT` and `SET_STRING_ELT`. This might cause a larger rewriting..