### PR TITLE
Added iterator for `Strings`

### DIFF
--- a/extendr-api/src/wrapper/strings.rs
+++ b/extendr-api/src/wrapper/strings.rs
@@ -159,3 +159,13 @@ impl From<Option<Strings>> for Robj {
         }
     }
 }
+
+impl IntoIterator for Strings {
+    type Item = &'static str;
+
+    type IntoIter = StrIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.robj.as_str_iter().unwrap()
+    }
+}


### PR DESCRIPTION
We already had this in `StrIter`. The universal conversion tool just needed to be used here.
In summary, this adds `.into_iter()` to `Strings`. 
