### PR TITLE
Documentation: Adjusting `README` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# extendr - A safe and user friendly R extension interface using Rust
+# `extendr` - A safe and user friendly R extension interface using Rust
 
 [![Github Actions Build Status](https://github.com/extendr/extendr/workflows/Tests/badge.svg)](https://github.com/extendr/extendr/actions)
 [![Crates.io](https://img.shields.io/crates/v/extendr-api.svg)](https://crates.io/crates/extendr-api)
@@ -8,7 +8,7 @@
 
 [![Logo](https://github.com/extendr/extendr/raw/master/extendr-logo-256.png)](https://github.com/extendr/extendr/raw/master/extendr-logo-256.png)
 
-## Welcome!
+## Welcome
 
 extendR is a suite of software packages, see the website [extendR](https://extendr.github.io/) for an overview.
 
@@ -101,7 +101,7 @@ pub fn my_sum(v: &[f64]) -> f64 {
 }
 ```
 
-You can interact in more detail with R objects using the RObj
+You can interact in more detail with R objects using the `Robj`
 type which wraps the native R object type. This supports a large
 subset of the R internals functions, but wrapped to prevent
 accidental segfaults and failures.
@@ -116,5 +116,5 @@ You can also get in contact via our [Discord server](https://discord.gg/7hmApuc)
 
 ### Development
 
-The documentation for the latest development version of `extendr-api` is available here: 
+The documentation for the latest development version of `extendr-api` is available here:
 <https://extendr.github.io/extendr/extendr_api/>

--- a/README.md
+++ b/README.md
@@ -86,8 +86,6 @@ and interfaces.
 This library aims to provide an interface that will be familiar to
 first-time users of Rust or indeed any compiled language.
 
-Anyone who knows the R library should be able to write R extensions.
-
 ## Goals of the project
 
 Instead of wrapping R objects, we convert to Rust native objects

--- a/extendr-api/README.md
+++ b/extendr-api/README.md
@@ -20,10 +20,12 @@ extendr-api = "0.6"
 
 ## Overview
 
-See [Robj] for much of the content of this crate.
-[Robj] provides a safe wrapper for the R object type.
+See `Robj` for much of the content of this crate.
+`Robj` provides a safe wrapper for the R object type.
 
 Use attributes and macros to export to R.
+
+For a module named `mymodule` (typically in a file named `mymodule.rs`)
 
 ```rust
 use extendr_api::prelude::*;
@@ -46,8 +48,8 @@ In R:
 result <- fred(1)
 ```
 
-[Robj] is a wrapper for R objects.
-The r!() and R!() macros let you build R objects
+`Robj` is a wrapper for R objects.
+The `r!()` and `R!()` macros let you build R objects
 using Rust and R syntax respectively.
 
 ```rust
@@ -145,10 +147,10 @@ test! {
 }
 ```
 
-The [R!] macro lets you embed R code in Rust
-and takes Rust expressions in {{ }} pairs.
+The `R!` macro lets you embed R code in Rust
+and takes Rust expressions in `{{ }}` pairs.
 
-The [Rraw!] macro will not expand the {{ }} pairs.
+The `Rraw!` macro will not expand the `{{ }}` pairs.
 
 ```rust
 use extendr_api::prelude::*;
@@ -178,7 +180,7 @@ test! {
 }
 ```
 
-The [r!] macro converts a rust object to an R object
+The `r!` macro converts a rust object to an R object
 and takes parameters.
 
 ```rust
@@ -190,7 +192,7 @@ test! {
 }
 ```
 
-You can call R functions and primitives using the [call!] macro.
+You can call R functions and primitives using the `call!` macro.
 
 ```rust
 use extendr_api::prelude::*;
@@ -211,11 +213,11 @@ test! {
 
 Rust has a concept of "Owned" and "Borrowed" objects.
 
-Owned objects, such as [Vec] and [String] allocate memory
+Owned objects, such as `Vec` and `String` allocate memory
 which is released when the object lifetime ends.
 
-Borrowed objects such as &[i32] and &str are just pointers
-to annother object's memory and can't live longer than the
+Borrowed objects such as `&[i32]` and `&str` are fat pointers
+to another object's memory and can't live longer than the
 object they reference.
 
 Borrowed objects are much faster than owned objects and use less

--- a/extendr-api/README.md
+++ b/extendr-api/README.md
@@ -1,12 +1,6 @@
-# extendr-api
+# `extendr-api`
 
-A safe and user friendly R extension interface.
-
-* Build rust extensions to R.
-* Convert R packages to Rust crates.
-
-This library aims to provide an interface that will be familiar to
-first-time users of Rust or indeed any compiled language.
+`extendr-api` is an opinionated, ergonomic, and safe interface to R API.
 
 ## Installation
 
@@ -15,8 +9,15 @@ You will then be able to call R code from Rust.
 
 ```toml
 [dependencies]
-extendr-api = "0.6"
+extendr-api = "0.7"
 ```
+
+## About
+
+On the [extendr homepage](https://extendr.github.io/) there is a [comprehensive user-guide](https://extendr.github.io/user-guide/).
+
+The [API documentation on doc.rs](https://docs.rs/extendr-api/latest/extendr_api/), and for
+[development API documentation](https://extendr.github.io/extendr/extendr_api/).
 
 ## Overview
 

--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -1,9 +1,5 @@
-//!
-//! A safe and user friendly R extension interface.
-//!
-//! * Build rust extensions to R.
-//! * Convert R packages to Rust crates.
-//!
+//! An ergonomic, opinionated, safe and user-friendly wrapper to the R-API
+//! 
 //! This library aims to provide an interface that will be familiar to
 //! first-time users of Rust or indeed any compiled language.
 //!
@@ -308,7 +304,6 @@
 //! These features are experimental and are subject to change.
 //! - `result_list`: return `Ok` as `list(ok=?, err=NULL)` or `Err` `list(ok=NULL, err=?)`
 //! - `result_condition`: return `Ok` as is or `Err` as $value in an R error condition.
-
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/extendr/extendr/master/extendr-logo-256.png"
 )]

--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -1,5 +1,5 @@
 //! An ergonomic, opinionated, safe and user-friendly wrapper to the R-API
-//! 
+//!
 //! This library aims to provide an interface that will be familiar to
 //! first-time users of Rust or indeed any compiled language.
 //!

--- a/extendr-engine/README.md
+++ b/extendr-engine/README.md
@@ -1,4 +1,26 @@
-# extendr-engine
+# `extendr-engine`
 
-This crate is mostly use for testing `extendr-api`. See
-`extendr-api` for more details.
+This crate facilitates embedding an R process together with a Rust binary.
+It is not meant to be used within rust-powered R-packages. Rather, this crate
+may be used to embed R in a Rust application.
+
+**This crate does not adhere to the non-API requirements of CRAN.**
+
+## Using it in R-packages
+
+Within `Cargo.toml` add `extendr-engine` under `dev-dependencies`.
+
+```toml
+[dev-dependencies]
+extendr-engine = "*"
+```
+
+Then, you may use `extendr_engine` within unit tests, integration tests,
+and binaries. If `extendr-engine` is added under `[dependencies]`, then the
+surrounding R-package will flag a CRAN note about non-API usage.
+
+## About
+
+See documentation on [doc.rs](https://docs.rs/extendr-engine/latest/extendr_engine/), or the latest development version on [extendr website](https://extendr.github.io/extendr/extendr_engine/index.html).
+
+This crate is similar in spirit as [`{Rinside}`, on CRAN](https://cran.r-project.org/web/packages/RInside/index.html).

--- a/extendr-engine/README.md
+++ b/extendr-engine/README.md
@@ -1,8 +1,9 @@
 # `extendr-engine`
 
-This crate facilitates embedding an R process together with a Rust binary.
-It is not meant to be used within rust-powered R-packages. Rather, this crate
-may be used to embed R in a Rust application.
+This crate facilitates embedding an R process together with a standalone binaries.
+In rust-powered R-packages, the R code calls Rust, and thus there is already an
+accompanying R process. Instead, this is meant to be used in unit tests, integration
+test and binaries that are standalone from R code.
 
 **This crate does not adhere to the non-API requirements of CRAN.**
 

--- a/extendr-engine/src/lib.rs
+++ b/extendr-engine/src/lib.rs
@@ -1,8 +1,8 @@
-//! Embeds an a single R process
+//! Embeds a a single R process
 //!
 //! Using R's C-API requires the embedding of the R runtime.
 //! Thus, when using bindings in `libR-sys`, it is necessary that
-//! either the an R process is the caller, or that the process instantiates
+//! either the a R process is the caller, or that the process instantiates
 //! an accompanying R process. Otherwise, a run-time error occurs e.g.
 //! `(signal: 11, SIGSEGV: invalid memory reference)` or
 //!
@@ -43,7 +43,7 @@
 //!
 //! ## Binaries
 //!
-//! In an binary program, one may use [`start_r`] directly in the `main`-function.
+//! In a binary program, one may use [`start_r`] directly in the `main`-function.
 //!
 //! There is no `end_r`, as we terminate the R process setup, when the parent
 //! process terminates.

--- a/extendr-engine/src/lib.rs
+++ b/extendr-engine/src/lib.rs
@@ -1,11 +1,65 @@
-//! A singleton instance of the R interpreter.
-//!
-//! Only call this from `main()` if you want to run stand-alone.
-//!
-//! Its principal use is for testing.
-//!
-//! See [Rembedded.c](https://github.com/wch/r-source/blob/trunk/src/unix/Rembedded.c).
-//!
+//! Embeds an a single R process
+//! 
+//! Using R's C-API requires the embedding of the R runtime. 
+//! Thus, when using bindings in `libR-sys`, it is necessary that
+//! either the an R process is the caller, or that the process instantiates
+//! an accompanying R process. Otherwise, a run-time error occurs e.g.
+//! `(signal: 11, SIGSEGV: invalid memory reference)` or
+//! 
+//! ```default
+//! Caused by:
+//! process didn't exit successfully: `/extendr/tests/extendrtest/target/debug/deps/extendrtest-59155c3c146ae614` (signal: 11, SIGSEGV: invalid memory reference)
+//! ```
+//! 
+//! ## Testing
+//! 
+//! Within tests, one must use [`test!`] or [`with_r`] as a wrapper around
+//! code that uses the R runtime, e.g.
+//! 
+//! ```rust
+//! #[test]
+//! fn testing_r_code() {
+//!     with_r(|| {
+//!     
+//!     });
+//! }
+//! ```
+//! 
+//! Similarly with `test!` that is available in `extendr_api`, one may
+//! 
+//! ```rust
+//! #[test]
+//! fn testing_r_code() {
+//!     test! {
+//!     
+//!     };
+//! }
+//! ```
+//! 
+//! The advantage of `test!` is that it allows the use of `?` in test code, while
+//! `with_r` is not macro-based, thus code formatter `rustfmt` and rust LSPs (Rust Analyzer, Rust Rover, etc.)
+//! works within `with_r` without any problems.
+//! 
+//! 
+//! ## Binaries
+//! 
+//! In an binary program, one may use [`start_r`] directly in the `main`-function.
+//! 
+//! There is no `end_r`, as we terminate the R process setup, when the parent
+//! process terminates.
+//! 
+//! [`test!`]: https://docs.rs/extendr-api/latest/extendr_api/macro.test.html
+//! 
+// # Internal documentation
+//
+// ## Background
+// 
+// 
+// See [Rembedded.c](https://github.com/wch/r-source/blob/trunk/src/unix/Rembedded.c).
+// 
+// [Rinside](https://github.com/eddelbuettel/rinside)
+// 
+// 
 
 use libR_sys::*;
 use std::os::raw;

--- a/extendr-engine/src/lib.rs
+++ b/extendr-engine/src/lib.rs
@@ -1,22 +1,22 @@
 //! Embeds an a single R process
-//! 
-//! Using R's C-API requires the embedding of the R runtime. 
+//!
+//! Using R's C-API requires the embedding of the R runtime.
 //! Thus, when using bindings in `libR-sys`, it is necessary that
 //! either the an R process is the caller, or that the process instantiates
 //! an accompanying R process. Otherwise, a run-time error occurs e.g.
 //! `(signal: 11, SIGSEGV: invalid memory reference)` or
-//! 
-//! ```default
+//!
+//! ```text
 //! Caused by:
 //! process didn't exit successfully: `/extendr/tests/extendrtest/target/debug/deps/extendrtest-59155c3c146ae614` (signal: 11, SIGSEGV: invalid memory reference)
 //! ```
-//! 
+//!
 //! ## Testing
-//! 
+//!
 //! Within tests, one must use [`test!`] or [`with_r`] as a wrapper around
 //! code that uses the R runtime, e.g.
-//! 
-//! ```rust
+//!
+//! ```no_run
 //! #[test]
 //! fn testing_r_code() {
 //!     with_r(|| {
@@ -24,10 +24,10 @@
 //!     });
 //! }
 //! ```
-//! 
+//!
 //! Similarly with `test!` that is available in `extendr_api`, one may
-//! 
-//! ```rust
+//!
+//! ```no_run   
 //! #[test]
 //! fn testing_r_code() {
 //!     test! {
@@ -35,31 +35,31 @@
 //!     };
 //! }
 //! ```
-//! 
+//!
 //! The advantage of `test!` is that it allows the use of `?` in test code, while
 //! `with_r` is not macro-based, thus code formatter `rustfmt` and rust LSPs (Rust Analyzer, Rust Rover, etc.)
 //! works within `with_r` without any problems.
-//! 
-//! 
+//!
+//!
 //! ## Binaries
-//! 
+//!
 //! In an binary program, one may use [`start_r`] directly in the `main`-function.
-//! 
+//!
 //! There is no `end_r`, as we terminate the R process setup, when the parent
 //! process terminates.
-//! 
+//!
 //! [`test!`]: https://docs.rs/extendr-api/latest/extendr_api/macro.test.html
-//! 
+//!
 // # Internal documentation
 //
 // ## Background
-// 
-// 
+//
+//
 // See [Rembedded.c](https://github.com/wch/r-source/blob/trunk/src/unix/Rembedded.c).
-// 
+//
 // [Rinside](https://github.com/eddelbuettel/rinside)
-// 
-// 
+//
+//
 
 use libR_sys::*;
 use std::os::raw;

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -47,7 +47,7 @@ Runs `R CMD check` tests in `tests/extendrtests`.
 
 ## `doc`
 
-Generates documentation as seen on [/extendr.github.io](https://extendr.github.io/extendr/extendr_api/), meaning it will enable feature `full-functionality`,
+Generates documentation as seen on [extendr.github.io](https://extendr.github.io/extendr/extendr_api/), meaning it will enable feature `full-functionality`,
 which includes all the optional dependencies, plus all the additive features.
 
 ## `msrv`


### PR DESCRIPTION
I would like to clean-up the `README` pages of extendr packages.

First we have `README`s that appear when navigating on GitHub:
https://github.com/extendr/extendr/blob/master/README.md
https://github.com/extendr/extendr/blob/master/extendr-api/README.md
https://github.com/extendr/extendr/blob/master/extendr-engine/README.md
https://github.com/extendr/extendr/blob/master/extendr-macros/README.md
https://github.com/extendr/extendr/blob/master/xtask/README.md

Then there are front-pages of doc.rs for the various crates
https://github.com/extendr/extendr/blob/master/extendr-api/src/lib.rs
https://github.com/extendr/extendr/blob/master/extendr-engine/src/lib.rs
https://github.com/extendr/extendr/blob/master/extendr-macros/src/lib.rs


After discussing this with @kbvernon, I think we should:

- Don't have too many code-examples in the GitHub `README`, but refer to docs.rs (for stable) / extendr-website hosted docs (for development), and those `lib.rs` files, should have the code-heavy introductions.
- Link to the website and the user-guide on each of the GitHub `README`s. 
