### PR TITLE
Mark is_valid_string as non-API

### DIFF
--- a/extendr-api/src/robj/rinternals.rs
+++ b/extendr-api/src/robj/rinternals.rs
@@ -354,11 +354,13 @@ pub trait Rinternals: Types + Conversions {
         unsafe { Rf_isUserBinop(self.get()).into() }
     }
 
+    #[cfg(feature = "non-api")]
     /// Return true if this is a valid string.
     fn is_valid_string(&self) -> bool {
         unsafe { Rf_isValidString(self.get()).into() }
     }
 
+    #[cfg(feature = "non-api")]
     /// Return true if this is a valid string.
     fn is_valid_string_f(&self) -> bool {
         unsafe { Rf_isValidStringF(self.get()).into() }


### PR DESCRIPTION
Closes https://github.com/extendr/extendr/issues/841.

libR-sys PR https://github.com/extendr/libR-sys/pull/253 removed more non-API items. This needs to be reflected in `extendr-api`. At present if libR-sys 0.7.1 is used with extendr-api 0.7.0 compilation will fail. 


This PR marks the `is_valid_string()` and `is_valid_string_f()` trait methods as `non-api` feature. 
