### PR TITLE
fix limitation in `ser/de` features

### DIFF
--- a/extendr-api/src/deserializer.rs
+++ b/extendr-api/src/deserializer.rs
@@ -161,11 +161,15 @@ impl<'de> Deserializer<'de> for Rbool {
 impl<'de> Deserializer<'de> for &'de Rstr {
     type Error = Error;
 
-    fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value>
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        unimplemented!()
+        if self.is_na() {
+            Err(Error::MustNotBeNA(self.robj.clone()))
+        } else {
+            visitor.visit_borrowed_str(self)
+        }
     }
 
     fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value>


### PR DESCRIPTION
The current `from_robj`/`to_robj` have a perculiar limitation: a struct with `Serialize/Deserialize`, that is stored as a List (see `IntoRobj` behavior for reference) is not properly deserialised (from `Robj`/ `list()`). This is now done in this PR. Plus a test.