### PR TITLE
chore: remove R_NamespaceRegistry from extendr

### DIFF
--- a/extendr-api/src/functions.rs
+++ b/extendr-api/src/functions.rs
@@ -2,7 +2,7 @@ use crate as extendr_api;
 use crate::*;
 use extendr_ffi::{
     R_BaseEnv, R_BaseNamespace, R_BlankScalarString, R_BlankString, R_EmptyEnv, R_GetCurrentEnv,
-    R_GlobalEnv, R_NaString, R_NamespaceRegistry, R_NilValue, R_Srcref, R_dot_Generic,
+    R_GlobalEnv, R_NaString, R_NilValue, R_Srcref, R_dot_Generic,
 };
 
 #[cfg(feature = "non-api")]
@@ -154,18 +154,6 @@ pub fn base_env() -> Environment {
 /// ```
 pub fn base_namespace() -> Environment {
     unsafe { Robj::from_sexp(R_BaseNamespace).try_into().unwrap() }
-}
-
-/// For registered namespaces.
-///
-/// ```
-/// use extendr_api::prelude::*;
-/// test! {
-///    assert_eq!(namespace_registry().is_environment(), true);
-/// }
-/// ```
-pub fn namespace_registry() -> Environment {
-    unsafe { Robj::from_sexp(R_NamespaceRegistry).try_into().unwrap() }
 }
 
 /// Current srcref, for debuggers

--- a/extendr-api/src/prelude.rs
+++ b/extendr-api/src/prelude.rs
@@ -7,7 +7,7 @@ pub use super::error::Error;
 pub use super::functions::{
     base_env, base_namespace, blank_scalar_string, blank_string, current_env, empty_env,
     eval_string, eval_string_with_params, find_namespace, find_namespaced_function, global_env,
-    global_function, na_string, namespace_registry, new_env, nil_value, parse, srcref,
+    global_function, na_string, new_env, nil_value, parse, srcref,
 };
 pub use super::{
     print_r_error, print_r_output, CanBeNA, Rtype, FALSE, NA_INTEGER, NA_LOGICAL, NA_REAL,

--- a/extendr-ffi/src/lib.rs
+++ b/extendr-ffi/src/lib.rs
@@ -322,8 +322,6 @@ extern "C" {
     #[doc = "Missing argument marker"]
     pub static R_MissingArg: SEXP;
     pub fn R_NamespaceEnvSpec(rho: SEXP) -> SEXP;
-    #[doc = "Registry for registered namespaces"]
-    pub static R_NamespaceRegistry: SEXP;
     #[doc = "Environment and Binding Features"]
     pub fn R_NewEnv(arg1: SEXP, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int) -> SEXP;
     pub fn R_PackageEnvName(rho: SEXP) -> SEXP;


### PR DESCRIPTION
Closes #1068 

R_NamespaceRegistry is used as a single function in extendr-api that is entirely unused (at least according to github search). Rather than adding a backport i think our best bet it is to remove this entirely. 