### PR TITLE
Patch release PR: 0.7.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 members = ["extendr-api", "extendr-engine", "extendr-macros", "xtask"]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 authors = [
     "andy-thomason <andy@andythomason.com>",
     "Thomas Down",
@@ -20,9 +20,9 @@ repository = "https://github.com/extendr/extendr"
 
 [workspace.dependencies]
 # When updating extendr's version, this version also needs to be updated
-extendr-macros = { path = "./extendr-macros", version = "0.7.0" }
+extendr-macros = { path = "./extendr-macros", version = "0.7.1" }
 
 # When uncommenting this, do not forget to uncomment the same line in
 # ./tests/extendrtests/src/rust/Cargo.toml, and "Run R integration tests using
 # {rextendr}" on .github/workflows/test.yml !
-libR-sys = { version = "0.7" }
+libR-sys = { version = "0.7.1" }

--- a/tests/extendrtests/src/rust/Cargo.toml
+++ b/tests/extendrtests/src/rust/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 
 [package]
 name = "extendrtests"
-version = "0.7.0"
+version = "0.7.1"
 authors = [
     "andy-thomason <andy@andythomason.com>",
     "Claus O. Wilke <wilke@austin.utexas.edu>",


### PR DESCRIPTION
I just made a release of `extendr-macros`, `extendr-api` and `extendr-engine` on crates.io based on this PR.
Patched version to make things compile everywhere (CRAN, in CI, rextendr, etc.)
