### PR TITLE
[internal] Adjust path for `extendrtests` 

### DIFF
--- a/tests/extendrtests/src/rust/Cargo.toml
+++ b/tests/extendrtests/src/rust/Cargo.toml
@@ -23,7 +23,7 @@ faer = "0.18.0"
 ## This is configured to work with RStudio features.
 ## Replace by absolute path to simplify testing.
 ## CI overrides this path.
-extendr-api = { path = "../../../../../../../extendr/extendr-api" }
+extendr-api = { path = "../../../../extendr-api" }
 ## This allows to run `rcmdcheck` from `./tests/extendrtests/`
 # extendr-api = { path = "../../../../../../../../../extendr/extendr-api"}
 


### PR DESCRIPTION
The path in `tests/extendrtests/src/rust/Cargo.toml` is very obscure.

I don't know who it serves.

With `xtask`, we adjust this in a process, to make it work with `devtools` and `rcmdcheck`.

Now, I ask that we merge this, so that it works when one is developing extendr, in the repository as workspace/working-directory, and when in vscode,

```json
{
    "rust-analyzer.linkedProjects": [
        "tests/extendrtests/src/rust/Cargo.toml",
    ]
}
```

I ask you to merge this as soon as possible, because I'm tired of things being set in an unhelpful way.