### PR TITLE
Remove unnecessary `doc(hidden)`

### DIFF
--- a/extendr-api/src/wrapper/list.rs
+++ b/extendr-api/src/wrapper/list.rs
@@ -1,7 +1,10 @@
 use super::*;
 use crate::robj::Attributes;
 use extendr_ffi::{dataptr, R_xlen_t, SET_VECTOR_ELT, VECTOR_ELT};
-use std::{collections::{HashMap, BTreeMap}, iter::FromIterator};
+use std::{
+    collections::{BTreeMap, HashMap},
+    iter::FromIterator,
+};
 
 #[derive(PartialEq, Clone)]
 pub struct List {


### PR DESCRIPTION
The public API was being polluted unnecessarily by reexports of `CString` and `HashMap`. This has now been cleared.