### PR TITLE
Internals fix: properly process attributes in wrappers

### DIFF
--- a/extendr-macros/src/wrappers.rs
+++ b/extendr-macros/src/wrappers.rs
@@ -38,7 +38,7 @@ pub const WRAP_PREFIX: &str = "wrap__";
 ///
 /// It also processes (and removes) attributes on the [`Signature`] provided, e.g.
 ///
-/// - `fn foo(#[extendr(default = "NULL")]` arg1: Robj)` will be processed.
+/// - `fn foo(#[default = "NULL"]` arg1: Robj)` will be processed.
 ///
 /// [`Signature`]: syn::Signature
 ///


### PR DESCRIPTION
## Background
Derive macros are meant to accept items with annotations, and then remove them, as the macro processes the items.

In `#[extendr]`-`fn` for instance, we allow `#[default = "42"]` in front of function arguments. That means
that after the wrapper-generation is done, this attribute needs to be removed, from the resulting function, as the attribute itself is actually invalid Rust code.

```rs
#[extendr] fn foo(#[default = "42") arg1: Rint) {} // compiles!

// `foo` is left without the attribute
fn foo(arg1: Rint) {}  // compiles!

// otherwise:
fn foo(#[default = "42") arg1: Rint) {}  // DOES NOT COMPILE
```
That's because our `#[extendr]` macro spits out the rust function as is, and produces a `extern "C" fn` next to it, that is used by R. 

## Description

There is a bug in current implementation, that is if we used multiple macros, that had other attributes on arguments, we would remove all those that came after our `#[default = "NULL"]` attribute. 


