### PR TITLE
[urgent] fix: relying on specific behavior for `List::iter`

### DIFF
--- a/extendr-api/src/iter.rs
+++ b/extendr-api/src/iter.rs
@@ -78,7 +78,7 @@ impl Iterator for StrIter {
             if i >= self.len {
                 None
             } else if TYPEOF(vector) == SEXPTYPE::NILSXP {
-                None
+                Some(<&str>::na())
             } else if TYPEOF(vector) == SEXPTYPE::STRSXP {
                 str_from_strsxp(vector, i)
             } else if TYPEOF(vector) == SEXPTYPE::CHARSXP {
@@ -222,13 +222,20 @@ mod tests {
         with_r(|| {
             let single_charsxp = blank_string();
             let s1: Vec<_> = single_charsxp.as_str_iter().unwrap().collect();
-            // dbg!(&s1);
             let single_charsxp = blank_scalar_string();
             let s2: Vec<_> = single_charsxp.as_str_iter().unwrap().collect();
-            // dbg!(&s2);
             assert_eq!(s1, s2);
             assert_eq!(s1.len(), 1);
             assert_eq!(s2.len(), 1);
+        });
+    }
+
+    #[test]
+    fn test_new_constructor() {
+        with_r(|| {
+            let str_iter = StrIter::new(10);
+
+            assert_eq!(str_iter.collect::<Vec<_>>().len(), 10);
         });
     }
 }

--- a/extendr-api/tests/into_iterator_tests.rs
+++ b/extendr-api/tests/into_iterator_tests.rs
@@ -5,6 +5,7 @@ use extendr_engine::with_r;
 fn iterating_unamed_list() {
     with_r(|| {
         let unamed_list = List::from_values([1, 2, 3, 42, 100]);
+        assert_eq!(unamed_list.names(), None);
         assert_eq!(unamed_list.iter().len(), 5);
         let unamed_list = List::from_values::<[i32; 0]>([]);
         assert_eq!(unamed_list.iter().len(), 0);

--- a/extendr-api/tests/into_iterator_tests.rs
+++ b/extendr-api/tests/into_iterator_tests.rs
@@ -1,0 +1,14 @@
+use extendr_api::prelude::*;
+use extendr_engine::with_r;
+
+#[test]
+fn iterating_unamed_list() {
+    with_r(|| {
+        let unamed_list = List::from_values([1, 2, 3, 42, 100]);
+        assert_eq!(unamed_list.iter().len(), 5);
+        let unamed_list = List::from_values::<[i32; 0]>([]);
+        assert_eq!(unamed_list.iter().len(), 0);
+
+        dbg!(unamed_list.iter().collect::<Vec<_>>());
+    });
+}

--- a/extendr-api/tests/into_iterator_tests.rs
+++ b/extendr-api/tests/into_iterator_tests.rs
@@ -5,11 +5,18 @@ use extendr_engine::with_r;
 fn iterating_unamed_list() {
     with_r(|| {
         let unamed_list = List::from_values([1, 2, 3, 42, 100]);
-        assert_eq!(unamed_list.names(), None);
+        assert!(unamed_list.names().is_none());
         assert_eq!(unamed_list.iter().len(), 5);
+
+        let empty_strings = unamed_list.iter().map(|(si, _)| si).collect::<Strings>();
+        let na_strs = (0..5).into_iter().map(|_| Rstr::na()).collect::<Strings>();
+        assert_eq!(empty_strings, na_strs);
+
+        dbg!(empty_strings, na_strs);
+
         let unamed_list = List::from_values::<[i32; 0]>([]);
         assert_eq!(unamed_list.iter().len(), 0);
 
-        dbg!(unamed_list.iter().collect::<Vec<_>>());
+        assert!(unamed_list.iter().collect::<Vec<_>>().is_empty());
     });
 }

--- a/extendr-api/tests/into_iterator_tests.rs
+++ b/extendr-api/tests/into_iterator_tests.rs
@@ -12,8 +12,6 @@ fn iterating_unamed_list() {
         let na_strs = (0..5).into_iter().map(|_| Rstr::na()).collect::<Strings>();
         assert_eq!(empty_strings, na_strs);
 
-        dbg!(empty_strings, na_strs);
-
         let unamed_list = List::from_values::<[i32; 0]>([]);
         assert_eq!(unamed_list.iter().len(), 0);
 


### PR DESCRIPTION
Discovered by @kbvernon: We removed this behaviour in #761, but it is used in `List::iter`. Basically, a `StrIter` can be initiated without any strings.

This points to `StrIter` being overloaded already, but we have to fix this bug sooner rather than later.

Here's the fix.