### PR TITLE
Implement Index and IndexMut for 3D Array (RMatrix3D)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added implementations for `Index<[usize; 3]>` and `IndexMut<[usize; 3]>` traits in `RMatrix3D`.
+- Added implementations for `Index<[usize; 3]>` and `IndexMut<[usize; 3]>` traits in `RMatrix3D` [[#897]](https://github.com/extendr/extendr/pull/897)
 - Type aliases `RMatrix4D` and `RMatrix5D` have been added <https://github.com/extendr/extendr/pull/875>
 - `ExternalPtr<T>` and `&ExternalPtr<T>` can now be used as function arguments with appropriate type checking <https://github.com/extendr/extendr/pull/853>
 - `TryFrom<Robj>` is now implemented for `&ExternalPtr<T>` and `&mut ExternalPtr<T>` <https://github.com/extendr/extendr/pull/833>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added implementations for `Index<[usize; 3]>` and `IndexMut<[usize; 3]>` traits in `RMatrix3D`.
 - Type aliases `RMatrix4D` and `RMatrix5D` have been added <https://github.com/extendr/extendr/pull/875>
 - `ExternalPtr<T>` and `&ExternalPtr<T>` can now be used as function arguments with appropriate type checking <https://github.com/extendr/extendr/pull/853>
 - `TryFrom<Robj>` is now implemented for `&ExternalPtr<T>` and `&mut ExternalPtr<T>` <https://github.com/extendr/extendr/pull/833>

--- a/extendr-api/src/wrapper/matrix.rs
+++ b/extendr-api/src/wrapper/matrix.rs
@@ -584,6 +584,66 @@ where
     }
 }
 
+impl<T> Index<[usize; 3]> for RArray<T, [usize; 3]>
+where
+    Robj: for<'a> AsTypedSlice<'a, T>,
+{
+    type Output = T;
+
+    /// Zero-based indexing in row, column order.
+    ///
+    /// Panics if out of bounds.
+    /// ```
+    /// use extendr_api::prelude::*;
+    /// test! {
+    ///    let matrix = RArray::new_matrix3d(3, 2, 2, |r, c, d| (r + c + d) as f64);
+    ///     assert_eq!(matrix[[0, 0, 0]], 0.);
+    ///     assert_eq!(matrix[[1, 0, 1]], 2.);
+    ///     assert_eq!(matrix[[2, 1, 1]], 4.);
+    /// }
+    /// ```
+    fn index(&self, index: [usize; 3]) -> &Self::Output {
+        unsafe {
+            self.data()
+                .as_ptr()
+                .add(self.offset(index))
+                .as_ref()
+                .unwrap()
+        }
+    }
+}
+
+impl<T> IndexMut<[usize; 3]> for RArray<T, [usize; 3]>
+where
+    Robj: for<'a> AsTypedSlice<'a, T>,
+{
+    /// Zero-based mutable indexing in row, column order.
+    ///
+    /// Panics if out of bounds.
+    /// ```
+    /// use extendr_api::prelude::*;
+    /// test! {
+    ///    let mut matrix = RMatrix3D::new_matrix3d(3, 2, 2, |_, _, _| 0.);
+    ///    matrix[[0, 0, 0]] = 1.;
+    ///    matrix[[1, 0, 0]] = 2.;
+    ///    matrix[[2, 0, 0]] = 3.;
+    ///    matrix[[0, 1, 0]] = 4.;
+    ///    assert_eq!(matrix.as_real_slice().unwrap(), 
+    ///        &[1., 2., 3., 4., 0., 0., 0., 0., 0., 0., 0., 0.]);
+    /// }
+    /// ```
+    fn index_mut(&mut self, index: [usize; 3]) -> &mut Self::Output {
+        unsafe {
+            self.data_mut()
+                .as_mut_ptr()
+                .add(self.offset(index))
+                .as_mut()
+                .unwrap()
+        }
+    }
+}
+
+
 impl<T, D> Deref for RArray<T, D> {
     type Target = Robj;
 


### PR DESCRIPTION
This PR adds implementations of `Index<[usize; 3]>` and `IndexMut<[usize; 3]>` for `RMatrix3D`. 

- Zero-based indexing for 3D arrays, allowing direct usage like `matrix[[r, c, d]]`.
- Includes doc tests demonstrating creation and mutation of 3D matrices.

This adds consistency with existing 2D matrix indexing.

