### PR TITLE
chore: rename master to main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Documents
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   docs:

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - master
   workflow_dispatch:
 
 # Cancel previous runs when new commits are pushed

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - master
 
 # Cancel previous runs when new commits are pushed
 concurrency:

--- a/.github/workflows/pr-devel-check.yml
+++ b/.github/workflows/pr-devel-check.yml
@@ -5,7 +5,6 @@ on:
     types: [labeled, synchronize, reopened]
     branches:
       - main
-      - master
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/trigger_rextendr_ci.yaml
+++ b/.github/workflows/trigger_rextendr_ci.yaml
@@ -5,7 +5,7 @@ on:
     types:
       - closed
     branches:
-      - master
+      - main
 
 jobs:
   dispatch-to-rextendr:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ We welcome contributions to the extendr project. Contributions come in many form
 
 ## Code of Conduct
 
-We take our open source community seriously and hold ourselves and other contributors to high standards of communication. By participating and contributing to this project, you agree to uphold our [Code of Conduct.](https://github.com/extendr/extendr/blob/master/CODE-OF-CONDUCT.md)
+We take our open source community seriously and hold ourselves and other contributors to high standards of communication. By participating and contributing to this project, you agree to uphold our [Code of Conduct.](https://github.com/extendr/extendr/blob/main/CODE-OF-CONDUCT.md)
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![DOI](https://joss.theoj.org/papers/10.21105/joss.06394/status.svg)](https://doi.org/10.21105/joss.06394)
 
-[![Logo](https://github.com/extendr/extendr/raw/master/extendr-logo-256.png)](https://github.com/extendr/extendr/raw/master/extendr-logo-256.png)
+[![Logo](https://github.com/extendr/extendr/raw/main/extendr-logo-256.png)](https://github.com/extendr/extendr/raw/main/extendr-logo-256.png)
 
 ## Welcome
 


### PR DESCRIPTION
  Changes all references from master to main branch in workflow files and documentation URLs.

  After merging: An admin needs to rename the branch on GitHub (Settings -> Branches ->  rename master to
  main). Then contributors should run:
  git branch -m master main
  git fetch origin
  git branch -u origin/main main