### PR TITLE
Replace `as *const _` / `as *mut _` with safer variants 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@
   [[#1020]](https://github.com/extendr/extendr/pull/1020)
 - **Breaking** we no longer permit `TryFrom<Robj> for &T/&mut T` as this violates
   Rust's memory model. [[#1000]](https://github.com/extendr/extendr/pull/1000)
+- **Breaking** graphics engine functions now appropriately mark mutability requirement. Previously arguments were marked immutable, but treated as immutable violating the type safety system [[#1017]](https://github.com/extendr/extendr/pull/1017)
+- **Possibly Breaking** extendr-engine now sets the flag `--vanilla` when starting R [[#1017]](https://github.com/extendr/extendr/pull/1017)
+- **Breaking** `extendr_api::catch_r_error()` now requires a mutable closure to ensure type-safe casting of pointers [[#1017]](https://github.com/extendr/extendr/pull/1017)
 
 ### Fixed
 

--- a/extendr-api/src/functions.rs
+++ b/extendr-api/src/functions.rs
@@ -160,7 +160,7 @@ pub fn parse(code: &str) -> Result<Expressions> {
     single_threaded(|| unsafe {
         use extendr_ffi::{ParseStatus, R_NilValue, R_ParseVector};
         let mut status = ParseStatus::PARSE_NULL;
-        let status_ptr = (&mut status) as *mut _;
+        let status_ptr = std::ptr::from_mut(&mut status);
         let codeobj: Robj = code.into();
         let parsed = Robj::from_sexp(R_ParseVector(codeobj.get(), -1, status_ptr, R_NilValue));
         match status {

--- a/extendr-api/src/io/load.rs
+++ b/extendr-api/src/io/load.rs
@@ -29,7 +29,7 @@ pub trait Load {
         hook: Option<ReadHook>,
     ) -> Result<Robj> {
         unsafe extern "C" fn inchar<R: Read>(arg1: R_inpstream_t) -> ::std::os::raw::c_int {
-            let reader = &mut *((*arg1).data as *mut R);
+            let reader = (*arg1).data.cast::<R>().as_mut().unwrap();
             let buf: &mut [u8] = &mut [0_u8];
             reader.read_exact(buf).map(|_| buf[0].into()).unwrap_or(-1)
         }
@@ -39,8 +39,8 @@ pub trait Load {
             arg2: *mut ::std::os::raw::c_void,
             arg3: ::std::os::raw::c_int,
         ) {
-            let reader = &mut *((*arg1).data as *mut R);
-            let buf = std::slice::from_raw_parts_mut(arg2 as *mut u8, arg3 as usize);
+            let reader = (*arg1).data.cast::<R>().as_mut().unwrap();
+            let buf = std::slice::from_raw_parts_mut(arg2.cast::<u8>(), arg3 as usize);
             reader.read_exact(buf).unwrap();
         }
 

--- a/extendr-api/src/optional/faer.rs
+++ b/extendr-api/src/optional/faer.rs
@@ -199,7 +199,7 @@ mod test {
 
     #[test]
     fn test_faer_mat_ref_to_rmatrix() {
-        test! {
+        extendr_engine::with_r(|| {
             let vec: Vec<f64> = (1..13).map(f64::from).collect();
             let a = mat![
                 [1.0, 5.0, 9.0],
@@ -209,7 +209,7 @@ mod test {
             ];
             let rmatrix: RMatrix<f64> = a.as_ref().into();
             assert_eq!(rmatrix.as_real_slice().expect("slice"), &vec);
-        }
+        });
     }
 
     #[test]

--- a/extendr-api/src/optional/faer.rs
+++ b/extendr-api/src/optional/faer.rs
@@ -198,7 +198,7 @@ mod test {
     }
 
     #[test]
-    fn test_faer_mat_ref_to_rmatrix() {
+    fn test_faer_mat_ref_to_rmatrix() -> Result<()> {
         extendr_engine::with_r(|| {
             let vec: Vec<f64> = (1..13).map(f64::from).collect();
             let a = mat![
@@ -209,7 +209,8 @@ mod test {
             ];
             let rmatrix: RMatrix<f64> = a.as_ref().into();
             assert_eq!(rmatrix.as_real_slice().expect("slice"), &vec);
-        });
+            Ok(())
+        })
     }
 
     #[test]

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -190,8 +190,6 @@ pub trait Slices: GetSexp {
             return &mut [];
         }
         let data = dataptr(self.get_mut()).cast::<T>().cast_mut();
-        debug_assert_ne!(data as usize, 1, "unexpected sentinel pointer for non-empty slice");
-        debug_assert_eq!((data as usize) % std::mem::align_of::<T>(), 0);
         std::slice::from_raw_parts_mut(data, len)
     }
 }

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -16,7 +16,7 @@ use std::os::raw;
 
 use extendr_ffi::{
     dataptr, R_IsNA, R_NilValue, R_compute_identical, R_tryEval, Rboolean, Rcomplex, Rf_getAttrib,
-    Rf_setAttrib, Rf_xlength, COMPLEX, DATAPTR, INTEGER, LOGICAL, PRINTNAME, RAW, REAL, SEXPTYPE,
+    Rf_setAttrib, Rf_xlength, COMPLEX, INTEGER, LOGICAL, PRINTNAME, RAW, REAL, SEXPTYPE,
     SEXPTYPE::*, STRING_ELT, STRING_PTR_RO, TYPEOF, XLENGTH,
 };
 
@@ -183,7 +183,7 @@ pub trait Slices: GetSexp {
     /// Not all objects (especially not list and strings) support this.
     unsafe fn as_typed_slice_raw_mut<T>(&mut self) -> &mut [T] {
         let len = XLENGTH(self.get()) as usize;
-        let data = DATAPTR(self.get_mut()).cast::<T>();
+        let data = dataptr(self.get_mut()).cast::<T>().cast_mut();
         std::slice::from_raw_parts_mut(data, len)
     }
 }

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -16,7 +16,7 @@ use std::os::raw;
 
 use extendr_ffi::{
     dataptr, R_IsNA, R_NilValue, R_compute_identical, R_tryEval, Rboolean, Rcomplex, Rf_getAttrib,
-    Rf_setAttrib, Rf_xlength, COMPLEX, INTEGER, LOGICAL, PRINTNAME, RAW, REAL, SEXPTYPE,
+    Rf_setAttrib, Rf_xlength, COMPLEX, DATAPTR, INTEGER, LOGICAL, PRINTNAME, RAW, REAL, SEXPTYPE,
     SEXPTYPE::*, STRING_ELT, STRING_PTR_RO, TYPEOF, XLENGTH,
 };
 
@@ -170,7 +170,7 @@ pub trait Slices: GetSexp {
     /// Creating this slice will also instantiate an Altrep objects.
     unsafe fn as_typed_slice_raw<T>(&self) -> &[T] {
         let len = XLENGTH(self.get()) as usize;
-        let data = dataptr(self.get()) as *const T;
+        let data = dataptr(self.get()).cast::<T>();
         std::slice::from_raw_parts(data, len)
     }
 
@@ -183,7 +183,7 @@ pub trait Slices: GetSexp {
     /// Not all objects (especially not list and strings) support this.
     unsafe fn as_typed_slice_raw_mut<T>(&mut self) -> &mut [T] {
         let len = XLENGTH(self.get()) as usize;
-        let data = dataptr(self.get_mut()) as *mut T;
+        let data = DATAPTR(self.get_mut()).cast::<T>();
         std::slice::from_raw_parts_mut(data, len)
     }
 }
@@ -726,7 +726,7 @@ pub trait Eval: GetSexp {
     fn eval_with_env(&self, env: &Environment) -> Result<Robj> {
         single_threaded(|| unsafe {
             let mut error: raw::c_int = 0;
-            let res = R_tryEval(self.get(), env.get(), &mut error as *mut raw::c_int);
+            let res = R_tryEval(self.get(), env.get(), std::ptr::from_mut(&mut error));
             if error != 0 {
                 Err(Error::EvalError(Robj::from_sexp(self.get())))
             } else {
@@ -790,7 +790,7 @@ macro_rules! make_typed_slice {
                                 return Some(&[])
                             }
                             // otherwise get the slice
-                            let ptr = $fn(self.get()) as *const $type;
+                            let ptr = $fn(self.get()).cast::<$type>();
                             Some(std::slice::from_raw_parts(ptr, self.len()))
                         }
                     }
@@ -805,7 +805,7 @@ macro_rules! make_typed_slice {
                             if self.is_empty() {
                                 return Some(&mut []);
                             }
-                            let ptr = $fn(self.get_mut()) as *mut $type;
+                            let ptr = $fn(self.get_mut()).cast::<$type>();
 
                             Some(std::slice::from_raw_parts_mut(ptr, self.len()))
 
@@ -824,7 +824,30 @@ make_typed_slice!(Rint, INTEGER, INTSXP);
 make_typed_slice!(f64, REAL, REALSXP);
 make_typed_slice!(Rfloat, REAL, REALSXP);
 make_typed_slice!(u8, RAW, RAWSXP);
-make_typed_slice!(Rstr, STRING_PTR_RO, STRSXP);
+
+// TODO: had to expand `make_typed_slice!(Rstr, STRING_PTR_RO, STRSXP)`
+// as we don't have a way to specific a mutability constraint via `AsTypedSlice`.
+
+impl<'a> AsTypedSlice<'a, Rstr> for Robj
+where
+    Self: 'a,
+{
+    fn as_typed_slice(&self) -> Option<&'a [Rstr]> {
+        match self.sexptype() {
+            STRSXP => unsafe {
+                if self.is_empty() {
+                    return Some(&[]);
+                }
+                let ptr = STRING_PTR_RO(self.get()).cast::<Rstr>();
+                Some(std::slice::from_raw_parts(ptr, self.len()))
+            },
+            _ => None,
+        }
+    }
+    fn as_typed_slice_mut(&mut self) -> Option<&'a mut [Rstr]> {
+        None
+    }
+}
 make_typed_slice!(c64, COMPLEX, CPLXSXP);
 make_typed_slice!(Rcplx, COMPLEX, CPLXSXP);
 make_typed_slice!(Rcomplex, COMPLEX, CPLXSXP);

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -170,6 +170,9 @@ pub trait Slices: GetSexp {
     /// Creating this slice will also instantiate an Altrep objects.
     unsafe fn as_typed_slice_raw<T>(&self) -> &[T] {
         let len = XLENGTH(self.get()) as usize;
+        if len == 0 {
+            return &[];
+        }
         let data = dataptr(self.get()).cast::<T>();
         std::slice::from_raw_parts(data, len)
     }
@@ -183,7 +186,12 @@ pub trait Slices: GetSexp {
     /// Not all objects (especially not list and strings) support this.
     unsafe fn as_typed_slice_raw_mut<T>(&mut self) -> &mut [T] {
         let len = XLENGTH(self.get()) as usize;
+        if len == 0 {
+            return &mut [];
+        }
         let data = dataptr(self.get_mut()).cast::<T>().cast_mut();
+        debug_assert_ne!(data as usize, 1, "unexpected sentinel pointer for non-empty slice");
+        debug_assert_eq!((data as usize) % std::mem::align_of::<T>(), 0);
         std::slice::from_raw_parts_mut(data, len)
     }
 }

--- a/extendr-api/src/robj/rinternals.rs
+++ b/extendr-api/src/robj/rinternals.rs
@@ -238,11 +238,7 @@ pub trait Rinternals: Types + Conversions {
     unsafe fn make_external_ptr<T>(p: *mut T, prot: Robj) -> Robj {
         let type_name: Robj = std::any::type_name::<T>().into();
         Robj::from_sexp(single_threaded(|| {
-            R_MakeExternalPtr(
-                p as *mut ::std::os::raw::c_void,
-                type_name.get(),
-                prot.get(),
-            )
+            R_MakeExternalPtr(p.cast(), type_name.get(), prot.get())
         }))
     }
 

--- a/extendr-api/src/thread_safety.rs
+++ b/extendr-api/src/thread_safety.rs
@@ -97,8 +97,8 @@ where
     }
 
     single_threaded(|| unsafe {
-        let fun_ptr = std::ptr::from_ref(&do_call::<F>).cast();
-        let clean_ptr = std::ptr::from_ref(&do_cleanup).cast();
+        let fun_ptr = (*std::ptr::from_ref(&do_call::<F>)) as *const ();
+        let clean_ptr = (*std::ptr::from_ref(&do_cleanup)) as *const ();
         let mut x = false;
         let fun = std::mem::transmute::<
             *const (),

--- a/extendr-api/src/thread_safety.rs
+++ b/extendr-api/src/thread_safety.rs
@@ -74,7 +74,7 @@ pub fn stop<S: AsRef<str>>(s: S) -> ! {
 ///    assert_eq!(res.is_ok(), false);
 /// }
 /// ```
-pub fn catch_r_error<F>(f: F) -> Result<SEXP>
+pub fn catch_r_error<F>(mut f: F) -> Result<SEXP>
 where
     F: FnOnce() -> SEXP + Copy,
     F: std::panic::UnwindSafe,
@@ -85,8 +85,8 @@ where
     where
         F: FnOnce() -> SEXP + Copy,
     {
-        let data = data as *const ();
-        let f: &F = &*(data as *const F);
+        let data: *mut () = data.cast();
+        let f = data.cast::<F>().as_ref().unwrap();
         f()
     }
 
@@ -97,9 +97,9 @@ where
     }
 
     single_threaded(|| unsafe {
-        let fun_ptr = do_call::<F> as *const ();
-        let clean_ptr = do_cleanup as *const ();
-        let x = false;
+        let fun_ptr = std::ptr::from_ref(&do_call::<F>).cast();
+        let clean_ptr = std::ptr::from_ref(&do_cleanup).cast();
+        let mut x = false;
         let fun = std::mem::transmute::<
             *const (),
             Option<unsafe extern "C" fn(*mut std::ffi::c_void) -> *mut extendr_ffi::SEXPREC>,
@@ -108,8 +108,8 @@ where
             *const (),
             std::option::Option<unsafe extern "C" fn(*mut std::ffi::c_void, extendr_ffi::Rboolean)>,
         >(clean_ptr);
-        let data = &f as *const _ as _;
-        let cleandata = &x as *const _ as _;
+        let data = std::ptr::from_mut(&mut f).cast();
+        let cleandata = std::ptr::from_mut(&mut x).cast();
         let cont = R_MakeUnwindCont();
         Rf_protect(cont);
 

--- a/extendr-api/src/wrapper/altrep.rs
+++ b/extendr-api/src/wrapper/altrep.rs
@@ -137,9 +137,9 @@ pub trait AltrepImpl: Clone + std::fmt::Debug {
             if data2 == R_NilValue || TYPEOF(data2) != TYPEOF(x) {
                 let data2 = manifest(x);
                 R_set_altrep_data2(x, data2);
-                DATAPTR(data2).cast::<u8>()
+                dataptr(data2) as *mut u8
             } else {
-                DATAPTR(data2).cast::<u8>()
+                dataptr(data2) as *mut u8
             }
         })
     }

--- a/extendr-api/src/wrapper/complexes.rs
+++ b/extendr-api/src/wrapper/complexes.rs
@@ -1,6 +1,6 @@
 use super::scalar::{c64, Rcplx};
 use super::*;
-use extendr_ffi::{dataptr, R_xlen_t, Rcomplex, COMPLEX, COMPLEX_GET_REGION, SEXPTYPE::CPLXSXP};
+use extendr_ffi::{R_xlen_t, Rcomplex, COMPLEX, COMPLEX_GET_REGION, SEXPTYPE::CPLXSXP};
 use std::iter::FromIterator;
 
 /// An obscure `NA`-aware wrapper for R's complex vectors.

--- a/extendr-api/src/wrapper/complexes.rs
+++ b/extendr-api/src/wrapper/complexes.rs
@@ -62,7 +62,7 @@ impl Deref for Complexes {
     /// Treat Complexes as if it is a slice, like `Vec<Rcplx>`
     fn deref(&self) -> &Self::Target {
         unsafe {
-            let ptr = dataptr(self.get()).cast::<Rcplx>();
+            let ptr = COMPLEX(self.get()).cast::<Rcplx>();
             std::slice::from_raw_parts(ptr, self.len())
         }
     }

--- a/extendr-api/src/wrapper/complexes.rs
+++ b/extendr-api/src/wrapper/complexes.rs
@@ -1,6 +1,6 @@
 use super::scalar::{c64, Rcplx};
 use super::*;
-use extendr_ffi::{dataptr, R_xlen_t, Rcomplex, COMPLEX_GET_REGION, SEXPTYPE::CPLXSXP};
+use extendr_ffi::{dataptr, R_xlen_t, Rcomplex, COMPLEX, COMPLEX_GET_REGION, SEXPTYPE::CPLXSXP};
 use std::iter::FromIterator;
 
 /// An obscure `NA`-aware wrapper for R's complex vectors.
@@ -40,7 +40,7 @@ impl Complexes {
     /// Get a region of elements from the vector.
     pub fn get_region(&self, index: usize, dest: &mut [Rcplx]) -> usize {
         unsafe {
-            let ptr: *mut Rcomplex = dest.as_mut_ptr() as *mut Rcomplex;
+            let ptr = dest.as_mut_ptr().cast::<Rcomplex>();
             COMPLEX_GET_REGION(self.get(), index as R_xlen_t, dest.len() as R_xlen_t, ptr) as usize
         }
     }
@@ -62,7 +62,7 @@ impl Deref for Complexes {
     /// Treat Complexes as if it is a slice, like `Vec<Rcplx>`
     fn deref(&self) -> &Self::Target {
         unsafe {
-            let ptr = dataptr(self.get()) as *const Rcplx;
+            let ptr = dataptr(self.get()).cast::<Rcplx>();
             std::slice::from_raw_parts(ptr, self.len())
         }
     }
@@ -72,7 +72,7 @@ impl DerefMut for Complexes {
     /// Treat Complexes as if it is a mutable slice, like `Vec<Rcplx>`
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe {
-            let ptr = dataptr(self.get_mut()) as *mut Rcplx;
+            let ptr = COMPLEX(self.get_mut()).cast::<Rcplx>();
             std::slice::from_raw_parts_mut(ptr, self.len())
         }
     }

--- a/extendr-api/src/wrapper/doubles.rs
+++ b/extendr-api/src/wrapper/doubles.rs
@@ -77,7 +77,7 @@ impl Deref for Doubles {
     /// Treat Doubles as if it is a slice, like `Vec<Rfloat>`
     fn deref(&self) -> &Self::Target {
         unsafe {
-            let ptr = dataptr(self.get()).cast::<Rfloat>();
+            let ptr = REAL(self.get()).cast::<Rfloat>();
             std::slice::from_raw_parts(ptr, self.len())
         }
     }

--- a/extendr-api/src/wrapper/doubles.rs
+++ b/extendr-api/src/wrapper/doubles.rs
@@ -1,8 +1,7 @@
 use super::scalar::Rfloat;
 use super::*;
 use extendr_ffi::{
-    dataptr, R_xlen_t, REAL, REAL_GET_REGION, REAL_IS_SORTED, REAL_NO_NA, SET_REAL_ELT,
-    SEXPTYPE::REALSXP,
+    R_xlen_t, REAL, REAL_GET_REGION, REAL_IS_SORTED, REAL_NO_NA, SET_REAL_ELT, SEXPTYPE::REALSXP,
 };
 use std::iter::FromIterator;
 

--- a/extendr-api/src/wrapper/doubles.rs
+++ b/extendr-api/src/wrapper/doubles.rs
@@ -1,7 +1,8 @@
 use super::scalar::Rfloat;
 use super::*;
 use extendr_ffi::{
-    dataptr, R_xlen_t, REAL_GET_REGION, REAL_IS_SORTED, REAL_NO_NA, SET_REAL_ELT, SEXPTYPE::REALSXP,
+    dataptr, R_xlen_t, REAL, REAL_GET_REGION, REAL_IS_SORTED, REAL_NO_NA, SET_REAL_ELT,
+    SEXPTYPE::REALSXP,
 };
 use std::iter::FromIterator;
 
@@ -45,7 +46,7 @@ impl Doubles {
     /// Get a region of elements from the vector.
     pub fn get_region(&self, index: usize, dest: &mut [Rfloat]) -> usize {
         unsafe {
-            let ptr: *mut f64 = dest.as_mut_ptr() as *mut f64;
+            let ptr = dest.as_mut_ptr().cast::<f64>();
             REAL_GET_REGION(self.get(), index as R_xlen_t, dest.len() as R_xlen_t, ptr) as usize
         }
     }
@@ -76,7 +77,7 @@ impl Deref for Doubles {
     /// Treat Doubles as if it is a slice, like `Vec<Rfloat>`
     fn deref(&self) -> &Self::Target {
         unsafe {
-            let ptr = dataptr(self.get()) as *const Rfloat;
+            let ptr = dataptr(self.get()).cast::<Rfloat>();
             std::slice::from_raw_parts(ptr, self.len())
         }
     }
@@ -86,7 +87,7 @@ impl DerefMut for Doubles {
     /// Treat Doubles as if it is a mutable slice, like `Vec<Rfloat>`
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe {
-            let ptr = dataptr(self.get_mut()) as *mut Rfloat;
+            let ptr = REAL(self.get_mut()).cast::<Rfloat>();
             std::slice::from_raw_parts_mut(ptr, self.len())
         }
     }

--- a/extendr-api/src/wrapper/integers.rs
+++ b/extendr-api/src/wrapper/integers.rs
@@ -78,7 +78,7 @@ impl Deref for Integers {
     /// Treat Integers as if it is a slice, like `Vec<Rint>`
     fn deref(&self) -> &Self::Target {
         unsafe {
-            let ptr = dataptr(self.get()).cast::<Rint>();
+            let ptr = INTEGER(self.get()).cast::<Rint>();
             std::slice::from_raw_parts(ptr, self.len())
         }
     }

--- a/extendr-api/src/wrapper/integers.rs
+++ b/extendr-api/src/wrapper/integers.rs
@@ -1,8 +1,7 @@
 use super::scalar::Rint;
 use super::*;
 use extendr_ffi::{
-    dataptr, R_xlen_t, INTEGER, INTEGER_GET_REGION, INTEGER_IS_SORTED, INTEGER_NO_NA,
-    SET_INTEGER_ELT,
+    R_xlen_t, INTEGER, INTEGER_GET_REGION, INTEGER_IS_SORTED, INTEGER_NO_NA, SET_INTEGER_ELT,
 };
 use std::iter::FromIterator;
 

--- a/extendr-api/src/wrapper/integers.rs
+++ b/extendr-api/src/wrapper/integers.rs
@@ -1,7 +1,8 @@
 use super::scalar::Rint;
 use super::*;
 use extendr_ffi::{
-    dataptr, R_xlen_t, INTEGER_GET_REGION, INTEGER_IS_SORTED, INTEGER_NO_NA, SET_INTEGER_ELT,
+    dataptr, R_xlen_t, INTEGER, INTEGER_GET_REGION, INTEGER_IS_SORTED, INTEGER_NO_NA,
+    SET_INTEGER_ELT,
 };
 use std::iter::FromIterator;
 
@@ -46,7 +47,7 @@ impl Integers {
     /// Get a region of elements from the vector.
     pub fn get_region(&self, index: usize, dest: &mut [Rint]) -> usize {
         unsafe {
-            let ptr: *mut i32 = dest.as_mut_ptr() as *mut i32;
+            let ptr = dest.as_mut_ptr().cast::<i32>();
             INTEGER_GET_REGION(self.get(), index as R_xlen_t, dest.len() as R_xlen_t, ptr) as usize
         }
     }
@@ -77,7 +78,7 @@ impl Deref for Integers {
     /// Treat Integers as if it is a slice, like `Vec<Rint>`
     fn deref(&self) -> &Self::Target {
         unsafe {
-            let ptr = dataptr(self.get()) as *const Rint;
+            let ptr = dataptr(self.get()).cast::<Rint>();
             std::slice::from_raw_parts(ptr, self.len())
         }
     }
@@ -87,7 +88,7 @@ impl DerefMut for Integers {
     /// Treat Integers as if it is a mutable slice, like `Vec<Rint>`
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe {
-            let ptr = dataptr(self.get_mut()) as *mut Rint;
+            let ptr = INTEGER(self.get_mut()).cast::<Rint>();
             std::slice::from_raw_parts_mut(ptr, self.len())
         }
     }

--- a/extendr-api/src/wrapper/list.rs
+++ b/extendr-api/src/wrapper/list.rs
@@ -152,7 +152,7 @@ impl List {
     /// Get the list a slice of `Robj`s.
     pub fn as_slice(&self) -> &[Robj] {
         unsafe {
-            let data = dataptr(self.robj.get()) as *const Robj;
+            let data = dataptr(self.robj.get()).cast::<Robj>();
             let len = self.robj.len();
             std::slice::from_raw_parts(data, len)
         }

--- a/extendr-api/src/wrapper/logicals.rs
+++ b/extendr-api/src/wrapper/logicals.rs
@@ -66,7 +66,7 @@ impl Deref for Logicals {
     /// Treat Logicals as if it is a slice, like `Vec<Rint>`
     fn deref(&self) -> &Self::Target {
         unsafe {
-            let ptr = dataptr(self.get()).cast::<Rbool>();
+            let ptr = LOGICAL(self.get()).cast::<Rbool>();
             std::slice::from_raw_parts(ptr, self.len())
         }
     }

--- a/extendr-api/src/wrapper/logicals.rs
+++ b/extendr-api/src/wrapper/logicals.rs
@@ -1,6 +1,6 @@
 use super::scalar::Rbool;
 use super::*;
-use extendr_ffi::{dataptr, R_xlen_t, LOGICAL_GET_REGION, SET_INTEGER_ELT, SEXPTYPE};
+use extendr_ffi::{dataptr, R_xlen_t, LOGICAL, LOGICAL_GET_REGION, SET_INTEGER_ELT, SEXPTYPE};
 use std::iter::FromIterator;
 
 /// An obscure `NA`-aware wrapper for R's logical vectors.
@@ -45,7 +45,7 @@ impl Logicals {
     /// Get a region of elements from the vector.
     pub fn get_region(&self, index: usize, dest: &mut [Rbool]) -> usize {
         unsafe {
-            let ptr: *mut i32 = dest.as_mut_ptr() as *mut i32;
+            let ptr = dest.as_mut_ptr().cast::<i32>();
             LOGICAL_GET_REGION(self.get(), index as R_xlen_t, dest.len() as R_xlen_t, ptr) as usize
         }
     }
@@ -66,7 +66,7 @@ impl Deref for Logicals {
     /// Treat Logicals as if it is a slice, like `Vec<Rint>`
     fn deref(&self) -> &Self::Target {
         unsafe {
-            let ptr = dataptr(self.get()) as *const Rbool;
+            let ptr = dataptr(self.get()).cast::<Rbool>();
             std::slice::from_raw_parts(ptr, self.len())
         }
     }
@@ -76,7 +76,7 @@ impl DerefMut for Logicals {
     /// Treat Logicals as if it is a mutable slice, like `Vec<Rint>`
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe {
-            let ptr = dataptr(self.get_mut()) as *mut Rbool;
+            let ptr = LOGICAL(self.get_mut()).cast::<Rbool>();
             std::slice::from_raw_parts_mut(ptr, self.len())
         }
     }

--- a/extendr-api/src/wrapper/logicals.rs
+++ b/extendr-api/src/wrapper/logicals.rs
@@ -1,6 +1,6 @@
 use super::scalar::Rbool;
 use super::*;
-use extendr_ffi::{dataptr, R_xlen_t, LOGICAL, LOGICAL_GET_REGION, SET_INTEGER_ELT, SEXPTYPE};
+use extendr_ffi::{R_xlen_t, LOGICAL, LOGICAL_GET_REGION, SET_INTEGER_ELT, SEXPTYPE};
 use std::iter::FromIterator;
 
 /// An obscure `NA`-aware wrapper for R's logical vectors.

--- a/extendr-api/src/wrapper/strings.rs
+++ b/extendr-api/src/wrapper/strings.rs
@@ -68,7 +68,7 @@ impl Strings {
     /// This is a relatively expensive operation, so use a variable if using this in a loop.
     pub fn as_slice<'a>(&self) -> &'a [Rstr] {
         unsafe {
-            let data = STRING_PTR_RO(self.robj.get()) as *const Rstr;
+            let data = STRING_PTR_RO(self.robj.get()).cast::<Rstr>();
             let len = self.robj.len();
             std::slice::from_raw_parts(data, len)
         }

--- a/extendr-api/tests/extendr_macro.rs
+++ b/extendr-api/tests/extendr_macro.rs
@@ -205,8 +205,7 @@ fn test_metadata() {
             c_name: "wrap__test_metadata_1",
             args,
             return_type: "i32",
-            func_ptr: unsafe { *std::ptr::from_ref(&wrap__test_metadata_1) }
-                as *const ()
+            func_ptr: unsafe { *std::ptr::from_ref(&wrap__test_metadata_1) } as *const ()
                 as *const u8,
             hidden: false,
             invisible: None,

--- a/extendr-api/tests/extendr_macro.rs
+++ b/extendr-api/tests/extendr_macro.rs
@@ -205,7 +205,9 @@ fn test_metadata() {
             c_name: "wrap__test_metadata_1",
             args,
             return_type: "i32",
-            func_ptr: wrap__test_metadata_1 as *const u8,
+            func_ptr: unsafe { *std::ptr::from_ref(&wrap__test_metadata_1) }
+                as *const ()
+                as *const u8,
             hidden: false,
             invisible: None,
         }

--- a/extendr-api/tests/graphics_tests.rs
+++ b/extendr-api/tests/graphics_tests.rs
@@ -27,7 +27,7 @@ mod graphics_tests {
             // Start a new page.
             // Use CSS "antiquewhite" https://www.w3.org/TR/2018/REC-css-color-3-20180619/
             gc.fill(antiquewhite());
-            dev.new_page(&gc);
+            dev.new_page(&mut gc);
 
             dev.mode_on()?;
 
@@ -36,7 +36,7 @@ mod graphics_tests {
             gc.line_width(0.1);
 
             // Draw a line.
-            dev.line((2.0, 2.0), (3.0, 3.0), &gc);
+            dev.line((2.0, 2.0), (3.0, 3.0), &mut gc);
 
             // Draw a circle using `polygon()`.
             let scale = std::f64::consts::PI*2.0/10.0;
@@ -45,11 +45,11 @@ mod graphics_tests {
                 (0..10).map(|i| (
                     ((i as f64) * scale).cos() + 4.0,
                     ((i as f64) * scale).sin() + 2.0
-                )), &gc);
+                )), &mut gc);
 
             // Draw a circle using `circle()`.
             gc.fill(Color::rgb(0x20, 0x20, 0xc0));
-            dev.circle((1.0, 1.0), 0.5, &gc);
+            dev.circle((1.0, 1.0), 0.5, &mut gc);
 
             gc.color(black());
             gc.point_size(36.0);
@@ -57,22 +57,22 @@ mod graphics_tests {
             gc.font_family("Helvetica");
 
             // Draw Hello -- World with the two dashes almost touching.
-            let w = dev.text_width("Hello -", &gc);
-            dev.text((1.0, 3.0), "Hello -", (0.0, 0.0), 0.0, &gc);
-            dev.text((1.0 + w, 3.0), "- World", (0.0, 0.0), 0.0, &gc);
+            let w = dev.text_width("Hello -", &mut gc);
+            dev.text((1.0, 3.0), "Hello -", (0.0, 0.0), 0.0, &mut gc);
+            dev.text((1.0 + w, 3.0), "- World", (0.0, 0.0), 0.0, &mut gc);
 
             gc.line_width(0.01);
             for i in 0..10 {
-                dev.symbol((1.0 + i as f64 * 0.3, 4.0), i, 0.25, &gc);
+                dev.symbol((1.0 + i as f64 * 0.3, 4.0), i, 0.25, &mut gc);
             }
 
-            println!("{:?}", dev.char_metric('a', &gc));
-            println!("{:?}", dev.char_metric('g', &gc));
-            println!("{:?}", dev.char_metric('ê', &gc));
+            println!("{:?}", dev.char_metric('a', &mut gc));
+            println!("{:?}", dev.char_metric('g', &mut gc));
+            println!("{:?}", dev.char_metric('ê', &mut gc));
 
-            println!("{:?}", dev.text_metric("a", &gc));
-            println!("{:?}", dev.text_metric("g", &gc));
-            println!("{:?}", dev.text_metric("ê", &gc));
+            println!("{:?}", dev.text_metric("a", &mut gc));
+            println!("{:?}", dev.text_metric("g", &mut gc));
+            println!("{:?}", dev.text_metric("ê", &mut gc));
 
             dev.mode_off()?;
 
@@ -240,7 +240,7 @@ mod graphics_tests {
             }
         }
 
-        fn raster<T: AsRef<[u32]>>(
+        fn raster<T: AsRef<[u32]> + AsMut<[u32]>>(
             &mut self,
             raster: Raster<T>,
             pos: (f64, f64),
@@ -286,7 +286,7 @@ mod graphics_tests {
             let device_descriptor = DeviceDescriptor::new();
             let device = device_driver.create_device::<TestDevice>(device_descriptor, "test device");
 
-            let gc = Context::from_device(&device, Unit::Device);
+            let mut gc = Context::from_device(&device, Unit::Device);
 
             // if activate() is invoked, value should be 100.0
             assert_eq!(value, 100.0);
@@ -306,34 +306,34 @@ mod graphics_tests {
 
             // ASCII char
             let c1 = 'c';
-            assert_eq!(device.char_metric(c1, &gc).width, c1 as i32 as f64);
+            assert_eq!(device.char_metric(c1, &mut gc).width, c1 as i32 as f64);
             // non-ASCII char
             let c2 = 'ú';
             let c3 = '鬼';
-            assert_eq!(device.char_metric(c2, &gc).width, c2 as i32 as f64);
-            assert_eq!(device.char_metric(c3, &gc).width, c3 as i32 as f64);
+            assert_eq!(device.char_metric(c2, &mut gc).width, c2 as i32 as f64);
+            assert_eq!(device.char_metric(c3, &mut gc).width, c3 as i32 as f64);
             // text
             let t1 = "ab";
-            assert_eq!(device.text_width(t1, &gc), ('a' as i32 + 'b' as i32) as f64);
+            assert_eq!(device.text_width(t1, &mut gc), ('a' as i32 + 'b' as i32) as f64);
 
             device.clip((1.1, 2.2), (3.3, 4.4), &gc);
-            device.circle((1.1, 2.2), 3.3, &gc);
-            device.line((1.1, 2.2), (3.3, 4.4), &gc);
-            device.rect((1.1, 2.2), (3.3, 4.4), &gc);
+            device.circle((1.1, 2.2), 3.3, &mut gc);
+            device.line((1.1, 2.2), (3.3, 4.4), &mut gc);
+            device.rect((1.1, 2.2), (3.3, 4.4), &mut gc);
 
-            device.polyline([(0.0, 0.0), (0.0, 2.0)], &gc);
-            device.polygon([(0.0, 0.0), (1.0, 2.0), (2.0, 0.0)], &gc);
-            device.path([[(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)], [(0.3, 0.0), (0.3, 0.3), (0.7, 0.3), (0.3, 0.7)]], true, &gc);
+            device.polyline([(0.0, 0.0), (0.0, 2.0)], &mut gc);
+            device.polygon([(0.0, 0.0), (1.0, 2.0), (2.0, 0.0)], &mut gc);
+            device.path([[(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)], [(0.3, 0.0), (0.3, 0.3), (0.7, 0.3), (0.3, 0.7)]], true, &mut gc);
 
             // x element of `center` is `hadj`, a horizontal adjustment
             // I'm yet to figure out how the `y` element is used. Let's leave it as 0 for now.
-            device.text((1.1, 2.2), "foo", (0.5, 0.0), 5.5, &gc);
+            device.text((1.1, 2.2), "foo", (0.5, 0.0), 5.5, &mut gc);
 
             let r = Raster {
-                pixels: &[1, 2, 3, 4, 5, 6],
+                pixels: [1, 2, 3, 4, 5, 6],
                 width: 3,
             };
-            device.raster(r, (1.1, 2.2), (3.3, 4.4), 5.5, false, &gc);
+            device.raster(r, (1.1, 2.2), (3.3, 4.4), 5.5, false, &mut gc);
 
             assert_eq!(canvas, "clip from=(1.1, 2.2) to=(3.3, 4.4)\n\
                                     circle center=(1.1, 2.2) r=3.3\n\
@@ -347,7 +347,7 @@ mod graphics_tests {
                                     ");
 
             // Clearing canvas.
-            device.new_page(&gc);
+            device.new_page(&mut gc);
             assert_eq!(canvas, "");
 
             // check if the R doesn't crash on closing the device.

--- a/extendr-engine/src/lib.rs
+++ b/extendr-engine/src/lib.rs
@@ -72,10 +72,7 @@ use std::sync::Once;
 // Generates asciiz.
 macro_rules! cstr_mut {
     ($s: expr) => {
-        concat!($s, "\0")
-            .as_ptr()
-            .cast::<raw::c_char>()
-            .cast_mut()
+        concat!($s, "\0").as_ptr().cast::<raw::c_char>().cast_mut()
     };
 }
 

--- a/extendr-engine/src/lib.rs
+++ b/extendr-engine/src/lib.rs
@@ -72,7 +72,7 @@ use std::sync::Once;
 // Generates asciiz.
 macro_rules! cstr_mut {
     ($s: expr) => {
-        concat!($s, "\0").as_ptr() as *mut raw::c_char
+        std::ptr::from_mut(&mut concat!($s, "\0")).cast::<raw::c_char>()
     };
 }
 

--- a/extendr-engine/src/lib.rs
+++ b/extendr-engine/src/lib.rs
@@ -72,12 +72,35 @@ use std::sync::Once;
 // Generates asciiz.
 macro_rules! cstr_mut {
     ($s: expr) => {
-        std::ptr::from_mut(&mut concat!($s, "\0")).cast::<raw::c_char>()
+        concat!($s, "\0")
+            .as_ptr()
+            .cast::<raw::c_char>()
+            .cast_mut()
     };
 }
 
+#[cfg(all(target_os = "windows", target_arch = "x86"))]
+static mut R_ARGV: [*mut raw::c_char; 6] = [
+    cstr_mut!("R"),
+    cstr_mut!("--arch=i386"),
+    cstr_mut!("--slave"),
+    cstr_mut!("--no-save"),
+    cstr_mut!("--vanilla"),
+    std::ptr::null_mut(),
+];
+
+#[cfg(not(all(target_os = "windows", target_arch = "x86")))]
+static mut R_ARGV: [*mut raw::c_char; 5] = [
+    cstr_mut!("R"),
+    cstr_mut!("--slave"),
+    cstr_mut!("--no-save"),
+    cstr_mut!("--vanilla"),
+    std::ptr::null_mut(),
+];
+
 static START_R: Once = Once::new();
 
+#[allow(static_mut_refs)]
 pub fn start_r() {
     START_R.call_once(|| {
         unsafe {
@@ -92,10 +115,15 @@ pub fn start_r() {
 
             //let res = unsafe { Rf_initEmbeddedR(1, args.as_mut_ptr()) };
             // NOTE: R will crash if this is called twice in the same process.
-            Rf_initialize_R(
-                3,
-                [cstr_mut!("R"), cstr_mut!("--slave"), cstr_mut!("--no-save")].as_mut_ptr(),
-            );
+            #[cfg(all(target_os = "windows", target_arch = "x86"))]
+            {
+                Rf_initialize_R(5, R_ARGV.as_mut_ptr());
+            }
+
+            #[cfg(not(all(target_os = "windows", target_arch = "x86")))]
+            {
+                Rf_initialize_R(4, R_ARGV.as_mut_ptr());
+            }
 
             // In case you are curious.
             // Maybe 8MB is a bit small.

--- a/extendr-ffi/src/backports.rs
+++ b/extendr-ffi/src/backports.rs
@@ -199,7 +199,7 @@ pub unsafe fn get_closure_formals(x: SEXP) -> SEXP {
     }
 }
 
-/// Access a DATAPTR
+/// Access a read-only DATAPTR
 ///
 /// # Safety
 ///
@@ -209,7 +209,7 @@ pub unsafe fn get_closure_formals(x: SEXP) -> SEXP {
 pub unsafe fn dataptr(x: SEXP) -> *const ::std::os::raw::c_void {
     #[cfg(not(r_4_5))]
     {
-        DATAPTR(x) as *const _
+        DATAPTR(x).cast_const()
     }
     #[cfg(r_4_5)]
     {

--- a/extendr-ffi/src/graphics.rs
+++ b/extendr-ffi/src/graphics.rs
@@ -12,7 +12,7 @@ pub const R_GE_version: u32 = 15;
 // Types
 pub type DevDesc = _DevDesc;
 pub type pDevDesc = *mut DevDesc;
-pub type pGEcontext = *mut R_GE_gcontext;
+pub type pGEcontext = *const R_GE_gcontext;
 pub type pGEDevDesc = *mut GEDevDesc;
 
 // Constants

--- a/extendr-ffi/src/lib.rs
+++ b/extendr-ffi/src/lib.rs
@@ -521,10 +521,7 @@ mod tests {
     // Generates asciiz.
     macro_rules! cstr_mut {
         ($s: expr) => {
-            concat!($s, "\0")
-                .as_ptr()
-                .cast::<raw::c_char>()
-                .cast_mut()
+            concat!($s, "\0").as_ptr().cast::<raw::c_char>().cast_mut()
         };
     }
 

--- a/extendr-ffi/src/lib.rs
+++ b/extendr-ffi/src/lib.rs
@@ -512,7 +512,7 @@ mod tests {
     // Generates asciiz.
     macro_rules! cstr {
         ($s: expr) => {
-            concat!($s, "\0").as_ptr() as *const raw::c_char
+            concat!($s, "\0").as_ptr().cast()
         };
     }
 
@@ -521,7 +521,7 @@ mod tests {
     // Generates asciiz.
     macro_rules! cstr_mut {
         ($s: expr) => {
-            concat!($s, "\0").as_ptr() as *mut raw::c_char
+            std::ptr::from_mut(&mut concat!($s, "\0")).cast::<raw::c_char>()
         };
     }
 

--- a/extendr-macros/src/extendr_module.rs
+++ b/extendr-macros/src/extendr_module.rs
@@ -62,7 +62,9 @@ pub fn extendr_module(item: TokenStream) -> TokenStream {
                 c_name: #wrap_module_metadata_name_str,
                 args: Vec::new(),
                 return_type: "Metadata",
-                func_ptr: #wrap_module_metadata_name as * const u8,
+                func_ptr: unsafe { *std::ptr::from_ref(&#wrap_module_metadata_name) }
+                    as *const ()
+                    as *const u8,
                 hidden: true,
                 invisible: None,
             });
@@ -81,7 +83,9 @@ pub fn extendr_module(item: TokenStream) -> TokenStream {
                 c_name: #wrap_make_module_wrappers_string,
                 args,
                 return_type: "String",
-                func_ptr: #wrap_make_module_wrappers as * const u8,
+                func_ptr: unsafe { *std::ptr::from_ref(&#wrap_make_module_wrappers) }
+                    as *const ()
+                    as *const u8,
                 hidden: true,
                 invisible: None,
             });

--- a/extendr-macros/src/lib.rs
+++ b/extendr-macros/src/lib.rs
@@ -40,7 +40,7 @@
 // fn init__hello(info: *mut extendr_api::DllInfo, call_methods: &mut Vec<extendr_api::CallMethod>) {
 //     call_methods.push(extendr_api::CallMethod {
 //         call_symbol: std::ffi::CString::new("wrap__hello").unwrap(),
-//         func_ptr: wrap__hello as *const u8,
+//         func_ptr: unsafe { *std::ptr::from_ref(&wrap__hello) } as *const () as *const u8,
 //         num_args: 0i32,
 //     })
 // }

--- a/extendr-macros/src/wrappers.rs
+++ b/extendr-macros/src/wrappers.rs
@@ -302,7 +302,9 @@ pub(crate) fn make_function_wrappers(
                 mod_name: #c_name_str,
                 args: args,
                 return_type: #return_type_string,
-                func_ptr: #wrap_name as * const u8,
+                func_ptr: unsafe { *std::ptr::from_ref(&#wrap_name) }
+                    as *const ()
+                    as *const u8,
                 hidden: false,
                 invisible: #opts_invisible,
             })

--- a/justfile
+++ b/justfile
@@ -71,7 +71,7 @@ expand *cargo_flags:
 
 # Verify MSRV with optional comma-separated FEATURES (empty means default features)
 msrv FEATURES="":
-    if [ "x{{FEATURES}}" = "x" ]; then \
+    if [ -z "{{FEATURES}}" ]; then \
       cargo msrv --path extendr-api verify -- cargo check; \
     else \
       cargo msrv --path extendr-api verify -- cargo check --features {{FEATURES}}; \
@@ -97,7 +97,7 @@ devtools-test FILTER="" SNAPSHOT="0":
     if [ "{{SNAPSHOT}}" = "1" ]; then \
       Rscript -e 'testthat::snapshot_accept("macro-snapshot")'; \
     fi; \
-    if [ "x{{FILTER}}" = "x" ]; then \
+    if [ -z "{{FILTER}}" ]; then \
       Rscript -e 'devtools::test()'; \
     else \
       Rscript -e 'devtools::test(filter = "{{FILTER}}")'; \

--- a/justfile
+++ b/justfile
@@ -12,18 +12,18 @@ clean *cargo_flags:
 
 alias cargo-check := check
 check *cargo_flags:
-    cargo check --workspace {{cargo_flags}}
-    cargo check --manifest-path=tests/extendrtests/src/rust/Cargo.toml {{cargo_flags}}
+    cargo check --features full-functionality --workspace {{cargo_flags}}
+    cargo check --features full-functionality --manifest-path=tests/extendrtests/src/rust/Cargo.toml {{cargo_flags}}
 
 alias cargo-build := build
 build *cargo_flags:
-    cargo build --workspace {{cargo_flags}}
-    cargo build --manifest-path=tests/extendrtests/src/rust/Cargo.toml {{cargo_flags}}
+    cargo build --features full-functionality --workspace {{cargo_flags}}
+    cargo build --features full-functionality --manifest-path=tests/extendrtests/src/rust/Cargo.toml {{cargo_flags}}
 
 alias cargo-clippy := clippy
 clippy *cargo_flags:
-    cargo clippy --workspace {{cargo_flags}}
-    cargo clippy --manifest-path=tests/extendrtests/src/rust/Cargo.toml {{cargo_flags}}
+    cargo clippy --features full-functionality --workspace {{cargo_flags}}
+    cargo clippy --features full-functionality --manifest-path=tests/extendrtests/src/rust/Cargo.toml {{cargo_flags}}
 
 alias cargo-doc-check := doc-check
 doc-check *cargo_flags:
@@ -55,19 +55,19 @@ test *args:
       if [ "$sep" = "0" ]; then cargo_flags="$cargo_flags $arg"; else test_args="$test_args $arg"; fi; \
     done \
     && cargo test --workspace --no-fail-fast --features=full-functionality $cargo_flags -- --no-capture --test-threads=1 $test_args \
-    && cargo test --manifest-path=tests/extendrtests/src/rust/Cargo.toml --no-fail-fast $cargo_flags -- --no-capture --test-threads=1 $test_args
+    && cargo test --manifest-path=tests/extendrtests/src/rust/Cargo.toml --no-fail-fast --features=full-functionality $cargo_flags -- --no-capture --test-threads=1 $test_args
 
 alias cargo-tree := tree
 tree *cargo_flags:
-  cargo tree --workspace {{cargo_flags}}
-  cargo tree --manifest-path=tests/extendrtests/src/rust/Cargo.toml {{cargo_flags}}
+  cargo tree --features=full-functionality --workspace {{cargo_flags}}
+  cargo tree --features=full-functionality --manifest-path=tests/extendrtests/src/rust/Cargo.toml {{cargo_flags}}
 
 alias cargo-expand := expand
 expand *cargo_flags:
-    cargo expand -p extendr-api {{cargo_flags}}
+    cargo expand --features=full-functionality -p extendr-api {{cargo_flags}}
     cargo expand -p extendr-macros {{cargo_flags}}
     cargo expand -p extendr-ffi {{cargo_flags}}
-    cargo expand --manifest-path=tests/extendrtests/src/rust/Cargo.toml {{cargo_flags}}
+    cargo expand --features=full-functionality --manifest-path=tests/extendrtests/src/rust/Cargo.toml {{cargo_flags}}
 
 # Verify MSRV with optional comma-separated FEATURES (empty means default features)
 msrv FEATURES="":


### PR DESCRIPTION
fixes #969

Increased MSRV to 1.76. Seeing as CRAN's MSRV is 1.81, I'm taking a very cautious increase here. The reason for this increase is then we can construct pointers via `std::ptr::from_ref` and  `std::ptr::from_mut`.

Furthermore, some inconsistencies were erased here with use of dataptr, by force casting `*const _` to `*mut const`, etc.
