### PR TITLE
Soundness: `Robj` must be transparent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 - `TryFrom<Robj>` is now implemented for `&ExternalPtr<T>` and `&mut ExternalPtr<T>` <https://github.com/extendr/extendr/pull/833>
 - `Option<T>` can now be returned from `#[extendr]` annotated functions for extendr_api types. `None` is translated into `NULL` value in R [[#802]](https://github.com/extendr/extendr/pull/802)
 
-
 ### Changed
 
 - Enhancement: string comparisons are now implemented for `Rstr` using R's string intern mechanism. Making string comparisons _much_ faster. [[#845]](https://github.com/extendr/extendr/pull/845)
@@ -19,6 +18,9 @@ return `Option<Strings>` instead of opaque `Robj`.
 ### Fixed
 
 ### Deprecated
+
+- Removed `from_sexp_ref` from public API. This is a completely unsound function, and uses of it must not
+used otherwise. [[#855]](https://github.com/extendr/extendr/pull/855)
 
 ## 0.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,7 @@ return `Option<Strings>` instead of opaque `Robj`.
 
 ### Deprecated
 
-- Removed `from_sexp_ref` from public API. This is a completely unsound function, and uses of it must not
-used otherwise. [[#855]](https://github.com/extendr/extendr/pull/855)
+- Removed `from_sexp_ref()` from the public API. `from_sexp_ref()` is an unsafe method and is for internal use only. [#855]](https://github.com/extendr/extendr/pull/855)
 
 ## 0.7.0
 

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -104,6 +104,7 @@ mod tests;
 /// panics and segfaults. We will take great trouble to ensure that this
 /// is true.
 ///
+#[repr(transparent)]
 pub struct Robj {
     inner: SEXP,
 }
@@ -222,9 +223,14 @@ impl Robj {
         })
     }
 
-    /// A ref of an robj can be constructed from a ref to a SEXP
+    /// A reference of an [`Robj`] can be constructed from a reference to a [`SEXP`]
     /// as they have the same layout.
-    pub fn from_sexp_ref(sexp: &SEXP) -> &Self {
+    ///
+    /// # SAFETY
+    ///
+    /// Unlike [`from_sexp`], this does not protect the converted [`SEXP`]. Therefore, one
+    /// must invoke [`ownership::protect`] manually, if necessary.
+    pub(crate) unsafe fn from_sexp_ref(sexp: &SEXP) -> &Self {
         unsafe { std::mem::transmute(sexp) }
     }
 }


### PR DESCRIPTION
It is possible to use `std::mem::transmute` to go from a `SEXP` to, say, `&Robj`/`&mut Robj`. This is indeed necessary to make some API possible. See `Index` on `List` as an example. A follow-up PR for `Index` on `List` will come..