### PR TITLE
chore: bump faer to 0.20

### DIFF
--- a/extendr-api/Cargo.toml
+++ b/extendr-api/Cargo.toml
@@ -20,7 +20,7 @@ libc = { version = "0.2", optional = true }
 ndarray = { version = "0.15.3", optional = true }
 num-complex = { version = "0.4", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
-faer = { version = "0.19", optional = true }
+faer = { version = "0.20", optional = true }
 
 [dev-dependencies]
 extendr-engine = { path = "../extendr-engine" }
@@ -37,7 +37,14 @@ result_condition = []
 # This dummy feature enables all features that increase the functionality of
 # extendr, via conversions or R features. Features that change behaviour
 # but do not add functionality (such as `libR-sys/use-bindgen`) are excluded
-full-functionality = ["graphics", "either", "ndarray", "faer", "num-complex", "serde"]
+full-functionality = [
+    "graphics",
+    "either",
+    "ndarray",
+    "faer",
+    "num-complex",
+    "serde",
+]
 
 # Parts of the R-API are locked behind non-API, as CRAN frowns upon the presence
 # of non-API items in packages. You may enable this feature, to generate
@@ -64,5 +71,5 @@ tests-all = ["tests", "graphics"]
 features = ["full-functionality"]
 
 [[test]]
-name  = "non_api_tests"
+name = "non_api_tests"
 required-features = ["non-api"]

--- a/extendr-api/src/optional/faer.rs
+++ b/extendr-api/src/optional/faer.rs
@@ -58,7 +58,7 @@ impl<'a> From<&'_ RMatrix<f64>> for MatRef<'a, f64> {
         let nrow = value.nrows();
         let ncol = value.ncols();
         let slice = value.as_typed_slice().expect("RMatrix should be doubles");
-        let mat_ref = faer::mat::from_column_major_slice::<f64>(slice, nrow, ncol);
+        let mat_ref = faer::mat::from_column_major_slice(slice, nrow, ncol);
         mat_ref
     }
 }
@@ -89,7 +89,7 @@ impl<'a> TryFrom<&'_ Robj> for MatRef<'a, f64> {
         let ncols = rmat.ncols();
 
         if let Some(slice) = robj.as_typed_slice() {
-            let fmat = mat::from_column_major_slice::<f64>(slice, nrows, ncols);
+            let fmat = mat::from_column_major_slice(slice, nrows, ncols);
             Ok(fmat)
         } else {
             Err(Error::ExpectedReal(robj.clone()))

--- a/tests/extendrtests/src/rust/Cargo.toml
+++ b/tests/extendrtests/src/rust/Cargo.toml
@@ -29,7 +29,7 @@ extendr-api = { version = "*", features = [
     "faer",
     "either",
 ] }
-faer = "0.19"
+faer = "0.20"
 
 [patch.crates-io]
 ## This is configured to work with RStudio features.


### PR DESCRIPTION
This PR bumps the faer version to 0.20 to address issues with faer compilation on CI. 