### PR TITLE
Add compatibility with latest cfg-check feature in stable rust

### DIFF
--- a/extendr-api/build.rs
+++ b/extendr-api/build.rs
@@ -13,25 +13,30 @@ fn main() {
 
     // R_NewEnv is available as of R 4.1.0
     if &*major >= "4" && &*minor >= "1" {
+        println!("cargo:rustc-check-cfg=cfg(use_r_newenv)");
         println!("cargo:rustc-cfg=use_r_newenv");
     }
 
     // pattern fill was introduced in R 4.1
     if &*major >= "4" && &*minor >= "1" {
+        println!("cargo:rustc-check-cfg=cfg(use_r_ge_version_14)");
         println!("cargo:rustc-cfg=use_r_ge_version_14");
     }
 
     // a few new features will be introduced in R 4.2
     // c.f. https://developer.r-project.org/Blog/public/2021/12/14/updating-graphics-devices-for-r-4.2.0/index.html
     if &*major >= "4" && &*minor >= "2" {
+        println!("cargo:rustc-check-cfg=cfg(use_r_ge_version_15)");
         println!("cargo:rustc-cfg=use_r_ge_version_15");
     }
 
     if &*major >= "4" && &*minor >= "3" {
+        println!("cargo:rustc-check-cfg=cfg(use_r_altlist)");
         println!("cargo:rustc-cfg=use_r_altlist");
     }
 
     if &*major >= "4" && &*minor >= "4" {
+        println!("cargo:rustc-check-cfg=cfg(use_objsxp)");
         println!("cargo:rustc-cfg=use_objsxp");
     }
 }

--- a/tests/extendrtests/src/rust/build.rs
+++ b/tests/extendrtests/src/rust/build.rs
@@ -53,6 +53,7 @@ fn main() {
     println!("cargo:r_version_patch={}", patch); // Becomes DEP_R_R_VERSION_PATCH
 
     if major >= 4 && minor >= 3 {
+        println!("cargo:rustc-check-cfg=cfg(use_r_altlist)");
         println!("cargo:rustc-cfg=use_r_altlist");
     }
 }


### PR DESCRIPTION
Current stable version of rust give warnings.

This is applying one of the suggestions. Hopefully it does not cause problems. 

<details><summary>Details</summary>
<p>

Excerpt of the warnings:
```rs
warning: unexpected `cfg` condition name: `use_objsxp`
   --> extendr-api/src/lib.rs:606:15
    |
606 |         #[cfg(use_objsxp)]
    |               ^^^^^^^^^^
    |
    = help: consider using a Cargo feature instead
    = help: or consider adding in `Cargo.toml` the `check-cfg` lint config for the lint:
             [lints.rust]
             unexpected_cfgs = { level = "warn", check-cfg = ['cfg(use_objsxp)'] }
    = help: or consider adding `println!("cargo::rustc-check-cfg=cfg(use_objsxp)");` to the top of the `build.rs`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration

warning: `extendr-api` (lib) generated 16 warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.03s
[Finished running. Exit status: 0]
```

</p>
</details> 