### PR TITLE
update: Don't export `faer` and `ndarray` and their contents in `prelude`

### DIFF
--- a/extendr-api/src/optional/ndarray.rs
+++ b/extendr-api/src/optional/ndarray.rs
@@ -4,13 +4,14 @@ Defines conversions between R objects and the [`ndarray`](https://docs.rs/ndarra
 To enable these conversions, you must first enable the `ndarray` feature for extendr:
 ```toml
 [dependencies]
-extendr-api = { version = "0.4", features = ["ndarray"] }
+extendr-api = { version = "0.7", features = ["ndarray"] }
 ```
 
 Specifically, extendr supports the following conversions:
 * [`Robj` → `ArrayView1`](FromRobj#impl-FromRobj<%27a>-for-ArrayView1<%27a%2C%20T>), for when you have an R vector that you want to analyse in Rust:
     ```rust
     use extendr_api::prelude::*;
+    use ndarray::ArrayView1;
 
     #[extendr]
     fn describe_vector(vector: ArrayView1<f64>){
@@ -20,6 +21,7 @@ Specifically, extendr supports the following conversions:
 * [`Robj` → `ArrayView2`](FromRobj#impl-FromRobj<%27a>-for-ArrayView2<%27a%2C%20f64>), for when you have an R matrix that you want to analyse in Rust.
     ```rust
     use extendr_api::prelude::*;
+    use ndarray::ArrayView2;
 
     #[extendr]
     fn describe_matrix(matrix: ArrayView2<f64>){
@@ -29,6 +31,7 @@ Specifically, extendr supports the following conversions:
 * [`ArrayBase` → `Robj`](Robj#impl-TryFrom<ArrayBase<S%2C%20D>>-for-Robj), for when you want to return a reference to an [`ndarray`] Array from Rust back to R.
     ```rust
     use extendr_api::prelude::*;
+    use ndarray::Array2;
 
     #[extendr]
     fn return_matrix() -> Robj {
@@ -45,6 +48,7 @@ It will then be copied into a new block of memory managed by R.
 This is made easier by the fact that [ndarray allocates a new array automatically when performing operations on array references](ArrayBase#binary-operators-with-array-and-scalar):
 ```rust
 use extendr_api::prelude::*;
+use ndarray::ArrayView2;
 
 #[extendr]
 fn scalar_multiplication(matrix: ArrayView2<f64>, scalar: f64) -> Robj {

--- a/extendr-api/src/prelude.rs
+++ b/extendr-api/src/prelude.rs
@@ -72,10 +72,10 @@ pub use super::scalar::*;
 pub use super::Nullable::*;
 
 #[cfg(feature = "ndarray")]
-pub use ::ndarray::*;
+pub use ::ndarray;
 
 #[cfg(feature = "either")]
 pub use ::either::*;
 
 #[cfg(feature = "faer")]
-pub use ::faer::*;
+pub use ::faer;

--- a/extendr-api/tests/ndarray_try_from_tests.rs
+++ b/extendr-api/tests/ndarray_try_from_tests.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "ndarray")]
 mod ndarray_try_from_tests {
     use extendr_api::prelude::*;
+    use ndarray::{ArrayView1, ArrayView2};
 
     #[test]
     fn test_1d_view_from_robj() {

--- a/tests/extendrtests/src/rust/src/optional_ndarray.rs
+++ b/tests/extendrtests/src/rust/src/optional_ndarray.rs
@@ -1,4 +1,5 @@
 use extendr_api::prelude::*;
+use ndarray::{s, ArrayView2};
 
 /// Calculate Euclidean distance matrix
 /// Test case adopted from https://github.com/mikemahoney218/examplerust/blob/23d21b1ced4e24b7a7c00dd36290114dc1bbd113/src/rust/src/lib.rs#L5

--- a/tests/extendrtests/tests/testthat/_snaps/macro-snapshot.md
+++ b/tests/extendrtests/tests/testthat/_snaps/macro-snapshot.md
@@ -5587,6 +5587,7 @@
       }
       mod optional_ndarray {
           use extendr_api::prelude::*;
+          use ndarray::{s, ArrayView2};
           /// Calculate Euclidean distance matrix
           /// Test case adopted from https://github.com/mikemahoney218/examplerust/blob/23d21b1ced4e24b7a7c00dd36290114dc1bbd113/src/rust/src/lib.rs#L5
           /// @param a : Matrix of real values or `NULL`


### PR DESCRIPTION
Currently, the prelude, i.e. using `use extendr_api::prelude::*;` exports the contents of both `faer` and `ndarray`. There are collisions.
 This PR merely exports the crates, and then the use may decide to include their contents downstream.
 
To obtain previous behavior, one has to do:
```rs
use extendr_api::prelude::*;
use ndarray::*;
use faer::*;
```
