### PR TITLE
Remove `libR-sys` from extendrtests permanently

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -204,16 +204,10 @@ jobs:
             cat('level=warning', file = output, append = TRUE)
           }
         shell: Rscript {0}
-      
-      - name: DEBUG CI
-        run: |
-          R CMD config --version
-        shell: bash
 
       - name: Run R integration tests using {extendrtests} and `cargo extendr r-cmd-check`
         run: |
           cargo extendr r-cmd-check --error-on ${{ steps.error-on.outputs.level }} --check-dir extendrtests_check
-        shell: bash
       - name: Upload `check-dir` if r-cmd-check failed on `{extendrtests}`
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -206,7 +206,6 @@ jobs:
         shell: Rscript {0}
 
       - name: Run R integration tests using {extendrtests} and `cargo extendr r-cmd-check`
-        id: id_cargo_r_cmd_check
         run: |
           cargo extendr r-cmd-check --error-on ${{ steps.error-on.outputs.level }} --check-dir extendrtests_check
       - name: Upload `check-dir` if r-cmd-check failed on `{extendrtests}`
@@ -381,7 +380,7 @@ jobs:
           echo "LD_LIBRARY_PATH=$(R -s -e 'cat(normalizePath(R.home()))')/lib" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       # 1. Retrieve targets
-      # 2. Retrieve 'libcalng' paths
+      # 2. Retrieve 'libclang' paths
       # 3. For each target run
       # 3.1 Select correct $target & $toolchain
       # 3.x Run build commands, checking for errors, providing explicit toolchain & target

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -204,6 +204,10 @@ jobs:
             cat('level=warning', file = output, append = TRUE)
           }
         shell: Rscript {0}
+      
+      - name: DEBUG CI
+        run: |
+          R CMD config --version
 
       - name: Run R integration tests using {extendrtests} and `cargo extendr r-cmd-check`
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -208,10 +208,12 @@ jobs:
       - name: DEBUG CI
         run: |
           R CMD config --version
+        shell: bash
 
       - name: Run R integration tests using {extendrtests} and `cargo extendr r-cmd-check`
         run: |
           cargo extendr r-cmd-check --error-on ${{ steps.error-on.outputs.level }} --check-dir extendrtests_check
+        shell: bash
       - name: Upload `check-dir` if r-cmd-check failed on `{extendrtests}`
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4

--- a/tests/extendrtests/src/rust/Cargo.toml
+++ b/tests/extendrtests/src/rust/Cargo.toml
@@ -23,7 +23,7 @@ faer = "0.18.0"
 ## This is configured to work with RStudio features.
 ## Replace by absolute path to simplify testing.
 ## CI overrides this path.
-extendr-api = { path = "../../../../../extendr-main/extendr-api" }
+extendr-api = { path = "../../../../../../../extendr/extendr-api" }
 ## This allows to run `rcmdcheck` from `./tests/extendrtests/`
 # extendr-api = { path = "../../../../../../../../../extendr/extendr-api"}
 

--- a/tests/extendrtests/src/rust/Cargo.toml
+++ b/tests/extendrtests/src/rust/Cargo.toml
@@ -19,15 +19,11 @@ crate-type = ["staticlib"]
 extendr-api = { version = "*", features = ["graphics", "ndarray", "faer", "either"] }
 faer = "0.18.0"
 
-# TODO: I couldn't find any nice way to add the condition based on the R version
-# except for using libR-sys just for "DEP_R_*" envvars.
-libR-sys = "*"
-
 [patch.crates-io]
 ## This is configured to work with RStudio features.
 ## Replace by absolute path to simplify testing.
 ## CI overrides this path.
-extendr-api = { path = "../../../../../../../extendr/extendr-api" }
+extendr-api = { path = "../../../../../extendr-main/extendr-api" }
 ## This allows to run `rcmdcheck` from `./tests/extendrtests/`
 # extendr-api = { path = "../../../../../../../../../extendr/extendr-api"}
 
@@ -36,5 +32,3 @@ extendr-api = { path = "../../../../../../../extendr/extendr-api" }
 ## for development work.
 #extendr-api = { git = "https://github.com/extendr/extendr"}
 
-# Build against current libR-sys version on github
-libR-sys = { git = "https://github.com/extendr/libR-sys", rev = "09d76ada0cd54aa4481d9f06bbdfa50bcca2814a" }

--- a/tests/extendrtests/src/rust/build.rs
+++ b/tests/extendrtests/src/rust/build.rs
@@ -1,8 +1,4 @@
 fn main() {
-    // TODO: I couldn't find any nice way to add the condition based on the R version
-    // except for using libR-sys just for "DEP_R_*" envvars.
-    // let major = std::env::var("DEP_R_R_VERSION_MAJOR").unwrap();
-    // let minor = std::env::var("DEP_R_R_VERSION_MINOR").unwrap();
     let mut major = 0;
     let mut minor = 0;
     let mut _patch = 0;
@@ -33,6 +29,9 @@ fn main() {
         minor = raw_r_version[1];
         _patch = raw_r_version[2];
     }
+    let major = major;
+    let minor = minor;
+    let _patch = _patch;
     // dbg!(major, minor);
 
     if major >= 4 && minor >= 3 {

--- a/tests/extendrtests/src/rust/build.rs
+++ b/tests/extendrtests/src/rust/build.rs
@@ -9,7 +9,7 @@ fn main() {
 
     // prefer `R_HOME` if set, otherwise use the `PATH` available R
     let mut path_to_r = if let Some(r_home_env) = r_home_env {
-        std::process::Command::new(r_home_env.join("R"))
+        std::process::Command::new(r_home_env.join("bin/R"))
     } else {
         std::process::Command::new("R")
     };

--- a/tests/extendrtests/src/rust/build.rs
+++ b/tests/extendrtests/src/rust/build.rs
@@ -1,38 +1,53 @@
+use std::path::PathBuf;
+
 fn main() {
-    let mut major = 0;
-    let mut minor = 0;
-    let mut _patch = 0;
-    let r_version = std::process::Command::new("R")
+    println!("cargo:rerun-if-env-changed=R_HOME");
+    println!("cargo::rerun-if-changed=build.rs");
+
+    let r_home_env = std::env::var_os("R_HOME");
+    let r_home_env = r_home_env.map(PathBuf::from);
+
+    // prefer `R_HOME` if set, otherwise use the `PATH` available R
+    let mut r_version = if let Some(r_home_env) = r_home_env {
+        std::process::Command::new(r_home_env.join("R"))
+    } else {
+        std::process::Command::new("R")
+    };
+    let r_version = r_version
         .arg("CMD")
         .args(["config", "--version"])
         .output()
-        .unwrap();
+        .expect("failed to run `R CMD config --version`");
     assert!(r_version.status.success());
-
     use std::io::BufRead as _;
-    if let Some(Ok(r_version_line)) = r_version.stdout.lines().next() {
-        let raw_r_version = r_version_line
-            .split(':')
-            .nth(1)
-            .unwrap()
-            .trim()
-            // ignore commit
-            // only capture the first the major.minor.patch part of the version
-            .split_ascii_whitespace()
-            .next()
-            .unwrap();
-        let raw_r_version: Vec<u32> = raw_r_version
-            .split('.')
-            .map(|x| x.parse().unwrap())
-            .collect();
-        major = raw_r_version[0];
-        minor = raw_r_version[1];
-        _patch = raw_r_version[2];
-    }
-    let major = major;
-    let minor = minor;
-    let _patch = _patch;
-    // dbg!(major, minor);
+    let r_version_line = r_version
+        .stdout
+        .lines()
+        .next()
+        .expect("there were no outputs from `R CMD config`")
+        .expect("failed to read the line with R version");
+    let raw_r_version = r_version_line
+        .split(':')
+        .nth(1)
+        .unwrap()
+        .trim()
+        // ignore commit
+        // only capture the first the major.minor.patch part of the version
+        .split_ascii_whitespace()
+        .next()
+        .unwrap();
+    dbg!(raw_r_version);
+    let raw_r_version: Vec<u32> = raw_r_version
+        .split('.')
+        .map(|x| x.parse().unwrap())
+        .collect();
+    let major = raw_r_version[0];
+    let minor = raw_r_version[1];
+    let patch = raw_r_version[2];
+
+    println!("cargo:r_version_major={}", major); // Becomes DEP_R_R_VERSION_MAJOR
+    println!("cargo:r_version_minor={}", minor); // Becomes DEP_R_R_VERSION_MINOR
+    println!("cargo:r_version_patch={}", patch); // Becomes DEP_R_R_VERSION_PATCH
 
     if major >= 4 && minor >= 3 {
         println!("cargo:rustc-cfg=use_r_altlist");

--- a/tests/extendrtests/src/rust/build.rs
+++ b/tests/extendrtests/src/rust/build.rs
@@ -42,7 +42,7 @@ fn main() {
         .collect();
     assert!(
         raw_r_version.len() >= 3,
-        "rust version was not detected properly"
+        "R version was not detected properly"
     );
     let major = raw_r_version[0];
     let minor = raw_r_version[1];

--- a/tests/extendrtests/src/rust/build.rs
+++ b/tests/extendrtests/src/rust/build.rs
@@ -8,12 +8,12 @@ fn main() {
     let r_home_env = r_home_env.map(PathBuf::from);
 
     // prefer `R_HOME` if set, otherwise use the `PATH` available R
-    let mut r_version = if let Some(r_home_env) = r_home_env {
+    let mut path_to_r = if let Some(r_home_env) = r_home_env {
         std::process::Command::new(r_home_env.join("R"))
     } else {
         std::process::Command::new("R")
     };
-    let r_version = r_version
+    let r_version = path_to_r
         .arg("CMD")
         .args(["config", "--version"])
         .output()
@@ -36,11 +36,14 @@ fn main() {
         .split_ascii_whitespace()
         .next()
         .unwrap();
-    dbg!(raw_r_version);
     let raw_r_version: Vec<u32> = raw_r_version
         .split('.')
         .map(|x| x.parse().unwrap())
         .collect();
+    assert!(
+        raw_r_version.len() >= 3,
+        "rust version was not detected properly"
+    );
     let major = raw_r_version[0];
     let minor = raw_r_version[1];
     let patch = raw_r_version[2];
@@ -52,5 +55,4 @@ fn main() {
     if major >= 4 && minor >= 3 {
         println!("cargo:rustc-cfg=use_r_altlist");
     }
-    assert_ne!(major, 0, "rust version was not detected properly");
 }

--- a/tests/extendrtests/src/rust/build.rs
+++ b/tests/extendrtests/src/rust/build.rs
@@ -1,12 +1,42 @@
-use std::env;
-
 fn main() {
     // TODO: I couldn't find any nice way to add the condition based on the R version
     // except for using libR-sys just for "DEP_R_*" envvars.
-    let major = env::var("DEP_R_R_VERSION_MAJOR").unwrap();
-    let minor = env::var("DEP_R_R_VERSION_MINOR").unwrap();
+    // let major = std::env::var("DEP_R_R_VERSION_MAJOR").unwrap();
+    // let minor = std::env::var("DEP_R_R_VERSION_MINOR").unwrap();
+    let mut major = 0;
+    let mut minor = 0;
+    let mut _patch = 0;
+    let r_version = std::process::Command::new("R")
+        .arg("CMD")
+        .args(["config", "--version"])
+        .output()
+        .unwrap();
+    assert!(r_version.status.success());
 
-    if &*major >= "4" && &*minor >= "3" {
+    use std::io::BufRead as _;
+    if let Some(Ok(r_version_line)) = r_version.stdout.lines().next() {
+        let raw_r_version = r_version_line
+            .split(':')
+            .nth(1)
+            .unwrap()
+            .trim()
+            // ignore commit
+            // only capture the first the major.minor.patch part of the version
+            .split_ascii_whitespace()
+            .next()
+            .unwrap();
+        let raw_r_version: Vec<u32> = raw_r_version
+            .split('.')
+            .map(|x| x.parse().unwrap())
+            .collect();
+        major = raw_r_version[0];
+        minor = raw_r_version[1];
+        _patch = raw_r_version[2];
+    }
+    // dbg!(major, minor);
+
+    if major >= 4 && minor >= 3 {
         println!("cargo:rustc-cfg=use_r_altlist");
     }
+    assert_ne!(major, 0, "rust version was not detected properly");
 }


### PR DESCRIPTION
Fixes #787 

As agreed, we now prefer `R_HOME` in `tests/extendrtests` or if R is available from `PATH`.

It is reasonable enough, to assume that the contributors to extendR, will have configured their terminal to have R available there.  