### PR TITLE
chore: set up R in docs CI step

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
+      - uses: r-lib/actions/setup-r@v2
       - name: Docs
         run: cargo doc --workspace --no-deps --document-private-items --features full-functionality
         env:


### PR DESCRIPTION
GHA runners removed R. So approximately 3 months ago the GHA to update docs has been failing. 

This PR uses the set up R action from the r-lib organization.