### PR TITLE
Remove secret exports of `HashMap` and `CString`.

### DIFF
--- a/extendr-api/src/graphics/device_driver.rs
+++ b/extendr-api/src/graphics/device_driver.rs
@@ -921,7 +921,7 @@ pub trait DeviceDriver: std::marker::Sized {
                 (*p_dev_desc).capabilities = None;
             } // unsafe ends here
         }
-        let device_name = CString::new(device_name).unwrap();
+        let device_name = std::ffi::CString::new(device_name).unwrap();
 
         single_threaded(|| unsafe {
             let device = GEcreateDevDesc(p_dev_desc);

--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -382,9 +382,6 @@ pub const NA_STRING: Option<&str> = None;
 /// NA value for logical. `r!(NA_LOGICAL)`
 pub const NA_LOGICAL: Rbool = Rbool::na_value();
 
-#[doc(hidden)]
-pub use std::collections::HashMap;
-
 /// This is needed for the generation of wrappers.
 #[doc(hidden)]
 pub use extendr_ffi::DllInfo;
@@ -403,9 +400,6 @@ pub use extendr_ffi::PutRNGstate;
 
 #[doc(hidden)]
 pub use extendr_ffi::SEXP;
-
-#[doc(hidden)]
-use std::ffi::CString;
 
 pub use metadata::Metadata;
 
@@ -603,7 +597,7 @@ pub fn sxp_to_rtype(sxptype: SEXPTYPE) -> Rtype {
 const PRINTF_NO_FMT_CSTRING: &[std::os::raw::c_char] = &[37, 115, 0]; // same as "%s\0"
 #[doc(hidden)]
 pub fn print_r_output<T: Into<Vec<u8>>>(s: T) {
-    let cs = CString::new(s).expect("NulError");
+    let cs = std::ffi::CString::new(s).expect("NulError");
     unsafe {
         extendr_ffi::Rprintf(PRINTF_NO_FMT_CSTRING.as_ptr(), cs.as_ptr());
     }
@@ -611,7 +605,7 @@ pub fn print_r_output<T: Into<Vec<u8>>>(s: T) {
 
 #[doc(hidden)]
 pub fn print_r_error<T: Into<Vec<u8>>>(s: T) {
-    let cs = CString::new(s).expect("NulError");
+    let cs = std::ffi::CString::new(s).expect("NulError");
     unsafe {
         extendr_ffi::REprintf(PRINTF_NO_FMT_CSTRING.as_ptr(), cs.as_ptr());
     }

--- a/extendr-api/src/wrapper/list.rs
+++ b/extendr-api/src/wrapper/list.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::robj::Attributes;
 use extendr_ffi::{dataptr, R_xlen_t, SET_VECTOR_ELT, VECTOR_ELT};
+use std::collections::{BTreeMap, HashMap};
 use std::iter::FromIterator;
 
 #[derive(PartialEq, Clone)]

--- a/extendr-api/src/wrapper/wrapper_macros.rs
+++ b/extendr-api/src/wrapper/wrapper_macros.rs
@@ -3,7 +3,7 @@ use crate as extendr_api;
 use extendr_ffi::{R_xlen_t, SET_VECTOR_ELT};
 
 pub(crate) fn make_symbol(name: &str) -> SEXP {
-    let name = CString::new(name).unwrap();
+    let name = std::ffi::CString::new(name).unwrap();
     unsafe { extendr_ffi::Rf_install(name.as_ptr()) }
 }
 


### PR DESCRIPTION
These exports are annotated with `doc(hidden)`. They leave a way to refer to certain items in macros. Fortunately, we don't need these anymore, and they have been undocumented, so they pose no breaking change challenge.