### PR TITLE
Bug fix: Don't use `libR_sys` in macros

### DIFF
--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -430,6 +430,14 @@ pub use libR_sys::DllInfo;
 #[doc(hidden)]
 pub use libR_sys::R_ExternalPtrAddr;
 
+/// This is used in `#[extendr(use_rng = true)]` on `fn`-items.
+#[doc(hidden)]
+pub use libR_sys::GetRNGstate;
+
+/// This is used in `#[extendr(use_rng = true)]` on `fn`-items.
+#[doc(hidden)]
+pub use libR_sys::PutRNGstate;
+
 #[doc(hidden)]
 pub use libR_sys::SEXP;
 

--- a/extendr-macros/src/wrappers.rs
+++ b/extendr-macros/src/wrappers.rs
@@ -141,7 +141,7 @@ pub(crate) fn make_function_wrappers(
         .use_rng
         .then(|| {
             quote!(single_threaded(|| unsafe {
-                libR_sys::GetRNGstate();
+                extendr_api::GetRNGstate();
             });)
         })
         .unwrap_or_default();
@@ -149,7 +149,7 @@ pub(crate) fn make_function_wrappers(
         .use_rng
         .then(|| {
             quote!(single_threaded(|| unsafe {
-                libR_sys::PutRNGstate();
+                extendr_api::PutRNGstate();
             });)
         })
         .unwrap_or_default();


### PR DESCRIPTION
Fixes #786 