### PR TITLE
[error handling]: Don't panic in FFI boundary

### DIFF
--- a/extendr-api/src/thread_safety.rs
+++ b/extendr-api/src/thread_safety.rs
@@ -101,7 +101,8 @@ where
 
     unsafe extern "C" fn do_cleanup(_: *mut raw::c_void, jump: Rboolean) {
         if jump != Rboolean::FALSE {
-            panic!("R has thrown an error.");
+            let caught_panic = std::panic::catch_unwind(|| panic!("R has thrown an error."));
+            assert!(caught_panic.is_err(), "must panic to drop rust items")
         }
     }
 


### PR DESCRIPTION
As part of revising the way extendr handles panic, there is this tiny PR:
It is undefined behavior to panic in FFI boundary. The reason we want to panic, is to drop / clean rust resources.
If one panics within a `catch_unwind`, then everything is dropped nice and easy.

_An aside_ `catch_r_error` is not used often in extendr, but it could very well be.