### PR TITLE
Remove build-print dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,12 +221,6 @@ jobs:
             any::rcmdcheck
             github::extendr/rextendr
 
-      - name: Install dependencies for rextendr
-        uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          cache-version: 4
-          working-directory: tests/rextendr
-
       # TODO: allow warnings on oldrel (cf., https://stat.ethz.ch/pipermail/r-package-devel/2023q2/009229.html)
       - name: Check R version
         id: error-on

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -212,19 +212,14 @@ jobs:
             ci-cargo test --features ${{ matrix.config.features }} $(if($target -ne 'default') {"--target=$target"} ) '--' --nocapture @( $testArgs ) -ActionName "Testing for $target target"
           }
 
-      # c.f. https://github.com/actions/checkout#checkout-multiple-repos-side-by-side
-      - name: Obtain 'rextendr'
-        uses: actions/checkout@v4
-        with:
-          repository: extendr/rextendr
-          path: ./tests/rextendr
-
       - name: Install dependencies for extendrtests and rcmdcheck
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
           cache-version: 4
           working-directory: tests/extendrtests
-          extra-packages: any::rcmdcheck
+          extra-packages: |
+            any::rcmdcheck
+            github::extendr/rextendr
 
       - name: Install dependencies for rextendr
         uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/trigger_rextendr_ci.yaml
+++ b/.github/workflows/trigger_rextendr_ci.yaml
@@ -1,19 +1,20 @@
 name: Trigger rextendr CI
+
 on:
-	pull_request:
-		types:
-			- closed
-		branches:
-			- master
+  pull_request:
+    types:
+      - closed
+    branches:
+      - master
 
 jobs:
-	dispatch-to-rextendr:
-		if: github.event.pull_request.merged == true
-		runs-on: ubuntu-latest
-		steps:
-			- name: Trigger rextendr test workflow
-				uses: peter-evans/repository-dispatch@v3
-				with:
-					token: ${{ secrets.GITHUB_TOKEN }}
-					repository: extendr/rextendr
-					event-type: extendr-pr-merged
+  dispatch-to-rextendr:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger rextendr test workflow
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: extendr/rextendr
+          event-type: extendr-pr-merged

--- a/extendr-ffi/Cargo.toml
+++ b/extendr-ffi/Cargo.toml
@@ -11,6 +11,3 @@ links = "R"
 [features]
 default = []
 non-api = []
-
-[build-dependencies]
-build-print = "0.1.1"

--- a/extendr-ffi/build.rs
+++ b/extendr-ffi/build.rs
@@ -183,6 +183,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Used by extendr-engine becomes DEP_R_R_HOME for clients
     println!("cargo:r_home={}", r_paths.r_home.display());
     println!("cargo:rustc-env=R_HOME={}", r_paths.r_home.display());
+
     // used by extendr-api
     println!("cargo:r_version_major={}", r_paths.version.major);
     println!("cargo:r_version_minor={}", r_paths.version.minor);
@@ -194,12 +195,14 @@ fn main() -> Result<(), Box<dyn Error>> {
         // For Windows
         (true, "x86_64") => Path::new(&r_paths.r_home).join("bin").join("x64"),
         (true, "x86") => Path::new(&r_paths.r_home).join("bin").join("i386"),
-        (true, _) => panic!("Unknown architecture"),
+        (true, _) => {
+            return Err("Cannot build extendr-ffi for unknown architecture".into());
+        }
         // For Unix-alike
         (false, _) => Path::new(&r_paths.r_home).join("lib"),
     };
 
-    info!("R library paths determined to be at: {libdir:?}");
+    note!("R library paths determined to be at: {libdir:?}");
 
     if let Ok(r_library) = libdir.canonicalize() {
         println!("cargo:rustc-link-search={}", r_library.display());
@@ -227,7 +230,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 // Taken from build-print
 #[macro_export]
-macro_rules! println {
+macro_rules! buildprintln {
     () => {
         ::std::println!("cargo:warning=\x1b[2K\r");
     };
@@ -239,43 +242,43 @@ macro_rules! println {
 #[macro_export]
 macro_rules! custom_println {
     ($prefix:literal, cyan, $($arg:tt)*) => {
-        $crate::println!("   \x1b[1m\x1b[36m{}\x1b[0m {}", $prefix, ::std::format!($($arg)+));
+        buildprintln!("   \x1b[1m\x1b[36m{}\x1b[0m {}", $prefix, ::std::format!($($arg)+));
     };
     ($prefix:literal, green, $($arg:tt)*) => {
-        $crate::println!("   \x1b[1m\x1b[32m{}\x1b[0m {}", $prefix, ::std::format!($($arg)+));
+       buildprintln!("   \x1b[1m\x1b[32m{}\x1b[0m {}", $prefix, ::std::format!($($arg)+));
     };
     ($prefix:literal, yellow, $($arg:tt)*) => {
-        $crate::println!("   \x1b[1m\x1b[33m{}\x1b[0m {}", $prefix, ::std::format!($($arg)+));
+        buildprintln!("   \x1b[1m\x1b[33m{}\x1b[0m {}", $prefix, ::std::format!($($arg)+));
     };
     ($prefix:literal, red, $($arg:tt)*) => {
-        $crate::println!("   \x1b[1m\x1b[31m{}\x1b[0m {}", $prefix, ::std::format!($($arg)+));
+        buildprintln!("   \x1b[1m\x1b[31m{}\x1b[0m {}", $prefix, ::std::format!($($arg)+));
     };
 }
 
 #[macro_export]
 macro_rules! info {
     ($($arg:tt)+) => {
-        $crate::custom_println!("info:", green, $($arg)+);
+        custom_println!("info:", green, $($arg)+);
     }
 }
 
 #[macro_export]
 macro_rules! warn {
     ($($arg:tt)+) => {
-        $crate::custom_println!("warning:", yellow, $($arg)+);
+        custom_println!("warning:", yellow, $($arg)+);
     }
 }
 
 #[macro_export]
 macro_rules! error {
     ($($arg:tt)+) => {
-        $crate::custom_println!("error:", red, $($arg)+);
+        custom_println!("error:", red, $($arg)+);
     }
 }
 
 #[macro_export]
 macro_rules! note {
     ($($arg:tt)+) => {
-        $crate::custom_println!("note:", cyan, $($arg)+);
+        custom_println!("note:", cyan, $($arg)+);
     }
 }

--- a/extendr-ffi/build.rs
+++ b/extendr-ffi/build.rs
@@ -1,4 +1,3 @@
-use build_print::{error, info, warn};
 use std::{
     error::Error,
     fs::read_to_string,
@@ -222,6 +221,61 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Only re-run if the include directory changes
     println!("cargo:rerun-if-env-changed=R_INCLUDE_DIR");
 
-    build_print::custom_println!(" Success:", green, "extendr-ffi has been built!");
+    custom_println!(" Success:", green, "extendr-ffi has been built!");
     Ok(())
+}
+
+// Taken from build-print
+#[macro_export]
+macro_rules! println {
+    () => {
+        ::std::println!("cargo:warning=\x1b[2K\r");
+    };
+    ($($arg:tt)*) => {
+        ::std::println!("cargo:warning=\x1b[2K\r{}", ::std::format!($($arg)*))
+    }
+}
+
+#[macro_export]
+macro_rules! custom_println {
+    ($prefix:literal, cyan, $($arg:tt)*) => {
+        $crate::println!("   \x1b[1m\x1b[36m{}\x1b[0m {}", $prefix, ::std::format!($($arg)+));
+    };
+    ($prefix:literal, green, $($arg:tt)*) => {
+        $crate::println!("   \x1b[1m\x1b[32m{}\x1b[0m {}", $prefix, ::std::format!($($arg)+));
+    };
+    ($prefix:literal, yellow, $($arg:tt)*) => {
+        $crate::println!("   \x1b[1m\x1b[33m{}\x1b[0m {}", $prefix, ::std::format!($($arg)+));
+    };
+    ($prefix:literal, red, $($arg:tt)*) => {
+        $crate::println!("   \x1b[1m\x1b[31m{}\x1b[0m {}", $prefix, ::std::format!($($arg)+));
+    };
+}
+
+#[macro_export]
+macro_rules! info {
+    ($($arg:tt)+) => {
+        $crate::custom_println!("info:", green, $($arg)+);
+    }
+}
+
+#[macro_export]
+macro_rules! warn {
+    ($($arg:tt)+) => {
+        $crate::custom_println!("warning:", yellow, $($arg)+);
+    }
+}
+
+#[macro_export]
+macro_rules! error {
+    ($($arg:tt)+) => {
+        $crate::custom_println!("error:", red, $($arg)+);
+    }
+}
+
+#[macro_export]
+macro_rules! note {
+    ($($arg:tt)+) => {
+        $crate::custom_println!("note:", cyan, $($arg)+);
+    }
 }

--- a/tests/extendrtests/DESCRIPTION
+++ b/tests/extendrtests/DESCRIPTION
@@ -15,9 +15,8 @@ SystemRequirements: Cargo (Rust's package manager), rustc
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
-Imports:
-    rextendr,
 Suggests:
+    rextendr,
     brio,
     patrick,
     processx,

--- a/tests/extendrtests/DESCRIPTION
+++ b/tests/extendrtests/DESCRIPTION
@@ -27,5 +27,7 @@ Suggests:
     vctrs,
     lobstr,
     rprojroot
+Remotes:
+    extendr/rextendr
 Config/testthat/edition: 3
 Config/rextendr/version: 0.3.1.9001

--- a/tests/extendrtests/tests/testthat/_snaps/macro-snapshot.md
+++ b/tests/extendrtests/tests/testthat/_snaps/macro-snapshot.md
@@ -73,7 +73,6 @@
                   self.0.len()
               }
           }
-          #[cfg(use_r_altlist)]
           impl VecUsize {}
           #[allow(non_snake_case)]
           fn meta__VecUsize(impls: &mut Vec<extendr_api::metadata::Impl>) {
@@ -85,7 +84,6 @@
                       methods,
                   });
           }
-          #[cfg(use_r_altlist)]
           impl AltListImpl for VecUsize {
               fn elt(&self, index: usize) -> Robj {
                   let mut v = Vec::with_capacity(1usize);
@@ -94,7 +92,6 @@
                   Self(v).into_robj()
               }
           }
-          #[cfg(use_r_altlist)]
           fn new_usize(robj: Integers) -> Altrep {
               let x = robj
                   .iter()


### PR DESCRIPTION
This PR removes build-print dev dependency for extendr-ffi. 

As build-print is MIT licensed, I've moved the macro definitions into the crate. This is because they set their rust edition to 2024. 