### PR TITLE
fix:  R_UnboundValue non-api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Changed
 
+- **Breaking**: Removed `is_unbound_value()` and `unbound_value()` as `R_UnboundValue` has been removed from the R-API
 - **Breaking**: MSRV has been bumped to 1.71
 - **Breaking**: `extendr_api::error::Result<>` has been removed from the prelude
 - **Deprecates** `List::from_hashmap()` in favor of the idiomatic `TryFrom` trait. replace `List::from_hashmap()` with `List::try_from()` [[#982]](https://github.com/extendr/extendr/pull/982)

--- a/extendr-api/build.rs
+++ b/extendr-api/build.rs
@@ -7,6 +7,8 @@ fn main() {
     println!("cargo:rustc-check-cfg=cfg(use_r_ge_version_16)");
     println!("cargo:rustc-check-cfg=cfg(use_r_ge_version_17)");
     println!("cargo:rustc-check-cfg=cfg(use_r_altlist)");
+    println!("cargo:rustc-check-cfg=cfg(r_4_4)");
+    println!("cargo:rustc-check-cfg=cfg(r_4_5)");
 
     // The R version information is needed to handle the API differences
     // between versions. `These DEP_R_R_VERSION_*` are provided by extendr-ffi
@@ -45,5 +47,10 @@ fn main() {
 
     if &*major >= "4" && &*minor >= "4" {
         println!("cargo:rustc-cfg=use_objsxp");
+        println!("cargo:rustc-cfg=r_4_4");
+    }
+
+    if &*major >= "4" && &*minor >= "5" {
+        println!("cargo:rustc-cfg=r_4_5");
     }
 }

--- a/extendr-api/src/prelude.rs
+++ b/extendr-api/src/prelude.rs
@@ -23,7 +23,7 @@ pub use super::wrapper::symbol::{
     dot_target, dots_symbol, double_colon_symbol, lastvalue_symbol, levels_symbol, missing_arg,
     mode_symbol, na_rm_symbol, name_symbol, names_symbol, namespace_env_symbol, package_symbol,
     previous_symbol, quote_symbol, row_names_symbol, seeds_symbol, sort_list_symbol, source_symbol,
-    spec_symbol, triple_colon_symbol, tsp_symbol, unbound_value,
+    spec_symbol, triple_colon_symbol, tsp_symbol,
 };
 
 // Exported macros have crate scope.

--- a/extendr-api/src/robj/debug.rs
+++ b/extendr-api/src/robj/debug.rs
@@ -10,9 +10,11 @@ impl std::fmt::Debug for Symbol {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.is_missing_arg() {
             write!(f, "missing_arg()")
-        } else if self.is_unbound_value() {
-            write!(f, "unbound_value()")
         } else {
+            #[cfg(not(r_4_5))]
+            if self.is_unbound_value() {
+                return write!(f, "unbound_value()");
+            }
             write!(f, "sym!({})", self.as_symbol().unwrap().as_str())
         }
     }

--- a/extendr-api/src/robj/rinternals.rs
+++ b/extendr-api/src/robj/rinternals.rs
@@ -1,15 +1,15 @@
 use crate::*;
 use extendr_ffi::{
-    get_var, is_data_frame, R_CFinalizer_t, R_ExternalPtrAddr, R_ExternalPtrProtected,
+    get_var_safe, is_data_frame, R_CFinalizer_t, R_ExternalPtrAddr, R_ExternalPtrProtected,
     R_ExternalPtrTag, R_GetCurrentSrcref, R_GetSrcFilename, R_IsNamespaceEnv, R_IsPackageEnv,
     R_MakeExternalPtr, R_MissingArg, R_NamespaceEnvSpec, R_PackageEnvName, R_RegisterCFinalizerEx,
-    R_UnboundValue, R_xlen_t, Rboolean, Rf_PairToVectorList, Rf_VectorToPairList, Rf_allocMatrix,
-    Rf_allocVector, Rf_asChar, Rf_asCharacterFactor, Rf_coerceVector, Rf_conformable, Rf_duplicate,
-    Rf_findFun, Rf_isArray, Rf_isComplex, Rf_isEnvironment, Rf_isExpression, Rf_isFactor,
-    Rf_isFunction, Rf_isInteger, Rf_isLanguage, Rf_isList, Rf_isLogical, Rf_isMatrix, Rf_isNewList,
-    Rf_isNull, Rf_isNumber, Rf_isObject, Rf_isPrimitive, Rf_isReal, Rf_isS4, Rf_isString,
-    Rf_isSymbol, Rf_isTs, Rf_isUserBinop, Rf_isVector, Rf_isVectorAtomic, Rf_isVectorList,
-    Rf_isVectorizable, Rf_ncols, Rf_nrows, Rf_xlengthgets, ALTREP, TYPEOF,
+    R_xlen_t, Rboolean, Rf_PairToVectorList, Rf_VectorToPairList, Rf_allocMatrix, Rf_allocVector,
+    Rf_asChar, Rf_asCharacterFactor, Rf_coerceVector, Rf_conformable, Rf_duplicate, Rf_findFun,
+    Rf_isArray, Rf_isComplex, Rf_isEnvironment, Rf_isExpression, Rf_isFactor, Rf_isFunction,
+    Rf_isInteger, Rf_isLanguage, Rf_isList, Rf_isLogical, Rf_isMatrix, Rf_isNewList, Rf_isNull,
+    Rf_isNumber, Rf_isObject, Rf_isPrimitive, Rf_isReal, Rf_isS4, Rf_isString, Rf_isSymbol,
+    Rf_isTs, Rf_isUserBinop, Rf_isVector, Rf_isVectorAtomic, Rf_isVectorList, Rf_isVectorizable,
+    Rf_ncols, Rf_nrows, Rf_xlengthgets, ALTREP, TYPEOF,
 };
 ///////////////////////////////////////////////////////////////
 /// The following impls wrap specific Rinternals.h functions.
@@ -198,14 +198,9 @@ pub trait Rinternals: Types + Conversions {
         // }
         unsafe {
             let sexp = self.get();
-            if let Ok(var) = catch_r_error(|| get_var(key.get(), sexp)) {
-                if var != R_UnboundValue {
-                    Ok(Robj::from_sexp(var))
-                } else {
-                    Err(Error::NotFound(key.into()))
-                }
-            } else {
-                Err(Error::NotFound(key.into()))
+            match get_var_safe(key.get(), sexp) {
+                Some(var) => Ok(Robj::from_sexp(var)),
+                None => Err(Error::NotFound(key.into())),
             }
         }
     }
@@ -424,8 +419,9 @@ pub trait Rinternals: Types + Conversions {
         unsafe { self.get() == R_MissingArg }
     }
 
+    #[cfg(not(r_4_5))]
     fn is_unbound_value(&self) -> bool {
-        unsafe { self.get() == R_UnboundValue }
+        unsafe { self.get() == extendr_ffi::R_UnboundValue }
     }
 
     fn is_package_env(&self) -> bool {

--- a/extendr-api/src/wrapper/environment.rs
+++ b/extendr-api/src/wrapper/environment.rs
@@ -204,9 +204,15 @@ impl Iterator for EnvIter {
             // Get the first available value from the pair list.
             for (key, value) in &mut self.pairlist {
                 // if the key and value are valid, return a pair.
-                if !key.is_na() && !value.is_unbound_value() {
-                    return Some((key, value));
+                #[cfg(not(r_4_5))]
+                if key.is_na() || value.is_unbound_value() {
+                    continue;
                 }
+                #[cfg(r_4_5)]
+                if key.is_na() {
+                    continue;
+                }
+                return Some((key, value));
             }
 
             // Get the first pairlist from the hash table.

--- a/extendr-api/src/wrapper/promise.rs
+++ b/extendr-api/src/wrapper/promise.rs
@@ -12,7 +12,6 @@ impl Promise {
     /// use extendr_api::prelude::*;
     /// test! {
     ///     let promise = Promise::from_parts(r!(1), global_env())?;
-    ///     assert!(promise.value().is_unbound_value());
     ///     assert_eq!(promise.eval_promise()?, r!(1));
     ///     assert_eq!(promise.value(), r!(1));
     /// }
@@ -24,6 +23,7 @@ impl Promise {
             let robj = Robj::from_sexp(sexp);
             extendr_ffi::SET_PRCODE(sexp, code.get());
             extendr_ffi::SET_PRENV(sexp, environment.robj.get());
+            #[cfg(not(r_4_5))]
             extendr_ffi::SET_PRVALUE(sexp, extendr_ffi::R_UnboundValue);
             Ok(Promise { robj })
         })
@@ -79,11 +79,11 @@ impl Promise {
     /// ```
     pub fn eval(&self) -> Result<Robj> {
         assert!(self.is_promise());
+        #[cfg(not(r_4_5))]
         if !self.value().is_unbound_value() {
-            Ok(self.value())
-        } else {
-            self.robj.eval()
+            return Ok(self.value());
         }
+        self.robj.eval()
     }
 }
 

--- a/extendr-api/src/wrapper/symbol.rs
+++ b/extendr-api/src/wrapper/symbol.rs
@@ -6,8 +6,8 @@ use extendr_ffi::{
     R_LastvalueSymbol, R_LevelsSymbol, R_MissingArg, R_ModeSymbol, R_NaRmSymbol, R_NameSymbol,
     R_NamesSymbol, R_NamespaceEnvSymbol, R_PackageSymbol, R_PreviousSymbol, R_QuoteSymbol,
     R_RowNamesSymbol, R_SeedsSymbol, R_SortListSymbol, R_SourceSymbol, R_SpecSymbol,
-    R_TripleColonSymbol, R_TspSymbol, R_UnboundValue, R_dot_Method, R_dot_defined,
-    R_dot_packageName, R_dot_target, PRINTNAME, TYPEOF,
+    R_TripleColonSymbol, R_TspSymbol, R_dot_Method, R_dot_defined, R_dot_packageName, R_dot_target,
+    PRINTNAME, TYPEOF,
 };
 /// Wrapper for creating symbol objects.
 ///
@@ -72,11 +72,6 @@ impl From<&str> for Symbol {
     fn from(name: &str) -> Self {
         Symbol::from_string(name)
     }
-}
-
-/// Unbound marker
-pub fn unbound_value() -> Symbol {
-    unsafe { Symbol::from_sexp(R_UnboundValue) }
 }
 
 /// Missing argument marker
@@ -234,7 +229,6 @@ mod test {
     #[test]
     fn test_constant_symbols() {
         test! {
-            assert!(unbound_value().is_symbol());
             assert!(missing_arg().is_symbol());
             assert!(base_symbol().is_symbol());
             assert!(brace_symbol().is_symbol());

--- a/extendr-ffi/src/backports.rs
+++ b/extendr-ffi/src/backports.rs
@@ -11,6 +11,9 @@
 
 use crate::{Rboolean, SEXP};
 
+#[cfg(not(r_4_5))]
+use crate::R_UnboundValue;
+
 extern "C" {
     #[cfg(not(r_4_5))]
     fn ENCLOS(x: SEXP) -> SEXP;
@@ -94,6 +97,33 @@ pub unsafe fn get_var(symbol: SEXP, env: SEXP) -> SEXP {
     #[cfg(r_4_5)]
     {
         R_getVar(symbol, env)
+    }
+}
+
+/// Returns a variable from an environment, or `None` if unbound.
+///
+/// On R < 4.5, uses `Rf_findVar` and checks against `R_UnboundValue`.
+/// On R >= 4.5, uses `R_getVar` which signals an error if not found;
+/// callers should wrap this with `catch_r_error` if needed.
+///
+/// # Safety
+///
+/// This function dereferences raw SEXP pointers.
+/// The caller must ensure that `symbol` and `env` are valid SEXP pointers.
+#[inline]
+pub unsafe fn get_var_safe(symbol: SEXP, env: SEXP) -> Option<SEXP> {
+    #[cfg(not(r_4_5))]
+    {
+        let var = Rf_findVar(symbol, env);
+        if var == R_UnboundValue {
+            None
+        } else {
+            Some(var)
+        }
+    }
+    #[cfg(r_4_5)]
+    {
+        Some(R_getVar(symbol, env))
     }
 }
 

--- a/extendr-ffi/src/lib.rs
+++ b/extendr-ffi/src/lib.rs
@@ -350,6 +350,7 @@ extern "C" {
     pub static R_Srcref: SEXP;
     pub fn R_tryEval(arg1: SEXP, arg2: SEXP, arg3: *mut ::std::os::raw::c_int) -> SEXP;
     pub fn R_tryEvalSilent(arg1: SEXP, arg2: SEXP, arg3: *mut ::std::os::raw::c_int) -> SEXP;
+    #[cfg(not(r_4_5))]
     #[doc = "Unbound marker"]
     pub static R_UnboundValue: SEXP;
     pub fn R_unif_index(arg1: f64) -> f64;


### PR DESCRIPTION
This PR closes https://github.com/extendr/extendr/issues/1064

It creates a new `get_var_safe()` in the extendr-ffi backports that will permit us to support 4.2-4.6 still