### PR TITLE
Less ambigious return type for colnames/rownames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Changed
 
+- Breaking change: `RMatrix::get_rownames` and `RMatrix::get_colnames` now both
+return `Option<Strings>` instead of opaque `Robj`.
+[[#801]](https://github.com/extendr/extendr/pull/790)
+
 ### Fixed
 
 ### Deprecated

--- a/extendr-api/src/wrapper/matrix.rs
+++ b/extendr-api/src/wrapper/matrix.rs
@@ -123,7 +123,7 @@ impl<T> RMatrix<T> {
                     let colnames = Robj::from_sexp(maybe_colnames);
                     Some(std::mem::transmute(colnames))
                 }
-                _ => unreachable!(),
+                _ => unreachable!("This should not have occurred. Please report an error at https://github.com/extendr/extendr/issues"),
             }
         }
     }
@@ -136,7 +136,7 @@ impl<T> RMatrix<T> {
                     let rownames = Robj::from_sexp(maybe_rownames);
                     Some(std::mem::transmute(rownames))
                 }
-                _ => unreachable!(),
+                _ => unreachable!("This should not have occurred. Please report an error at https://github.com/extendr/extendr/issues"),
             }
         }
     }

--- a/extendr-api/src/wrapper/matrix.rs
+++ b/extendr-api/src/wrapper/matrix.rs
@@ -114,13 +114,31 @@ where
 }
 
 impl<T> RMatrix<T> {
-    pub fn get_colnames(&self) -> Robj {
-        let colnames = Robj::from_sexp(unsafe { Rf_GetColNames(Rf_GetArrayDimnames(self.get())) });
-        colnames
+    pub fn get_colnames(&self) -> Option<Strings> {
+        unsafe {
+            let maybe_colnames = Rf_GetColNames(Rf_GetArrayDimnames(self.get()));
+            match TYPEOF(maybe_colnames) {
+                SEXPTYPE::NILSXP => None,
+                SEXPTYPE::STRSXP => {
+                    let colnames = Robj::from_sexp(maybe_colnames);
+                    Some(std::mem::transmute(colnames))
+                }
+                _ => unreachable!(),
+            }
+        }
     }
-    pub fn get_rownames(&self) -> Robj {
-        let rownames = Robj::from_sexp(unsafe { Rf_GetRowNames(Rf_GetArrayDimnames(self.get())) });
-        rownames
+    pub fn get_rownames(&self) -> Option<Strings> {
+        unsafe {
+            let maybe_rownames = Rf_GetRowNames(Rf_GetArrayDimnames(self.get()));
+            match TYPEOF(maybe_rownames) {
+                SEXPTYPE::NILSXP => None,
+                SEXPTYPE::STRSXP => {
+                    let rownames = Robj::from_sexp(maybe_rownames);
+                    Some(std::mem::transmute(rownames))
+                }
+                _ => unreachable!(),
+            }
+        }
     }
 }
 

--- a/extendr-api/src/wrapper/strings.rs
+++ b/extendr-api/src/wrapper/strings.rs
@@ -148,3 +148,12 @@ impl std::fmt::Debug for Strings {
         }
     }
 }
+
+impl From<Option<Strings>> for Robj {
+    fn from(value: Option<Strings>) -> Self {
+        match value {
+            Some(value_strings) => value_strings.into(),
+            None => nil_value(),
+        }
+    }
+}

--- a/tests/extendrtests/src/rust/src/matrix.rs
+++ b/tests/extendrtests/src/rust/src/matrix.rs
@@ -6,12 +6,12 @@ fn fetch_dimnames(x: RMatrix<f64>) -> List {
 }
 
 #[extendr]
-fn fetch_rownames(x: RMatrix<f64>) -> Robj {
+fn fetch_rownames(x: RMatrix<f64>) -> Option<Strings> {
     x.get_rownames()
 }
 
 #[extendr]
-fn fetch_colnames(x: RMatrix<f64>) -> Robj {
+fn fetch_colnames(x: RMatrix<f64>) -> Option<Strings> {
     x.get_colnames()
 }
 

--- a/tests/extendrtests/tests/testthat/_snaps/macro-snapshot.md
+++ b/tests/extendrtests/tests/testthat/_snaps/macro-snapshot.md
@@ -2611,7 +2611,7 @@
                       hidden: false,
                   })
           }
-          fn fetch_rownames(x: RMatrix<f64>) -> Robj {
+          fn fetch_rownames(x: RMatrix<f64>) -> Option<Strings> {
               x.get_rownames()
           }
           #[no_mangle]
@@ -2691,12 +2691,12 @@
                       r_name: "fetch_rownames",
                       mod_name: "fetch_rownames",
                       args: args,
-                      return_type: "Robj",
+                      return_type: "Option",
                       func_ptr: wrap__fetch_rownames as *const u8,
                       hidden: false,
                   })
           }
-          fn fetch_colnames(x: RMatrix<f64>) -> Robj {
+          fn fetch_colnames(x: RMatrix<f64>) -> Option<Strings> {
               x.get_colnames()
           }
           #[no_mangle]
@@ -2776,7 +2776,7 @@
                       r_name: "fetch_colnames",
                       mod_name: "fetch_colnames",
                       args: args,
-                      return_type: "Robj",
+                      return_type: "Option",
                       func_ptr: wrap__fetch_colnames as *const u8,
                       hidden: false,
                   })


### PR DESCRIPTION
Follow-up to #796

Instead of returning `Robj`, we should aim to be more descriptive of the returned result. For `colnames`/`rownames` it is a bit obvious that it should be `NULL` or a character vector.

_This uncovered something_ that our vector types `Integers`, `Doubles` etc. are not implemented for `From<Robj> for Option<r-vector-type>`. That could be a follow-up to this.

- [ ] Partial dependence on #802.