### PR TITLE
Add type-checking to `#[extendr]`-impl

### DIFF
--- a/extendr-api/src/wrapper/externalptr.rs
+++ b/extendr-api/src/wrapper/externalptr.rs
@@ -271,9 +271,10 @@ impl<T: 'static> TryFrom<&mut Robj> for &mut ExternalPtr<T> {
         }
         let raw_type_id = value.get_attrib("rust_type_id").unwrap();
         let raw_type_id = raw_type_id.as_raw_slice().unwrap();
+        // these lines extract the type ID of `T` and store is as a slice for us to compare against
         let expected_type_id = std::any::TypeId::of::<T>();
-        let expected_type_id = unsafe { std::mem::transmute::<_, [u8; 16]>(expected_type_id) };
-        let expected_type_id = expected_type_id.as_slice();
+        let expected_type_id = unsafe { std::mem::transmute::<_, [u8; 16]>(expected_type_id) }.as_slice();
+        // now we compare the expected type ID with what we found. If they do not match, we return an error
         if expected_type_id != raw_type_id {
             return Err(Error::ExpectedExternalPtrType(
                 value.clone(),

--- a/extendr-api/src/wrapper/externalptr.rs
+++ b/extendr-api/src/wrapper/externalptr.rs
@@ -266,10 +266,9 @@ impl<T: 'static> TryFrom<&mut Robj> for &mut ExternalPtr<T> {
         }
 
         // type checking that could be optional
-        if !value.has_attrib("rust_type_id") {
-            return Err(Error::ExpectedExternalPtr(value.clone()));
-        }
-        let raw_type_id = value.get_attrib("rust_type_id").unwrap();
+        let Some(raw_type_id) = value.get_attribute("rust_type_id") else {
+           return Err(Error::ExpectedExternalPtr(value.clone()));
+        };
         let raw_type_id = raw_type_id.as_raw_slice().unwrap();
         // these lines extract the type ID of `T` and store is as a slice for us to compare against
         let expected_type_id = std::any::TypeId::of::<T>();

--- a/extendr-macros/src/extendr_impl.rs
+++ b/extendr-macros/src/extendr_impl.rs
@@ -1,13 +1,9 @@
-extern crate proc_macro;
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::{ItemFn, ItemImpl};
 
 use crate::extendr_options::ExtendrOptions;
 use crate::wrappers;
-
-#[allow(unused_imports)]
-use crate::extendr;
 
 /// Make inherent implementations available to R
 ///

--- a/tests/extendrtests/.Rbuildignore
+++ b/tests/extendrtests/.Rbuildignore
@@ -1,3 +1,4 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^LICENSE\.md$
+^notebooks$

--- a/tests/extendrtests/src/rust/Cargo.toml
+++ b/tests/extendrtests/src/rust/Cargo.toml
@@ -19,6 +19,10 @@ crate-type = ["staticlib"]
 extendr-api = { version = "*", features = ["graphics", "ndarray", "faer", "either"] }
 faer = "0.19"
 
+[features]
+full-functionality = []
+serde = ["extendr-api/serde"]
+
 [patch.crates-io]
 ## This is configured to work with RStudio features.
 ## Replace by absolute path to simplify testing.


### PR DESCRIPTION
I'm finally back to working on extendr.

The idea of type-checking `#[extendr]`-impl/`ExternalPtr<T>` was brought up again.
I recall that I made a fairly clever strategy to embed `std::any::TypeId`, to use as a mechanism
for checking Rust types retrieved from R.
Comparing `TypeId` should be more than sufficient.

Instead of embedding it in all sorts of convoluted ways, I just figured that we can
embed it as a `Raw`-blob, and comparing this with other `Raw`-blob is good enough for purpose.
We could of course make this more efficient, but not by all that much.

**This PR is not done, and won't be done unless design decisions are made on how this should work**

Therefore, I'd like some discussion on this, and thoughts, and I will try to implement these ideas in this PR.


## Example output

```r
> MyClass$new()
 [1] 66 73 05 dc d3 37 0a 0f d8 88 c5 b2 cb d6 1a ba
<pointer: 0x1583e6880>
attr(,"rust_type_id")
 [1] 66 73 05 dc d3 37 0a 0f d8 88 c5 b2 cb d6 1a ba
attr(,"class")
[1] "MyClass"
```