### PR TITLE
Update Makevars for integration test

### DIFF
--- a/tests/extendrtests/src/Makevars.win
+++ b/tests/extendrtests/src/Makevars.win
@@ -3,7 +3,7 @@ TARGET = $(subst 64,x86_64,$(subst 32,i686,$(WIN)))-pc-windows-gnu
 TARGET_DIR = ./rust/target
 LIBDIR = $(TARGET_DIR)/$(TARGET)/debug
 STATLIB = $(LIBDIR)/lextendrtest.a
-PKG_LIBS = -L$(LIBDIR) -lextendrtests -lws2_32 -ladvapi32 -luserenv -lbcrypt -lntdll
+PKG_LIBS = -L$(LIBDIR) -lextendrtests -lws2_32 -ladvapi32 -luserenv -lbcrypt -lntdll -lsynchronization
 
 all: C_clean
 


### PR DESCRIPTION
We found this file that describes how the linking should look like [`.mk` file for rust compiler tests](https://github.com/rust-lang/rust/blob/bf8fff783ff533c055d276378ada30563312def1/tests/run-make/tools.mk). 

There are other hints in this file, as to what to include, with other platforms.
Hopefully we can include those too.. 