### PR TITLE
Add: Checked conversion to `&[u32]` and `Vec<u32>` from integer vector

### DIFF
--- a/extendr-api/src/error.rs
+++ b/extendr-api/src/error.rs
@@ -88,6 +88,9 @@ pub enum Error {
 
     #[cfg(feature = "either")]
     EitherError(Box<Error>, Box<Error>),
+
+    // used in &[u32] conversion
+    ExpectedNonNegativeValue,
 }
 
 impl std::fmt::Display for Error {
@@ -191,6 +194,9 @@ impl std::fmt::Display for Error {
                     left_err, right_err
                 )
             }
+            Error::ExpectedNonNegativeValue => write!(
+                f, "expected vector of non-negative values"
+            )
         }
     }
 }

--- a/extendr-api/src/error.rs
+++ b/extendr-api/src/error.rs
@@ -194,9 +194,7 @@ impl std::fmt::Display for Error {
                     left_err, right_err
                 )
             }
-            Error::ExpectedNonNegativeValue => write!(
-                f, "expected vector of non-negative values"
-            )
+            Error::ExpectedNonNegativeValue => write!(f, "expected vector of non-negative values"),
         }
     }
 }

--- a/extendr-api/src/robj/try_from_robj.rs
+++ b/extendr-api/src/robj/try_from_robj.rs
@@ -353,6 +353,34 @@ impl TryFrom<&Robj> for &[f64] {
     }
 }
 
+impl TryFrom<&Robj> for &[u32] {
+    type Error = Error;
+
+    /// Returns a slice by reference, if the underlying `&[i32]` values are
+    /// all non-negative.
+    fn try_from(value: &Robj) -> Result<Self> {
+        let integer_slice: Option<&[i32]> = value.as_typed_slice();
+        if let Some(value) = integer_slice {
+            let any_negative = value.iter().any(|x| x.is_negative());
+            if any_negative {
+                return Err(Error::ExpectedNonNegativeValue);
+            }
+            Ok(unsafe { std::mem::transmute(integer_slice) })
+        } else {
+            Err(Error::ExpectedInteger(value.clone()))
+        }
+    }
+}
+
+impl TryFrom<&Robj> for Vec<u32> {
+    type Error = Error;
+
+    fn try_from(value: &Robj) -> Result<Self> {
+        let slice: &[u32] = value.try_into()?;
+        Ok(Vec::from(slice))
+    }
+}
+
 impl TryFrom<&Robj> for Rcplx {
     type Error = Error;
 


### PR DESCRIPTION
#768 was rejected, because adding run-time checks to `AsTypedSlice` would break the promise that providing a slice would entail. 

Due to #788, and since `faer` only support `u32`/`u64`, it seems reasonable to provide safe conversions to atleast `u32`.

I believe `TryFrom` does not signal zero-checked conversion -- actually the opposite.

Therefore, I propose this addition: This conversion has a slight run-time cost for checking non-negative numbers, but does provide access to the underlying values by-reference without copying.