### PR TITLE
fix: rethrow panic without prepending unwrap message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Changed
 
+- **Breaking**: MSRV has been bumped to 1.71
 - **Breaking**: `extendr_api::error::Result<>` has been removed from the prelude
 - **Deprecates** `List::from_hashmap()` in favor of the idiomatic `TryFrom` trait. replace `List::from_hashmap()` with `List::try_from()` [[#982]](https://github.com/extendr/extendr/pull/982)
 - **Deprecates** `List::into_hashmap()` in favor of the idiomatic `TryFrom` trait. replace `List::into_hashmap()` with `HashMap::<String, Robj>::try_from()` [[#982]](https://github.com/extendr/extendr/pull/982)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,16 +9,6 @@ members = [
 
 [workspace.package]
 version = "0.8.1"
-authors = [
-  "andy-thomason <andy@andythomason.com>",
-  "Thomas Down",
-  "Mossa Merhi Reimert <mossa@sund.ku.dk>",
-  "Josiah Parry <josiah.parry@gmail.com>",
-  "Claus O. Wilke <wilke@austin.utexas.edu>",
-  "Hiroaki Yutani",
-  "Ilia A. Kosenkov <ilia.kosenkov@outlook.com>",
-  "Michael Milton <michael.r.milton@gmail.com>",
-]
 edition = "2021"
 rust-version = "1.71"
 repository = "https://github.com/extendr/extendr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ authors = [
   "Michael Milton <michael.r.milton@gmail.com>",
 ]
 edition = "2021"
-rust-version = "1.68"
+rust-version = "1.71"
 repository = "https://github.com/extendr/extendr"
 license = "MIT"
 

--- a/extendr-api/Cargo.toml
+++ b/extendr-api/Cargo.toml
@@ -1,48 +1,48 @@
 [package]
 name = "extendr-api"
-description = "Safe and user friendly bindings to the R programming language."
 version.workspace = true
-authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license.workspace = true
+description = "Safe and user friendly bindings to the R programming language."
 repository.workspace = true
+license.workspace = true
+
+[package.metadata.docs.rs]
+features = ["full-functionality"]
 
 [dependencies]
+either = { version = "1.8.1", optional = true }
 extendr-ffi = { workspace = true }
 extendr-macros = { workspace = true }
-once_cell = "1.21.3"
-paste = "1.0.15"
-either = { version = "1.8.1", optional = true }
+faer = { version = "0.20", optional = true }
 libc = { version = "0.2", optional = true }
 ndarray = { version = "0.16.1", optional = true }
 num-complex = { version = "0.4.6", optional = true }
-serde = { version = "1.0.219", features = ["derive"], optional = true }
-faer = { version = "0.20", optional = true }
+once_cell = "1.21.3"
+paste = "1.0.15"
 readonly = "0.2.13"
+serde = { version = "1.0.219", features = ["derive"], optional = true }
 
 [dev-dependencies]
 extendr-engine = { path = "../extendr-engine" }
 rstest = "0.22.0"
 
-
 [features]
-
+result_condition = []
 # Features to modify behaviour of returning Result<T,E> from extendr to R, instead of unwrap-throw_r_error().
 # Add new features below
 # None, one or both can be set, but the one with highest precedence will take effect.
 result_list = []
-result_condition = []
 
 # This dummy feature enables all features that increase the functionality of
 # extendr, via conversions or R features. Features that change behaviour
 full-functionality = [
-    "graphics",
-    "either",
-    "ndarray",
-    "faer",
-    "num-complex",
-    "serde",
+  "either",
+  "faer",
+  "graphics",
+  "ndarray",
+  "num-complex",
+  "serde",
 ]
 
 # Parts of the R-API are locked behind non-API, as CRAN frowns upon the presence
@@ -57,13 +57,9 @@ graphics = ["libc"]
 # The minimal set of features without all optional ones
 tests-minimal = []
 
-tests = ["tests-minimal", "ndarray", "faer", "serde", "num-complex", "either"]
+tests = ["either", "faer", "ndarray", "num-complex", "serde", "tests-minimal"]
 
-tests-graphics = ["tests-minimal", "graphics"]
+tests-graphics = ["graphics", "tests-minimal"]
 
 # Literally all features to test
-tests-all = ["tests", "graphics"]
-
-
-[package.metadata.docs.rs]
-features = ["full-functionality"]
+tests-all = ["graphics", "tests"]

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -68,7 +68,10 @@ where
     E: std::fmt::Debug + std::fmt::Display,
 {
     fn from(res: std::result::Result<T, E>) -> Self {
-        res.unwrap().into()
+        match res {
+            Ok(val) => val.into(),
+            Err(err) => panic!("{}", err),
+        }
     }
 }
 

--- a/extendr-api/tests/optional/non_api.rs
+++ b/extendr-api/tests/optional/non_api.rs
@@ -1,17 +1,19 @@
 #![cfg(test)]
 use extendr_api::prelude::*;
 use extendr_engine::with_r;
+use std::result::Result;
 
 #[test]
-fn non_api_promise() {
+fn non_api_promise() -> Result<(), Box<dyn std::error::Error>> {
     with_r(|| {
         let _special = r!(Primitive::from_string("if"));
         let _builtin = r!(Primitive::from_string("+"));
-    });
+        Ok(())
+    })
 }
 
 #[test]
-fn environment() {
+fn environment() -> Result<(), Box<dyn std::error::Error>> {
     with_r(|| {
         let names_and_values = (0..100).map(|i| (format!("n{}", i), i));
         let env = Environment::from_pairs(global_env(), names_and_values);
@@ -36,11 +38,12 @@ fn environment() {
             .iter()
             .collect::<Vec<_>>();
         assert_eq!(names_and_values, vec![("x", r!(1))]);
-    });
+        Ok(())
+    })
 }
 
 #[test]
-fn non_api_rinternals_promise() {
+fn non_api_rinternals_promise() -> Result<(), Box<dyn std::error::Error>> {
     with_r(|| {
         let iris_dataframe = global_env()
             .find_var(sym!(iris))
@@ -52,30 +55,33 @@ fn non_api_rinternals_promise() {
 
         // Note: this may crash on some versions of windows which don't support unwinding.
         //assert_eq!(global_env().find_var(sym!(imnotasymbol)), None);
-    });
+        Ok(())
+    })
 }
 
 #[test]
-fn non_api_getsexp_rtype() {
+fn non_api_getsexp_rtype() -> Result<(), Box<dyn std::error::Error>> {
     with_r(|| {
         assert_eq!(r!(Primitive::from_string("if")).rtype(), Rtype::Special);
         assert_eq!(r!(Primitive::from_string("+")).rtype(), Rtype::Builtin);
-    });
+        Ok(())
+    })
 }
 
 #[test]
-fn non_api_rmacros() {
+fn non_api_rmacros() -> Result<(), Box<dyn std::error::Error>> {
     with_r(|| {
         // The "iris" dataset is a dataframe.
         assert!(global!(iris).unwrap().is_frame());
-    });
+        Ok(())
+    })
 }
 
 /// In `extendr-api/lib.rs` there was a section with this
 ///
 /// > You can call R functions and primitives using the [call!] macro.
 #[test]
-fn non_api_lib_readme() {
+fn non_api_lib_readme() -> Result<(), Box<dyn std::error::Error>> {
     with_r(|| {
         // As one R! macro call
         let confint1 = R!("confint(lm(weight ~ group - 1, PlantGrowth))").unwrap();
@@ -88,16 +94,18 @@ fn non_api_lib_readme() {
         let confint2 = call!("confint", model).unwrap();
 
         assert_eq!(confint1.as_real_vector(), confint2.as_real_vector());
-    });
+        Ok(())
+    })
 }
 
 #[test]
-fn non_api_base_env() {
+fn non_api_base_env() -> Result<(), Box<dyn std::error::Error>> {
     with_r(|| {
         global_env().set_local(sym!(x), "hello");
         assert_eq!(
             base_env().local(sym!(+)),
             Ok(r!(Primitive::from_string("+")))
         );
-    });
+        Ok(())
+    })
 }

--- a/extendr-engine/Cargo.toml
+++ b/extendr-engine/Cargo.toml
@@ -1,16 +1,15 @@
 [package]
 name = "extendr-engine"
-description = "Safe and user friendly bindings to the R programming language."
 version.workspace = true
-authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license.workspace = true
+description = "Safe and user friendly bindings to the R programming language."
 repository.workspace = true
+license.workspace = true
 
 [dependencies]
-extendr-ffi = { workspace = true }
 ctor = "0.6.0"
+extendr-ffi = { workspace = true }
 
 [features]
 default = []

--- a/extendr-ffi/Cargo.toml
+++ b/extendr-ffi/Cargo.toml
@@ -1,12 +1,11 @@
 [package]
 name = "extendr-ffi"
-description = "Barebone bindings to `libR` for use in extendr."
 version.workspace = true
-authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license.workspace = true
+description = "Barebone bindings to `libR` for use in extendr."
 repository.workspace = true
+license.workspace = true
 links = "R"
 
 [features]

--- a/extendr-macros/Cargo.toml
+++ b/extendr-macros/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "extendr-macros"
 version.workspace = true
-authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 description = "Generate bindings from R to Rust."
@@ -12,8 +11,8 @@ license.workspace = true
 proc-macro = true
 
 [dependencies]
-proc-macro2 = { version = "1.0.103" }
 lazy_static = "1.5.0"
+proc-macro2 = { version = "1.0.103" }
 quote = "1.0.42"
 syn = { version = "2.0.109", features = ["extra-traits", "full"] }
 

--- a/tests/extendrtests/src/rust/Cargo.toml
+++ b/tests/extendrtests/src/rust/Cargo.toml
@@ -1,11 +1,6 @@
 [package]
 name = "extendrtests"
 version = "0.7.1"
-authors = [
-  "andy-thomason <andy@andythomason.com>",
-  "Claus O. Wilke <wilke@austin.utexas.edu>",
-  "Ilia Kosenkov <ilia.kosenkov@outlook.com",
-]
 edition = "2021"
 rust-version = "1.65"
 publish = false
@@ -23,6 +18,7 @@ name = "document"
 path = "document.rs"
 
 [dependencies]
+anyhow = "1"
 extendr-api = { version = "*", features = [
   "either",
   "faer",

--- a/tests/extendrtests/src/rust/src/errors.rs
+++ b/tests/extendrtests/src/rust/src/errors.rs
@@ -1,3 +1,4 @@
+use anyhow::bail;
 use extendr_api::{error::Result, prelude::*};
 
 #[extendr]
@@ -53,6 +54,11 @@ fn error_on_panic() {
     panic!("this does circumvents the hook mechanism");
 }
 
+#[extendr]
+fn error_anyhow() -> anyhow::Result<()> {
+    bail!("This is an anyhow error");
+}
+
 extendr_module! {
     mod errors;
     fn error_simple;
@@ -62,4 +68,5 @@ extendr_module! {
     fn error_chain;
     fn error_long_message;
     fn error_on_panic;
+    fn error_anyhow;
 }

--- a/tests/extendrtests/tests/testthat/test-errors.R
+++ b/tests/extendrtests/tests/testthat/test-errors.R
@@ -74,7 +74,6 @@ test_that("EXTENDR_BACKTRACE=true shows full traceback", {
     Sys.setenv(EXTENDR_BACKTRACE = orig_val)
   }
 
-  expect_true(grepl("unwrap.*Err", err, ignore.case = TRUE))
   expect_true(grepl("This is a simple error message", err))
 })
 
@@ -95,7 +94,6 @@ test_that("EXTENDR_BACKTRACE=1 also shows full traceback", {
     Sys.setenv(EXTENDR_BACKTRACE = orig_val)
   }
 
-  expect_true(grepl("unwrap.*Err", err, ignore.case = TRUE))
   expect_true(grepl("This is a simple error message", err))
 })
 

--- a/tests/extendrtests/tests/testthat/test-errors.R
+++ b/tests/extendrtests/tests/testthat/test-errors.R
@@ -194,6 +194,14 @@ test_that("Error handling does not leak memory", {
   }
 })
 
+test_that("Foreign error types (anyhow) produce clean errors", {
+  Sys.unsetenv("EXTENDR_BACKTRACE")
+  err <- tryCatch(error_anyhow(), error = function(e) conditionMessage(e))
+  expect_true(grepl("This is an anyhow error", err, fixed = TRUE))
+  expect_false(grepl("called.*unwrap.*on an.*Err", err))
+  expect_false(grepl("stack backtrace", err, ignore.case = TRUE))
+})
+
 test_that("Error handling on panic", {
   # Save original EXTENDR_BACKTRACE value
   orig_val <- Sys.getenv("EXTENDR_BACKTRACE", unset = NA)


### PR DESCRIPTION
Partially closes: https://github.com/extendr/extendr/issues/1054

Previously we were calling `.unwrap().into()` instead, we match on the result and don't unwrap but instead panic with the error message itself.