### PR TITLE
Add tests for extendr features

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -207,9 +207,10 @@ jobs:
           foreach($target in ($env:BUILD_TARGETS).Split(',')) {
             $features = ${{ matrix.config.features }}
             if (-eq $features "full-functionality") {
-              $testArgs += "--test-threads=1"
+               $testArgs += "--test-threads=1"
             }
-            ci-cargo test --features ${{ matrix.config.features }} $(if($target -ne 'default') {"--target=$target"} ) @( $testArgs ) '--' --nocapture -ActionName "Testing for $target target"
+            # Note: no feature is specified, which means such features like graphics, serde, ndarray, and num-complex are not tested here.
+            ci-cargo test --features ${{ matrix.config.features }} @( $testArgs ) $(if($target -ne 'default') {"--target=$target"} ) '--' --nocapture -ActionName "Testing for $target target"
           }
 
       # c.f. https://github.com/actions/checkout#checkout-multiple-repos-side-by-side

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,7 +210,7 @@ jobs:
                $testArgs += "--test-threads=1"
             }
             # Note: no feature is specified, which means such features like graphics, serde, ndarray, and num-complex are not tested here.
-            ci-cargo test --features ${{ matrix.config.features }} @( $testArgs ) $(if($target -ne 'default') {"--target=$target"} ) '--' --nocapture -ActionName "Testing for $target target"
+            ci-cargo test --features ${{ matrix.config.features }} $(if($target -ne 'default') {"--target=$target"} ) '--' --nocapture @( $testArgs ) -ActionName "Testing for $target target"
           }
 
       # c.f. https://github.com/actions/checkout#checkout-multiple-repos-side-by-side

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -205,8 +205,11 @@ jobs:
         run: |
           . ./ci-cargo.ps1
           foreach($target in ($env:BUILD_TARGETS).Split(',')) {
-            # Note: no feature is specified, which means such features like graphics, serde, ndarray, and num-complex are not tested here.
-            ci-cargo test --features ${{ matrix.config.features }} $(if($target -ne 'default') {"--target=$target"} ) '--' --nocapture -ActionName "Testing for $target target"
+            $features = ${{ matrix.config.features }}
+            if (-eq $features "full-functionality") {
+              $testArgs += "--test-threads=1"
+            }
+            ci-cargo test --features ${{ matrix.config.features }} $(if($target -ne 'default') {"--target=$target"} ) @( $testArgs ) '--' --nocapture -ActionName "Testing for $target target"
           }
 
       # c.f. https://github.com/actions/checkout#checkout-multiple-repos-side-by-side

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,36 +29,56 @@ jobs:
               r: "release",
               rust-version: "stable-msvc",
               rtools-version: "44",
+              features: "full-functionality",
             }
           - {
               os: windows-latest,
               r: "devel",
               rust-version: "stable-msvc",
               rtools-version: "44",
+              features: "default",
             }
           - {
               os: windows-latest,
               r: "oldrel",
               rust-version: "stable-msvc",
               rtools-version: "43",
+              features: "default",
             }
 
-          - { os: macOS-latest, r: "release", rust-version: "stable" }
+          - {
+              os: macOS-latest,
+              r: "release",
+              rust-version: "stable",
+              features: "full-functionality",
+            }
           - {
               os: ubuntu-latest,
               r: "release",
               rust-version: "stable",
+              features: "full-functionality",
               check_fmt: true,
             }
           - {
               os: ubuntu-latest,
               r: "release",
               rust-version: "nightly",
+              features: "full-functionality",
               extra-args: ["-Zdoctest-xcompile"],
             }
           # R-devel requires LD_LIBRARY_PATH
-          - { os: ubuntu-latest, r: "devel", rust-version: "stable" }
-          - { os: ubuntu-latest, r: "oldrel", rust-version: "stable" }
+          - {
+              os: ubuntu-latest,
+              r: "devel",
+              rust-version: "stable",
+              features: "default",
+            }
+          - {
+              os: ubuntu-latest,
+              r: "oldrel",
+              rust-version: "stable",
+              features: "default",
+            }
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
@@ -186,7 +206,7 @@ jobs:
           . ./ci-cargo.ps1
           foreach($target in ($env:BUILD_TARGETS).Split(',')) {
             # Note: no feature is specified, which means such features like graphics, serde, ndarray, and num-complex are not tested here.
-            ci-cargo test $(if($target -ne 'default') {"--target=$target"} ) '--' --nocapture -ActionName "Testing for $target target"
+            ci-cargo test --features ${{ matrix.config.features }} $(if($target -ne 'default') {"--target=$target"} ) '--' --nocapture -ActionName "Testing for $target target"
           }
 
       # c.f. https://github.com/actions/checkout#checkout-multiple-repos-side-by-side

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -205,8 +205,8 @@ jobs:
         run: |
           . ./ci-cargo.ps1
           foreach($target in ($env:BUILD_TARGETS).Split(',')) {
-            $features = ${{ matrix.config.features }}
-            if (-eq $features "full-functionality") {
+            $features = "${{ matrix.config.features }}"
+            if ($features -eq "full-functionality") {
                $testArgs += "--test-threads=1"
             }
             # Note: no feature is specified, which means such features like graphics, serde, ndarray, and num-complex are not tested here.


### PR DESCRIPTION
In PR #812 we removed CI that builds bindgen bindings. However, these tests were actually also secretly testing each feature of extendr. 

This PR modifies the `matrix.config` to add a `features` section to make it explicit which features are being tested.
