### PR TITLE
Support `&mut Robj`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 - feature `non-api` that gives access to non-API items; Requires compile-time generation of bindings
 [[#754]](https://github.com/extendr/extendr/pull/754)
 - `TryFrom<&Robj>` for `StrIter`, `HashMap<K, Robj>` for `K = String` and `K = &str` [[#759]](https://github.com/extendr/extendr/pull/759)
+- Added conversion for `&mut Robj -> Robj` and `&mut List -> Robj`. [[#779]](https://github.com/extendr/extendr/pull/779)
+This adds the convenience, when `.set_class` / `.set_attrib` returns a mutable
+reference object, it may be converted to `Robj` / `List` via `into_robj()` (or `.into()` if type inference allows).
 
 ### Changed
 

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -143,10 +143,15 @@ impl From<Error> for String {
 
 /// Convert an Robj reference into a borrowed Robj.
 impl From<&Robj> for Robj {
-    // Note: we should probably have a much better reference
-    // mechanism as double-free or underprotection is a distinct possibility.
     fn from(val: &Robj) -> Self {
         unsafe { Robj::from_sexp(val.get()) }
+    }
+}
+
+/// Convert an Robj reference into a mutably borrowed Robj.
+impl From<&mut Robj> for Robj {
+    fn from(val: &mut Robj) -> Self {
+        unsafe { Robj::from_sexp(val.get_mut()) }
     }
 }
 
@@ -721,6 +726,7 @@ impl From<Vec<Rstr>> for Robj {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::prelude::test;
 
     #[test]
     fn test_vec_rint_to_robj() {

--- a/extendr-api/src/wrapper/mod.rs
+++ b/extendr-api/src/wrapper/mod.rs
@@ -96,11 +96,32 @@ macro_rules! make_conversions {
             }
         }
 
+        // We can convert a mutable reference to any wrapper to a Robj by cloning the robj pointer
+        impl From<&mut $typename> for Robj {
+            /// Make an robj from a wrapper.
+            fn from(val: &mut $typename) -> Self {
+                val.robj.to_owned()
+            }
+        }
+
         impl TryFrom<&Robj> for $typename {
             type Error = crate::Error;
 
             /// Make a wrapper from a robj if it matches.
             fn try_from(robj: &Robj) -> Result<Self> {
+                if robj.$isfunc() {
+                    Ok($typename { robj: robj.clone() })
+                } else {
+                    Err(Error::$errname(robj.clone()))
+                }
+            }
+        }
+
+        impl TryFrom<&mut Robj> for $typename {
+            type Error = crate::Error;
+
+            /// Make a wrapper from a robj if it matches.
+            fn try_from(robj: &mut Robj) -> Result<Self> {
                 if robj.$isfunc() {
                     Ok($typename { robj: robj.clone() })
                 } else {

--- a/extendr-api/tests/ref_mut_robj.rs
+++ b/extendr-api/tests/ref_mut_robj.rs
@@ -1,0 +1,25 @@
+use extendr_api::prelude::*;
+
+#[extendr]
+fn generate_model_object() -> Robj {
+    Robj::from(1).set_class(["ModelObject"]).unwrap().into()
+}
+
+#[extendr]
+fn generate_model_object_old() -> Robj {
+    let mut robj = Robj::from(1);
+    robj.set_class(["ModelObject"]).unwrap();
+    robj
+}
+
+#[extendr]
+fn generate_model_object_list() -> Robj {
+    List::new(3).set_class(["ModelObject"]).unwrap().into()
+}
+
+#[extendr]
+fn generate_model_object_list_old() -> Robj {
+    let mut robj = List::new(3);
+    robj.set_class(["ModelObject"]).unwrap();
+    robj.into_robj()
+}


### PR DESCRIPTION
Using `&mut Robj` is _new_ and I think stuff like the following wasn't added.

It needs to be implemented for all "Robj"-types, so that one may return `&mut Robj` from `extendr`-fn and it working out. **You can already do this with `&Robj`.**

## Motivation

Recent change to the API now uses `&mut Robj` as a _return-type_. It would improve user experience if users could do

```rust
#[extendr]
fn generate_model_object() -> Robj {
    Robj::from(1).set_class(["ModelObject"]).unwrap().into() 
    // or `.into_robj()`, but here, the type-inference is obvious to rustc
}
```
instead of what they have to do at the moment, which is
```rust
#[extendr]
fn generate_model_object_old() -> Robj {
    let mut robj = Robj::from(1);
    robj.set_class(["ModelObject"]).unwrap();
    robj
}
```