### PR TITLE
Bump MSRV to 1.81

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-      - uses: r-lib/actions/setup-r@v2
       - name: Docs
         run: cargo doc --workspace --no-deps --document-private-items --features full-functionality
         env:

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -29,9 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: baptiste0928/cargo-install@v3
-        with:
-          crate: cargo-msrv
+      - name: Installing `cargo-msrv`
+        run: |
+          . ./ci-cargo.ps1
+          ci-cargo install cargo-msrv
 
       # Default R installation has been removed from OS image starting with 24.04
       # https://github.com/actions/runner-images/issues/10636
@@ -40,7 +41,11 @@ jobs:
         with:
           r-version: 'release'
 
-      - name: Verify minimum rust version
+      - name: Verify minimum rust version of extendr-api
         run: |
           . ./ci-cargo.ps1
-          ci-cargo msrv --path extendr-api/ verify -ActionName "Verify Rust MSRV"
+          ci-cargo extendr msrv verify -ActionName "Verify Rust MSRV for extendr-api"
+      - name: Verify minimum rust version of extendr-api with full functionality
+        run: |
+          . ./ci-cargo.ps1
+          ci-cargo extendr msrv --features=full-functionality --path extendr-api/ verify -ActionName "Verify Rust MSRV for extendr-api"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,14 +107,6 @@ jobs:
           components: rustfmt, clippy
 
       - name: Install cargo-expand
-        uses: dtolnay/install@master
-        if: startsWith(runner.os, 'Windows') != true
-        with:
-          crate: cargo-expand
-
-        # https://github.com/dtolnay/install/issues/12
-      - name: Install cargo-expand (dtolnay/install#12 workaround)
-        if: startsWith(runner.os, 'Windows')
         run: cargo install cargo-expand
 
       - name: Set up R
@@ -124,9 +116,6 @@ jobs:
           rtools-version: ${{ matrix.config.rtools-version }}
           # TODO: enable RSPM when all the packages are available
           use-public-rspm: true
-
-      - name: Set up Pandoc
-        uses: r-lib/actions/setup-pandoc@v2
 
       - name: Configure Windows
         if: startsWith(runner.os, 'Windows')
@@ -187,7 +176,9 @@ jobs:
       # Check code formatting. As this doesn't depend on the platform, do this only on one platform.
       - name: Check code formatting
         if: matrix.config.check_fmt
-        run: cargo fmt -- --check
+        run: |
+          . ./ci-cargo.ps1
+          ci-cargo extendr check-fmt
 
       # For each target in the BUILD_TARGETS comma-separated list, run cargo build with appropriate target
       # Required by Windows builds, does not affect other platforms
@@ -246,7 +237,8 @@ jobs:
 
       - name: Run R integration tests using {extendrtests} and `cargo extendr r-cmd-check`
         run: |
-          cargo extendr r-cmd-check --error-on ${{ steps.error-on.outputs.level }} --check-dir extendrtests_check
+          . ./ci-cargo.ps1
+          ci-cargo extendr r-cmd-check --error-on ${{ steps.error-on.outputs.level }} --check-dir extendrtests_check
       - name: Upload `check-dir` if r-cmd-check failed on `{extendrtests}`
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/trigger_rextendr_ci.yaml
+++ b/.github/workflows/trigger_rextendr_ci.yaml
@@ -1,19 +1,18 @@
 name: Trigger rextendr CI
 on:
-	pull_request:
-		types:
-			- closed
-		branches:
-			- master
-
+  pull_request:
+    types:
+      - closed
+    branches:
+      - master
 jobs:
-	dispatch-to-rextendr:
-		if: github.event.pull_request.merged == true
-		runs-on: ubuntu-latest
-		steps:
-			- name: Trigger rextendr test workflow
-				uses: peter-evans/repository-dispatch@v3
-				with:
-					token: ${{ secrets.GITHUB_TOKEN }}
-					repository: extendr/rextendr
-					event-type: extendr-pr-merged
+  dispatch-to-rextendr:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger rextendr test workflow
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: extendr/rextendr
+          event-type: extendr-pr-merged

--- a/extendr-api/Cargo.toml
+++ b/extendr-api/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 repository.workspace = true
 
 # Note: it seems cargo-msrv doesn't support rust-version.workspace = true.
-rust-version = "1.65"
+rust-version = "1.81"
 
 [dependencies]
 extendr-ffi = { workspace = true }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -9,6 +9,6 @@ authors.workspace = true
 publish = false
 
 [dependencies]
-clap = { version = "4.4", features = ["derive"] }
+clap = { version = "4.5", features = ["derive"] }
 toml_edit = "0.22"
 xshell = "0.2"

--- a/xtask/src/cli/mod.rs
+++ b/xtask/src/cli/mod.rs
@@ -1,9 +1,11 @@
 use clap::{Parser, Subcommand};
 
 pub(crate) mod devtools_test;
+pub(crate) mod msrv;
 pub(crate) mod r_cmd_check;
 
 use devtools_test::DevtoolsTestArg;
+use msrv::MsrvArg;
 use r_cmd_check::RCmdCheckArg;
 
 #[derive(Parser, Debug)]
@@ -24,7 +26,7 @@ pub(crate) enum Commands {
     #[command(about = "Generate documentation for all features")]
     Doc,
     #[command(about = "Check that the specified rust-version is MSRV")]
-    Msrv,
+    Msrv(MsrvArg),
     #[command(about = "Run devtools::test() on {extendrtests} and generate snapshots")]
     DevtoolsTest(DevtoolsTestArg),
     #[command(about = "Generate wrappers by `rextendr::document()`")]

--- a/xtask/src/cli/msrv.rs
+++ b/xtask/src/cli/msrv.rs
@@ -1,0 +1,7 @@
+use clap::Args;
+
+#[derive(Args, Debug)]
+pub(crate) struct MsrvArg {
+    #[arg(short='F', long, num_args=1.., value_delimiter=',')]
+    pub(crate) features: Option<Vec<String>>,
+}

--- a/xtask/src/commands/cargo_msrv.rs
+++ b/xtask/src/commands/cargo_msrv.rs
@@ -1,7 +1,13 @@
 use xshell::{cmd, Error, Shell};
 
-pub(crate) fn run(shell: &Shell) -> Result<(), Error> {
-    let msrv = cmd!(shell, "cargo-msrv --path extendr-api verify").run();
+pub(crate) fn run(shell: &Shell, features: Option<Vec<String>>) -> Result<(), Error> {
+    let features_arg = features.map(|x| x.join(",")).unwrap_or_default();
+
+    let msrv = cmd!(
+        shell,
+        "cargo-msrv --path extendr-api verify -- cargo check --features={features_arg}"
+    )
+    .run();
     if msrv.is_err() {
         println!(
             "Cannot perform `cargo-msrv` check\nInstall `cargo-msrv` by `cargo install cargo-msrv`"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use xshell::Shell;
 
+use cli::msrv::MsrvArg;
 use cli::r_cmd_check::RCmdCheckArg;
 
 mod cli;
@@ -35,7 +36,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             original_path,
         )?,
         cli::Commands::Doc => commands::generate_docs::run(&shell)?,
-        cli::Commands::Msrv => commands::cargo_msrv::run(&shell)?,
+        cli::Commands::Msrv(MsrvArg { features }) => commands::cargo_msrv::run(&shell, features)?,
         cli::Commands::DevtoolsTest(args) => commands::devtools_test::run(&shell, args)?,
         cli::Commands::Document => commands::rextendr_document::run(&shell)?,
     };


### PR DESCRIPTION
Fixes #921 

- Bump `extendr-api`'s MSRV to `1.81`
- Now, the embedded `faer` version does satisfy MSRV
- Added `cargo extendr msrv --features` argument, to ensure that we routinely check the MSRV of extendr-api and its optionals.

Together with this PR, a slew of CI improvements made it through. 