### PR TITLE
internal: Add `full-functionality` in `extendrtests` for convenience of developer

### DIFF
--- a/tests/extendrtests/src/rust/Cargo.toml
+++ b/tests/extendrtests/src/rust/Cargo.toml
@@ -19,6 +19,10 @@ crate-type = ["staticlib"]
 extendr-api = { version = "*", features = ["graphics", "ndarray", "faer", "either"] }
 faer = "0.19"
 
+[features]
+# dummy feature for compatibility with extendr-api's feature
+full-functionality = []
+
 [patch.crates-io]
 ## This is configured to work with RStudio features.
 ## Replace by absolute path to simplify testing.


### PR DESCRIPTION
Usually, when I'm testing extendr, I use this in `.vscode/settings.json`:
```json
{
  "rust-analyzer.cargo.features": [
    "full-functionality"
  ],
  "rust-analyzer.linkedProjects": [
    "tests/extendrtests/src/rust/Cargo.toml",
  ],
}
```
But then what Rust Analyzer wants to do here is apply `full-functionality` to `extendrtests` too. However, that feature isn't there, because it doesn't do anything. I suggest we add this dummy feature here, to allow for easy integration of both rust projects in Rust Analyzer.

It is very convenient.


