### PR TITLE
Enable only symbol lookup for Rust wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Changed
 
+- Force symbol-based lookup of native entry points in packages built with extendr (`R_forceSymbols(TRUE)`); `.Call("wrap__…", …)` strings must now be replaced with the symbol form `.Call(wrap__…, …)`. <https://github.com/extendr/extendr/pull/1009>
 - **Breaking**: bumps MSRV to 1.77 <https://github.com/extendr/extendr/pull/1075>
 - **Breaking**: deprecates and removed `global_env()`, `base_env()`, and `empty_env()` from the `prelude`  <https://github.com/extendr/extendr/pull/1075>
 - **Breaking**: non-API items `global_var()`, `local_var()`, `global!()` have been removed  <https://github.com/extendr/extendr/pull/1075>

--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -461,9 +461,11 @@ pub unsafe fn register_call_methods(info: *mut extendr_ffi::DllInfo, metadata: M
         std::ptr::null(),
     );
 
-    // This seems to allow both symbols and strings,
+    // Force symbol-based lookup of C entry points (.Call(symbol, ...) instead of
+    // .Call("symbol", ...)) — skips R_FindSymbol's string scan. See:
+    // https://github.com/r-devel/r-svn/blob/trunk/src/main/Rdynload.c#L1185-L1201
     extendr_ffi::R_useDynamicSymbols(info, extendr_ffi::Rboolean::FALSE);
-    extendr_ffi::R_forceSymbols(info, extendr_ffi::Rboolean::FALSE);
+    extendr_ffi::R_forceSymbols(info, extendr_ffi::Rboolean::TRUE);
 }
 
 /// Type of R objects used by [Robj::rtype].

--- a/tests/extendrtests/tests/testthat/test-wrappers.R
+++ b/tests/extendrtests/tests/testthat/test-wrappers.R
@@ -24,7 +24,7 @@ test_that("Wrapper code is up-to-date", {
   # Make sure you know which it is before running `make_wrappers()`.
 
   x <- .Call(
-    "wrap__make_extendrtests_wrappers",
+    wrap__make_extendrtests_wrappers,
     use_symbols = TRUE,
     package_name = "extendrtests"
   )


### PR DESCRIPTION
This PR enables symbol lookup of Rust wrappers by default. One may call a C-function either by quoting the name, or using a symbol, i.e. `.Call(C_wrapper_foo)`, or `.Call("C_wrapper_foo")`. In `extendr-api` we enable the ability to emit wrappers that use either invocation, but the common standard is to use the symbol lookup, as is today. There will be less work done by `R_FindSymbol` if this is enabled, see 

https://github.com/r-devel/r-svn/blob/trunk/src/main/Rdynload.c#L1185-L1201
