### PR TITLE
Hotfix: Mishandling `NULL` pointer

### DIFF
--- a/extendr-api/src/wrapper/externalptr.rs
+++ b/extendr-api/src/wrapper/externalptr.rs
@@ -247,7 +247,7 @@ impl<T: 'static> TryFrom<&Robj> for &ExternalPtr<T> {
                 .external_ptr_addr::<Box<dyn Any>>()
                 .cast_const()
                 .as_ref()
-                .unwrap()
+                .ok_or_else(|| Error::ExpectedExternalNonNullPtr(value.clone()))?
         };
 
         if boxed_ptr.downcast_ref::<T>().is_none() {
@@ -275,7 +275,7 @@ impl<T: 'static> TryFrom<&mut Robj> for &mut ExternalPtr<T> {
                 .external_ptr_addr::<Box<dyn Any>>()
                 .cast_const()
                 .as_ref()
-                .unwrap()
+                .ok_or_else(|| Error::ExpectedExternalNonNullPtr(value.clone()))?
         };
 
         if boxed_ptr.downcast_ref::<T>().is_none() {


### PR DESCRIPTION
In #853, type-checking was added to `ExternalPtr<T>`. Previously, there were issues with processing `NULL` pointers, that we covered through a test. This test resided in `test-classes.R` of `extendrtests`. While the test still logically made sense after #853, the test would _panic_. For some reason, the `panic!` (due to an `unwrap()`) would not fail the test. We believe that this was unnoticed, because there was no signal of failure, outside the print log. The print log of R tests are not visible in the CI.

Now, the case of `NULL` pointer is handled in the type-checking code. It was an oversight, made possible by me being overly naive. But now, it is handled properly.

This is not a critical issue, but many exotic extendr code relies on passing of `NULL` pointers, so in a sense, it is critical to advanced use-cases. 

