### PR TITLE
Adding ser/de to `Complexes` and `Strings`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,4 @@ repository = "https://github.com/extendr/extendr"
 # When updating extendr's version, this version also needs to be updated
 extendr-macros = { path = "./extendr-macros", version = "0.8.0" }
 extendr-ffi = { path = "./extendr-ffi", version = "0.8.0" }
+serde = { version = "1.0.219", features = ["derive"] }

--- a/extendr-api/Cargo.toml
+++ b/extendr-api/Cargo.toml
@@ -19,7 +19,7 @@ either = { version = "1.8.1", optional = true }
 libc = { version = "0.2", optional = true }
 ndarray = { version = "0.16.1", optional = true }
 num-complex = { version = "0.4.6", optional = true }
-serde = { version = "1.0.219", features = ["derive"], optional = true }
+serde = { workspace = true, optional = true }
 faer = { version = "0.20", optional = true }
 
 [dev-dependencies]
@@ -45,6 +45,7 @@ full-functionality = [
     "num-complex",
     "serde",
 ]
+serde = ["dep:serde", "extendr-ffi/serde"]
 
 # Parts of the R-API are locked behind non-API, as CRAN frowns upon the presence
 # of non-API items in packages. You may enable this feature, to generate

--- a/extendr-api/src/scalar/rcplx_default.rs
+++ b/extendr-api/src/scalar/rcplx_default.rs
@@ -39,9 +39,9 @@ impl CanBeNA for c64 {
     }
 }
 
-/// Rcplx is a wrapper for f64 in the context of an R's complex vector.
+/// Rcplx is a wrapper for `f64` in the context of an R's complex vector.
 ///
-/// Rcplx has a special NA value, obtained from R headers via R_NaReal.
+/// Rcplx has a special `NA` value, obtained from R headers via `R_NaReal`.
 ///
 /// Rcplx has the same footprint as R's complex value allowing us to use it in zero copy slices.
 #[derive(Clone, Copy, Default, PartialEq)]

--- a/extendr-api/src/scalar/rcplx_full.rs
+++ b/extendr-api/src/scalar/rcplx_full.rs
@@ -19,9 +19,9 @@ impl CanBeNA for c64 {
     }
 }
 
-/// Rcplx is a wrapper for f64 in the context of an R's complex vector.
+/// Rcplx is a wrapper for `f64` in the context of an R's complex vector.
 ///
-/// Rcplx has a special NA value, obtained from R headers via R_NaReal.
+/// Rcplx has a special `NA` value, obtained from R headers via `R_NaReal`.
 ///
 /// Rcplx has the same footprint as R's complex value allowing us to use it in zero copy slices.
 #[repr(transparent)]

--- a/extendr-api/src/wrapper/complexes.rs
+++ b/extendr-api/src/wrapper/complexes.rs
@@ -96,6 +96,17 @@ impl TryFrom<Vec<c64>> for Complexes {
     }
 }
 
+#[cfg(feature = "serde")]
+impl serde::Serialize for Complexes {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let self_as_slice: &[Rcomplex] = self.robj.as_typed_slice().unwrap();
+        self_as_slice.serialize(serializer)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/extendr-ffi/Cargo.toml
+++ b/extendr-ffi/Cargo.toml
@@ -12,5 +12,8 @@ links = "R"
 default = []
 non-api = []
 
+[dependencies]
+serde = { workspace = true, optional = true }
+
 [build-dependencies]
 build-print = "0.1.1"

--- a/extendr-ffi/src/lib.rs
+++ b/extendr-ffi/src/lib.rs
@@ -32,6 +32,7 @@ extern "C" {
 
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// A C type with enumeration constants FALSE and TRUE defined.
 pub enum Rboolean {
     #[doc = ", MAYBE"]
@@ -137,6 +138,7 @@ pub type Int32 = ::std::os::raw::c_uint;
 #[doc = "R 4.3 redefined `Rcomplex` to a union for compatibility with Fortran.\n But the old definition is compatible both the union version\n and the struct version.\n See: <https://github.com/extendr/extendr/issues/524>\n <div rustbindgen replaces=\"Rcomplex\"></div>"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Rcomplex {
     pub r: f64,
     pub i: f64,


### PR DESCRIPTION
Fixes #876

While #876 seemed like a good-first-issue, I believe it requires too much for newcomers. Here's my take on it.

- `Rcomplex` is the direct, independent of enabled features, way to serialize `Complexes`.

- [ ] Missing `Strings` serialization