### PR TITLE
Support aarch64-win

### DIFF
--- a/extendr-api/src/metadata.rs
+++ b/extendr-api/src/metadata.rs
@@ -200,7 +200,7 @@ fn write_function_wrapper(
             func.return_type == "()" || func.return_type == "Result"
         }
     };
-    
+
     if should_be_invisible {
         write!(
             w,
@@ -267,11 +267,9 @@ fn write_method_wrapper(
     let should_be_invisible = match func.invisible {
         Some(true) => true,
         Some(false) => false,
-        None => {
-            func.return_type == "()" || func.return_type == "Result"
-        }
+        None => func.return_type == "()" || func.return_type == "Result",
     };
-    
+
     if should_be_invisible {
         write!(
             w,

--- a/extendr-ffi/build.rs
+++ b/extendr-ffi/build.rs
@@ -195,6 +195,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         // For Windows
         (true, "x86_64") => Path::new(&r_paths.r_home).join("bin").join("x64"),
         (true, "x86") => Path::new(&r_paths.r_home).join("bin").join("i386"),
+        (true, "aarch64") => Path::new(&r_paths.r_home).join("bin"),
         (true, _) => {
             return Err("Cannot build extendr-ffi for unknown architecture".into());
         }


### PR DESCRIPTION
Allow building `extendr-ffi` for `aarch64` on Windiws