### PR TITLE
chore: avoid r-devel check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ return `Option<Strings>` instead of opaque `Robj`.
 
 ### Fixed
 
+- Addresses change in R-Devel which turn [accessing 0 length vectors intto a segfault](https://github.com/wch/r-source/commit/d4dff56ff9d11ef96d67afccf8d9e8790d250664) <https://github.com/extendr/extendr/pull/883>
+
 ### Deprecated
 
 - Removed `from_sexp_ref()` from the public API. `from_sexp_ref()` is an unsafe method and is for internal use only. [#855]](https://github.com/extendr/extendr/pull/855)

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -777,6 +777,11 @@ macro_rules! make_typed_slice {
                 match self.sexptype() {
                     $( $sexp )|* => {
                         unsafe {
+                            // if the vector is empty return an empty slice
+                            if self.is_empty() {
+                                return Some(&[])
+                            }
+                            // otherwise get the slice
                             let ptr = $fn(self.get()) as *const $type;
                             Some(std::slice::from_raw_parts(ptr, self.len()))
                         }
@@ -789,8 +794,13 @@ macro_rules! make_typed_slice {
                 match self.sexptype() {
                     $( $sexp )|* => {
                         unsafe {
+                            if self.is_empty() {
+                                return Some(&mut []);
+                            }
                             let ptr = $fn(self.get_mut()) as *mut $type;
+
                             Some(std::slice::from_raw_parts_mut(ptr, self.len()))
+
                         }
                     }
                     _ => None

--- a/tests/extendrtests/.Rbuildignore
+++ b/tests/extendrtests/.Rbuildignore
@@ -2,3 +2,5 @@
 ^\.Rproj\.user$
 ^LICENSE\.md$
 ^notebooks$
+^src/\.cargo$
+^src/rust/vendor$

--- a/tests/extendrtests/.gitignore
+++ b/tests/extendrtests/.gitignore
@@ -41,5 +41,3 @@ vignettes/*.pdf
 # check dir
 check/
 src/rust/vendor
-src/Makevars
-src/Makevars.win

--- a/tests/extendrtests/.gitignore
+++ b/tests/extendrtests/.gitignore
@@ -40,3 +40,6 @@ vignettes/*.pdf
 
 # check dir
 check/
+src/rust/vendor
+src/Makevars
+src/Makevars.win

--- a/tests/extendrtests/DESCRIPTION
+++ b/tests/extendrtests/DESCRIPTION
@@ -11,7 +11,7 @@ Description:
   Provides tests for extendr functionality used from
   within an R package.
 License: MIT + file LICENSE
-SystemRequirements: Rust
+SystemRequirements: Cargo (Rust's package manager), rustc
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2

--- a/tests/extendrtests/configure
+++ b/tests/extendrtests/configure
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+: "${R_HOME=`R RHOME`}"
+"${R_HOME}/bin/Rscript" tools/msrv.R 
+

--- a/tests/extendrtests/configure.win
+++ b/tests/extendrtests/configure.win
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+"${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" tools/msrv.R
+

--- a/tests/extendrtests/src/Makevars
+++ b/tests/extendrtests/src/Makevars
@@ -8,7 +8,7 @@ all: C_clean
 $(SHLIB): $(STATLIB)
 
 $(STATLIB):
-	cargo build --lib --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) --color=auto
+	cargo build --quiet --lib --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) --color=auto
 
 C_clean:
 	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)

--- a/tests/extendrtests/src/Makevars.ucrt
+++ b/tests/extendrtests/src/Makevars.ucrt
@@ -1,5 +1,0 @@
-# Rtools42 doesn't have the linker in the location that cargo expects, so we
-# need to overwrite it via configuration.
-CARGO_LINKER = x86_64-w64-mingw32.static.posix-gcc.exe
-
-include Makevars.win

--- a/tests/extendrtests/src/Makevars.win
+++ b/tests/extendrtests/src/Makevars.win
@@ -24,7 +24,7 @@ $(STATLIB):
 	# CARGO_LINKER is provided in Makevars.ucrt for R >= 4.2
 	export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
 		export LIBRARY_PATH="$${LIBRARY_PATH};$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \
-		cargo build --target=$(TARGET) --lib --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) --color=always
+		cargo build --quiet --target=$(TARGET) --lib --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) --color=always
 
 C_clean:
 	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)

--- a/tests/extendrtests/src/extendrtests-win.def
+++ b/tests/extendrtests/src/extendrtests-win.def
@@ -1,0 +1,2 @@
+EXPORTS
+R_init_extendrtests

--- a/tests/extendrtests/tools/msrv.R
+++ b/tests/extendrtests/tools/msrv.R
@@ -1,0 +1,116 @@
+# read the DESCRIPTION file
+desc <- read.dcf("DESCRIPTION")
+
+if (!"SystemRequirements" %in% colnames(desc)) {
+  fmt <- c(
+    "`SystemRequirements` not found in `DESCRIPTION`.",
+    "Please specify `SystemRequirements: Cargo (Rust's package manager), rustc`"
+  )
+  stop(paste(fmt, collapse = "\n"))
+}
+
+# extract system requirements
+sysreqs <- desc[, "SystemRequirements"]
+
+# check that cargo and rustc is found
+if (!grepl("cargo", sysreqs, ignore.case = TRUE)) {
+  stop("You must specify `Cargo (Rust's package manager)` in your `SystemRequirements`")
+}
+
+if (!grepl("rustc", sysreqs, ignore.case = TRUE)) {
+  stop("You must specify `Cargo (Rust's package manager), rustc` in your `SystemRequirements`")
+}
+
+# split into parts
+parts <- strsplit(sysreqs, ", ")[[1]]
+
+# identify which is the rustc
+rustc_ver <- parts[grepl("rustc", parts)]
+
+# perform checks for the presence of rustc and cargo on the OS
+no_cargo_msg <- c(
+  "----------------------- [CARGO NOT FOUND]--------------------------",
+  "The 'cargo' command was not found on the PATH. Please install Cargo",
+  "from: https://www.rust-lang.org/tools/install",
+  "",
+  "Alternatively, you may install Cargo from your OS package manager:",
+  " - Debian/Ubuntu: apt-get install cargo",
+  " - Fedora/CentOS: dnf install cargo",
+  " - macOS: brew install rust",
+  "-------------------------------------------------------------------"
+)
+
+no_rustc_msg <- c(
+  "----------------------- [RUST NOT FOUND]---------------------------",
+  "The 'rustc' compiler was not found on the PATH. Please install",
+  paste(rustc_ver, "or higher from:"),
+  "https://www.rust-lang.org/tools/install",
+  "",
+  "Alternatively, you may install Rust from your OS package manager:",
+  " - Debian/Ubuntu: apt-get install rustc",
+  " - Fedora/CentOS: dnf install rustc",
+  " - macOS: brew install rust",
+  "-------------------------------------------------------------------"
+)
+
+# Add {user}/.cargo/bin to path before checking
+new_path <- paste0(
+  Sys.getenv("PATH"),
+  ":",
+  paste0(Sys.getenv("HOME"), "/.cargo/bin")
+)
+
+# set the path with the new path
+Sys.setenv("PATH" = new_path)
+
+# check for rustc installation
+rustc_version <- tryCatch(
+  system("rustc --version", intern = TRUE),
+  error = function(e) {
+    stop(paste(no_rustc_msg, collapse = "\n"))
+  }
+)
+
+# check for cargo installation
+cargo_version <- tryCatch(
+  system("cargo --version", intern = TRUE),
+  error = function(e) {
+    stop(paste(no_cargo_msg, collapse = "\n"))
+  }
+)
+
+# helper function to extract versions
+extract_semver <- function(ver) {
+  if (grepl("\\d+\\.\\d+(\\.\\d+)?", ver)) {
+    sub(".*?(\\d+\\.\\d+(\\.\\d+)?).*", "\\1", ver)
+  } else {
+    NA
+  }
+}
+
+# get the MSRV
+msrv <- extract_semver(rustc_ver)
+
+# extract current version
+current_rust_version <- extract_semver(rustc_version)
+
+# perform check
+if (!is.na(msrv)) {
+  # -1 when current version is later
+  # 0 when they are the same
+  # 1 when MSRV is newer than current
+  is_msrv <- utils::compareVersion(msrv, current_rust_version)
+  if (is_msrv == 1) {
+    fmt <- paste0(
+      "\n------------------ [UNSUPPORTED RUST VERSION]------------------\n",
+      "- Minimum supported Rust version is %s.\n",
+      "- Installed Rust version is %s.\n",
+      "---------------------------------------------------------------"
+    )
+    stop(sprintf(fmt, msrv, current_rust_version))
+  }
+}
+
+# print the versions
+versions_fmt <- "Using %s\nUsing %s"
+message(sprintf(versions_fmt, cargo_version, rustc_version))


### PR DESCRIPTION
This PR :

- makes `cargo build` quiet in extendrtests so that CI for r-devel can finally pass. 
- adds `tools/msrv.R` to report rustc and cargo versions for r-devel
- addresses 0x1 error in 0 length vectors in r-devel
