### PR TITLE
Replace `master` with `main` everywhere

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -4,13 +4,13 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
+      - main
     paths:
       - "**.rs"
       - "**/Cargo.toml"
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - "**.rs"
       - "**/Cargo.toml"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,16 +2,17 @@
 
 We welcome contributions to the extendr project. Contributions come in many forms. Please carefully read and follow these guidelines. This will help us make the contribution process easy and effective for everyone involved. It also communicates that you agree to respect the time of the developers managing and developing this project.
 
-
 ## Quicklinks
 
-* [Code of Conduct](#code-of-conduct)
-* [Getting Started](#getting-started)
-    * [Issues](#issues)
-    * [Pull Requests](#pull-requests)
-* [Getting Help](#getting-help)
-* [Authorship](#authorship)
-* [Attribution](#attribution)
+- [Contributing](#contributing)
+  - [Quicklinks](#quicklinks)
+  - [Code of Conduct](#code-of-conduct)
+  - [Getting Started](#getting-started)
+    - [Issues](#issues)
+    - [Pull Requests](#pull-requests)
+  - [Getting Help](#getting-help)
+  - [Authorship](#authorship)
+  - [Attribution](#attribution)
 
 ## Code of Conduct
 
@@ -66,4 +67,4 @@ Contributors who have made multiple, sustained, and/or non-trivial contributions
 
 ## Attribution
 
-This document was adapted from the [General Contributing Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md) of the auth0 project.
+This document was adapted from the [General Contributing Guidelines](https://github.com/auth0/open-source-template/blob/main/GENERAL-CONTRIBUTING.md) of the auth0 project.

--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -304,7 +304,7 @@
 //! - `result_list`: return `Ok` as `list(ok=?, err=NULL)` or `Err` `list(ok=NULL, err=?)`
 //! - `result_condition`: return `Ok` as is or `Err` as $value in an R error condition.
 #![doc(
-    html_logo_url = "https://raw.githubusercontent.com/extendr/extendr/master/extendr-logo-256.png"
+    html_logo_url = "https://raw.githubusercontent.com/extendr/extendr/main/extendr-logo-256.png"
 )]
 
 pub mod error;

--- a/tests/extendrtests/README.md
+++ b/tests/extendrtests/README.md
@@ -5,12 +5,12 @@
 
 This package serves as a test to see whether an R package using extendr can successfully build, run, and pass `R CMD check` on all major platforms.
 
-The Rust code that is part of the package is located here: <https://github.com/extendr/extendr/tree/master/tests/extendrtests/src/rust>
+The Rust code that is part of the package is located here: <https://github.com/extendr/extendr/tree/main/tests/extendrtests/src/rust>
 
 The wrapper scripts calling the Rust functions are located here:
-<https://github.com/extendr/extendr/blob/master/tests/extendrtests/R/make-wrappers.R>
+<https://github.com/extendr/extendr/blob/main/tests/extendrtests/R/make-wrappers.R>
 
-The test functions that verify that the wrapper and Rust functions work correctly are located here: <https://github.com/extendr/extendr/blob/master/tests/extendrtests/tests/testthat/test-wrappers.R>
+The test functions that verify that the wrapper and Rust functions work correctly are located here: <https://github.com/extendr/extendr/blob/main/tests/extendrtests/tests/testthat/test-wrappers.R>
 
 ## Using local extendr packages
 


### PR DESCRIPTION
We forgot to replace `master` with `main` internally.
