### PR TITLE
Use full path in macros

### DIFF
--- a/extendr-api/src/robj/try_from_robj.rs
+++ b/extendr-api/src/robj/try_from_robj.rs
@@ -6,9 +6,9 @@
 //!
 //!
 //! [`ownership`]: crate::ownership
-use crate::conversions::try_into_int::FloatToInt;
-
 use super::*;
+use crate as extendr_api;
+use crate::conversions::try_into_int::FloatToInt;
 
 macro_rules! impl_try_from_scalar_integer {
     ($t:ty) => {

--- a/extendr-macros/src/dataframe.rs
+++ b/extendr-macros/src/dataframe.rs
@@ -11,7 +11,7 @@ fn parse_struct(input: &DeriveInput, datastruct: &DataStruct) -> TokenStream {
     quote! {
         impl extendr_api::wrapper::IntoDataFrameRow<#structname> for Vec<#structname>
         {
-            fn into_dataframe(self) -> Result<extendr_api::wrapper::Dataframe<#structname>> {
+            fn into_dataframe(self) -> extendr_api::Result<extendr_api::wrapper::Dataframe<#structname>> {
                 #(let mut #a = Vec::with_capacity(self.len());)*
                 for val in self {
                     #(#a.push(val.#a);)*
@@ -29,7 +29,7 @@ fn parse_struct(input: &DeriveInput, datastruct: &DataStruct) -> TokenStream {
             I : ExactSizeIterator<Item=#structname>,
         {
             /// Thanks to RFC 2451, we need to wrap a generic iterator in a tuple!
-            fn into_dataframe(self) -> Result<extendr_api::wrapper::Dataframe<#structname>> {
+            fn into_dataframe(self) -> extendr_api::Result<extendr_api::wrapper::Dataframe<#structname>> {
                 #(let mut #a = Vec::with_capacity(self.0.len());)*
                 for val in self.0 {
                     #(#a.push(val.#a);)*

--- a/extendr-macros/src/lib.rs
+++ b/extendr-macros/src/lib.rs
@@ -339,11 +339,11 @@ pub fn impl_try_from_robj_tuples(input: TokenStream) -> TokenStream {
         TokenStream::from(quote! {
             impl<#(#types),*> TryFrom<&Robj> for (#(#types,)*)
             where
-                #(#types: for<'a> TryFrom<&'a Robj, Error = crate::error::Error>),*
+                #(#types: for<'a> TryFrom<&'a Robj, Error = extendr_api::Error>),*
             {
                 type Error = Error;
 
-                fn try_from(robj: &Robj) -> Result<Self> {
+                fn try_from(robj: &Robj) -> extendr_api::Result<Self> {
                     let list: List = robj.try_into()?;
                     if list.len() != #n {
                         return Err(Error::ExpectedLength(#n));
@@ -359,20 +359,20 @@ pub fn impl_try_from_robj_tuples(input: TokenStream) -> TokenStream {
 
             impl<#(#types),*> TryFrom<Robj> for (#(#types,)*)
             where
-                #(#types: for<'a> TryFrom<&'a Robj, Error = crate::error::Error>),* {
+                #(#types: for<'a> TryFrom<&'a Robj, Error = extendr_api::Error>),* {
                 type Error = Error;
 
-                fn try_from(robj: Robj) -> Result<Self> {
+                fn try_from(robj: Robj) -> extendr_api::Result<Self> {
                     Self::try_from(&robj)
                 }
             }
 
             impl<#(#types),*> TryFrom<&Robj> for Option<(#(#types,)*)>
             where
-            #(#types: for<'a> TryFrom<&'a Robj, Error = crate::error::Error>),*{
+            #(#types: for<'a> TryFrom<&'a Robj, Error = extendr_api::Error>),*{
                 type Error = Error;
 
-                fn try_from(robj: &Robj) -> Result<Self> {
+                fn try_from(robj: &Robj) -> extendr_api::Result<Self> {
                     if robj.is_null() || robj.is_na() {
                         Ok(None)
                     } else {
@@ -383,10 +383,10 @@ pub fn impl_try_from_robj_tuples(input: TokenStream) -> TokenStream {
 
             impl<#(#types),*> TryFrom<Robj> for Option<(#(#types,)*)>
             where
-            #(#types: for<'a> TryFrom<&'a Robj, Error = crate::error::Error>),*{
+            #(#types: for<'a> TryFrom<&'a Robj, Error = extendr_api::Error>),*{
                 type Error = Error;
 
-                fn try_from(robj: Robj) -> Result<Self> {
+                fn try_from(robj: Robj) -> extendr_api::Result<Self> {
                     Self::try_from(&robj)
                 }
             }

--- a/tests/extendrtests/tests/testthat/_snaps/macro-snapshot.md
+++ b/tests/extendrtests/tests/testthat/_snaps/macro-snapshot.md
@@ -899,7 +899,9 @@
               }
           }
           impl extendr_api::wrapper::IntoDataFrameRow<MyStruct> for Vec<MyStruct> {
-              fn into_dataframe(self) -> Result<extendr_api::wrapper::Dataframe<MyStruct>> {
+              fn into_dataframe(
+                  self,
+              ) -> extendr_api::Result<extendr_api::wrapper::Dataframe<MyStruct>> {
                   let mut x = Vec::with_capacity(self.len());
                   let mut y = Vec::with_capacity(self.len());
                   for val in self {
@@ -924,7 +926,9 @@
               I: ExactSizeIterator<Item = MyStruct>,
           {
               /// Thanks to RFC 2451, we need to wrap a generic iterator in a tuple!
-              fn into_dataframe(self) -> Result<extendr_api::wrapper::Dataframe<MyStruct>> {
+              fn into_dataframe(
+                  self,
+              ) -> extendr_api::Result<extendr_api::wrapper::Dataframe<MyStruct>> {
                   let mut x = Vec::with_capacity(self.0.len());
                   let mut y = Vec::with_capacity(self.0.len());
                   for val in self.0 {


### PR DESCRIPTION
Currently, our macros assume  `use extendr_api::prelude::*`. It is an ongoing effort to remove this assumption. This PR does that. 