### PR TITLE
feat(anyhow): add conversion support from `anyhow::Error` to `extendr_api::Error`

### DIFF
--- a/extendr-api/Cargo.toml
+++ b/extendr-api/Cargo.toml
@@ -20,6 +20,7 @@ num-complex = { version = "0.4.6", optional = true }
 serde = { version = "1.0.219", features = ["derive"], optional = true }
 faer = { version = "0.20", optional = true }
 readonly = "0.2.13"
+anyhow = { version = "*", optional = true }
 
 [dev-dependencies]
 extendr-engine = { path = "../extendr-engine" }

--- a/extendr-api/src/error.rs
+++ b/extendr-api/src/error.rs
@@ -249,6 +249,13 @@ impl From<String> for Error {
     }
 }
 
+#[cfg(feature = "anyhow")]
+impl From<anyhow::Error> for Error {
+    fn from(err: anyhow::Error) -> Error {
+        Error::Other(format!("{:?}.", err))
+    }
+}
+
 // NoneError is unstable.
 //
 // impl From<std::option::NoneError> for Error {

--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -294,6 +294,7 @@
 //! - `graphics`: provides the functionality to control or implement graphics devices.
 //! - `either`: provides implementation of type conversion traits for `Either<L, R>` from [`either`](https://docs.rs/either/latest/either/) if `L` and `R` both implement those traits.
 //! - `faer`: provides conversion between R's matrices and [`faer`](https://docs.rs/faer/latest/faer/).
+//! - `anyhow`: provides conversion from anyhow error type to extendr-api's error type.
 //!
 //! extendr-api supports three ways of returning a Result<T,E> to R.
 //! Only one behavior feature can be enabled at a time.

--- a/tests/extendrtests/R/extendr-wrappers.R
+++ b/tests/extendrtests/R/extendr-wrappers.R
@@ -107,6 +107,8 @@ error_long_message <- function() .Call(wrap__error_long_message)
 
 error_on_panic <- function() .Call(wrap__error_on_panic)
 
+error_anyhow <- function() .Call(wrap__error_anyhow)
+
 test_hm_string <- function(x) .Call(wrap__test_hm_string, x)
 
 test_hm_i32 <- function(x) .Call(wrap__test_hm_i32, x)

--- a/tests/extendrtests/src/rust/Cargo.toml
+++ b/tests/extendrtests/src/rust/Cargo.toml
@@ -28,7 +28,9 @@ extendr-api = { version = "*", features = [
     "ndarray",
     "faer",
     "either",
+    "anyhow"
 ] }
+anyhow = { version = "*" }
 
 [patch.crates-io]
 ## This is configured to work with RStudio features.

--- a/tests/extendrtests/src/rust/src/errors.rs
+++ b/tests/extendrtests/src/rust/src/errors.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use extendr_api::{error::Result, prelude::*};
 
 #[extendr]
@@ -53,6 +54,12 @@ fn error_on_panic() {
     panic!("this does circumvents the hook mechanism");
 }
 
+#[extendr]
+fn error_anyhow() -> Result<()> {
+    Err(anyhow::anyhow!("This is the anyhow Error")).with_context(|| format!("anyhow Context"))?;
+    Ok(())
+}
+
 extendr_module! {
     mod errors;
     fn error_simple;
@@ -62,4 +69,5 @@ extendr_module! {
     fn error_chain;
     fn error_long_message;
     fn error_on_panic;
+    fn error_anyhow;
 }

--- a/tests/extendrtests/tests/testthat/test-errors.R
+++ b/tests/extendrtests/tests/testthat/test-errors.R
@@ -34,6 +34,11 @@ test_that("Error functions throw clean errors by default", {
     error_long_message(),
     "This is a longer error message"
   )
+
+  expect_error(
+    error_anyhow(),
+    "anyhow Context\\\\n\\\\nCaused by:\\\\n.*anyhow Error"
+  )
 })
 
 test_that("Successful Result returns value correctly", {
@@ -204,7 +209,7 @@ test_that("Error handling on panic", {
   expect_error(
     error_on_panic()
   )
-  
+
   # Restore original value
   if (is.na(orig_val)) {
     Sys.unsetenv("EXTENDR_BACKTRACE")


### PR DESCRIPTION
fix https://github.com/extendr/extendr/issues/1031

This PR adds support for converting `anyhow::Error` to `extendr_api::Error`.

Since `anyhow::Error` doesn’t implement the `PartialEq` trait, it can’t be directly wrapped in `extendr_api::Error` by creating a new enum variant like `Error::Anyhow` (which I would have preferred, as it would allow conversion back to the original `anyhow::Error` without data loss). Instead, I’ve opted to convert the `anyhow::Error` to a string and wrap it in `Error::Other`. For the conversion to a string, I use the `{:?}` format, which fully supports `anyhow::Context` and backtrace.
<https://docs.rs/anyhow/latest/anyhow/struct.Error.html#display-representations>

A simple test has been added in `tests/extendrtests`, and the documentation for the feature gates has been updated to reflect the new anyhow feature.