### PR TITLE
Allow multiple impl block 

### DIFF
--- a/extendr-macros/Cargo.toml
+++ b/extendr-macros/Cargo.toml
@@ -14,6 +14,7 @@ proc-macro = true
 syn = { version = "2.0", features = ["full", "extra-traits"] }
 quote = "1.0"
 proc-macro2 = { version = "1.0" }
+lazy_static = '*'
 
 [dev-dependencies]
 extendr-api = { path = "../extendr-api" }


### PR DESCRIPTION
add static ref CONVERSION_IMPLS hashmap to store impl blocks and only generate wrappers once. But it's getting overwritten.