### PR TITLE
Allowing multiple `impl Foo` blocks with `#[extendr]`

### DIFF
--- a/extendr-macros/src/extendr_impl.rs
+++ b/extendr-macros/src/extendr_impl.rs
@@ -58,7 +58,7 @@ use crate::wrappers;
 ///         // return self
 ///         self
 ///     }
-///     
+///
 ///     // Convert the struct into a data.frame
 ///     fn into_df(&self) -> Robj {
 ///         let df = self.0.clone().into_dataframe();
@@ -218,38 +218,62 @@ pub(crate) fn extendr_impl(
         }
     };
 
-    let expanded = TokenStream::from(quote! {
-        // The impl itself copied from the source.
-        #item_impl
+    let expanded = if opts.impl_only {
+        TokenStream::from(quote! {
+            // The impl itself copied from the source.
+            #item_impl
 
-        // Function wrappers
-        #( #wrappers )*
+            // Function wrappers
+            #( #wrappers )*
 
-        #conversion_impls
 
-        // Output conversion function for this type.
-        impl From<#self_ty> for Robj {
-            fn from(value: #self_ty) -> Self {
-                use extendr_api::ExternalPtr;
-                unsafe {
-                    let mut res: ExternalPtr<#self_ty> = ExternalPtr::new(value);
-                    res.set_attrib(class_symbol(), #self_ty_name).unwrap();
-                    res.into()
+            #[allow(non_snake_case)]
+            fn #meta_name(impls: &mut Vec<extendr_api::metadata::Impl>) {
+                let mut methods = Vec::new();
+                #( #method_meta_names(&mut methods); )*
+                impls.push(extendr_api::metadata::Impl {
+                    doc: #doc_string,
+                    name: #self_ty_name,
+                    methods,
+                    methods_only: true
+                });
+            }
+        })
+    } else {
+        TokenStream::from(quote! {
+            // The impl itself copied from the source.
+            #item_impl
+
+            // Function wrappers
+            #( #wrappers )*
+
+            #conversion_impls
+
+            // Output conversion function for this type.
+            impl From<#self_ty> for Robj {
+                fn from(value: #self_ty) -> Self {
+                    use extendr_api::ExternalPtr;
+                    unsafe {
+                        let mut res: ExternalPtr<#self_ty> = ExternalPtr::new(value);
+                        res.set_attrib(class_symbol(), #self_ty_name).unwrap();
+                        res.into()
+                    }
                 }
             }
-        }
 
-        #[allow(non_snake_case)]
-        fn #meta_name(impls: &mut Vec<extendr_api::metadata::Impl>) {
-            let mut methods = Vec::new();
-            #( #method_meta_names(&mut methods); )*
-            impls.push(extendr_api::metadata::Impl {
-                doc: #doc_string,
-                name: #self_ty_name,
-                methods,
-            });
-        }
-    });
+            #[allow(non_snake_case)]
+            fn #meta_name(impls: &mut Vec<extendr_api::metadata::Impl>) {
+                let mut methods = Vec::new();
+                #( #method_meta_names(&mut methods); )*
+                impls.push(extendr_api::metadata::Impl {
+                    doc: #doc_string,
+                    name: #self_ty_name,
+                    methods,
+                    methods_only: false
+                });
+            }
+        })
+    };
 
     //eprintln!("{}", expanded);
     Ok(expanded)

--- a/extendr-macros/src/extendr_options.rs
+++ b/extendr-macros/src/extendr_options.rs
@@ -5,6 +5,7 @@ pub(crate) struct ExtendrOptions {
     pub r_name: Option<String>,
     pub mod_name: Option<String>,
     pub use_rng: bool,
+    pub impl_only: bool,
 }
 
 impl ExtendrOptions {
@@ -14,6 +15,7 @@ impl ExtendrOptions {
     ///
     /// - `r_name = "name"` which specifies the name of the wrapper on the R-side.
     /// - `use_rng = bool` ensures the RNG-state is pulled and pushed
+    /// - `impl_only = bool` create wrappers for impl functions only
     ///
     pub fn parse(&mut self, meta: ParseNestedMeta) -> syn::parse::Result<()> {
         let value = meta.value()?;
@@ -45,6 +47,14 @@ impl ExtendrOptions {
                     Ok(())
                 } else {
                     Err(value.error("`use_rng` must be `true` or `false`"))
+                }
+            }
+            "impl_only" => {
+                if let Ok(LitBool { value, .. }) = value.parse() {
+                    self.impl_only = value;
+                    Ok(())
+                } else {
+                    Err(value.error("`impl_only` must be `true` or `false`"))
                 }
             }
             _ => Err(syn::Error::new_spanned(meta.path, "Unexpected key")),


### PR DESCRIPTION
This PR aims to address #538. As a recap, the `#[extendr]` module implements the conversions to an Robj when used on an `impl <T>` block. This causes a conflicts in implementations when trying to have multiple `impl` blocks tagged with `#[extendr]` across the code base.

The approach taken was to introduce a new optional key in `#[extendr(impl_only = true)]` which will exclude implementing the conversions for that block. Additionally, changes were made to `extendr-api/scr/metadata.rs` so that the `struct Impl` type is aware of if the methods are the only thing required and thus the wrappers do not overwrite each other.

This makes the following syntax valid 

```rust

use extendr_api::prelude::*;

struct Counter {
    n: i32,
}

mod create {
    use super::*;

    #[extendr]
    impl Counter {
        fn new() -> Self {
            Self { n: 0 }
        }
    }

    extendr_module! {
      mod create;
      impl Counter;
    }
}

mod increment {
    use super::*;

    #[extendr(impl_only = true)]
    impl Counter {
        fn get(&self) -> i32 {
            self.n
        }

        fn increment(&mut self) {
            self.n += 1
        }
    }

    extendr_module! {
      mod increment;
      impl Counter;
    }
}

extendr_module! {
  mod counter;
  use create;
  use increment;
}
```

The above would be invalid if the user attempted to tag, `#[extendr]` within the same mod. Thus the convention from this PR would be one `#[extendr]` tag  per impl block of a given type per module.

@CGMossa has also suggested removing the conversions from the impl blocks and instead requiring them on the struct itself. This PR does not take this approach, but I wouldn't mind updating the PR to do so.
