### PR TITLE
CI: fix MSRV broken

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -36,4 +36,4 @@ jobs:
       - name: Verify minimum rust version
         run: |
           . ./ci-cargo.ps1
-          ci-cargo msrv --path extendr-api --output-format minimal verify -ActionName "Verify Rust MSRV"
+          ci-cargo msrv --path extendr-api --output-format minimal verify  --rust-version 1.65 -ActionName "Verify Rust MSRV"

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -36,4 +36,4 @@ jobs:
       - name: Verify minimum rust version
         run: |
           . ./ci-cargo.ps1
-          ci-cargo msrv --path extendr-api --output-format minimal verify
+          ci-cargo msrv --path extendr-api --output-format minimal verify -ActionName "Verify Rust MSRV"

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -35,4 +35,5 @@ jobs:
           crate: cargo-msrv
       - name: Verify minimum rust version
         run: |
-          cargo msrv --path extendr-api --output-format=minimal verify
+          . ./ci-cargo.ps1
+          ci-cargo msrv --path extendr-api --output-format minimal verify

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -9,9 +9,9 @@ on:
   pull_request:
     branches:
       - master
-    paths:
-      - "**.rs"
-      - "**/Cargo.toml"
+    # paths:
+    #   - "**.rs"
+    #   - "**/Cargo.toml"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -35,5 +35,4 @@ jobs:
           crate: cargo-msrv
       - name: Verify minimum rust version
         run: |
-          . ./ci-cargo.ps1
-          ci-cargo msrv --path extendr-api/ verify -ActionName "Verify Rust MSRV"
+          cargo msrv --path extendr-api/ verify

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -35,4 +35,4 @@ jobs:
           crate: cargo-msrv
       - name: Verify minimum rust version
         run: |
-          cargo msrv --path extendr-api/ verify
+          cargo msrv --path extendr-api --output-format=minimal verify


### PR DESCRIPTION
In the new version of `cargo-msrv`,  there are many changes, and one of them is, that `--output-format=minimal` is the preferred output for CI usage.

But that does not fix the failure on CI.

Locally, the output is

```sh
 "Verify Rust MSRV"
::group::Verify Rust MSRV
Running cargo msrv --path extendr-api --output-format minimal verify
true
::endgroup::
```

However, in CI, it appears to be `false`.  I don't know why. 