### PR TITLE
chore: prep v0.9.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ repository = "https://github.com/extendr/extendr"
 license = "MIT"
 
 [workspace.dependencies]
-extendr-ffi = { path = "./extendr-ffi", version = "0.8.1" }
+extendr-ffi = { path = "./extendr-ffi", workspace = true }
 # When updating extendr's version, this version also needs to be updated
-extendr-macros = { path = "./extendr-macros", version = "0.8.1" }
+extendr-macros = { path = "./extendr-macros", workspace = true }

--- a/extendr-api/tests/optional/ndarray.rs
+++ b/extendr-api/tests/optional/ndarray.rs
@@ -73,7 +73,7 @@ fn complex_matrix_2d() {
     test! {
          let robj = R!("matrix(c(1, 2, 3i, 4i, 5 + 5i, 6 - 6i), ncol = 2, nrow = 3, byrow = TRUE)")?;
 
-         let expected = vec![1, 2, 0, 0, 5, 6].iter().zip(vec![0, 0, 3, 4, 5, -6]).map(|(&re, im)| <c64>::new(re as f64, im as f64))
+         let expected = [1, 2, 0, 0, 5, 6].iter().zip(vec![0, 0, 3, 4, 5, -6]).map(|(&re, im)| <c64>::new(re as f64, im as f64))
          .collect::<Vec<_>>();
 
          let view = <ArrayView2<Rcplx>>::try_from(&robj)?;
@@ -160,7 +160,7 @@ fn complex_matrix_1d() {
     test! {
          let robj = R!("matrix(c(1, 2, 3i, 4i, 5 + 5i, 6 - 6i), ncol = 1, nrow = 6)")?;
 
-         let expected = vec![1, 2, 0, 0, 5, 6].iter().zip(vec![0, 0, 3, 4, 5, -6]).map(|(&re, im)| <c64>::new(re as f64, im as f64))
+         let expected = [1, 2, 0, 0, 5, 6].iter().zip(vec![0, 0, 3, 4, 5, -6]).map(|(&re, im)| <c64>::new(re as f64, im as f64))
          .collect::<Vec<_>>();
 
          let view = <ArrayView1<Rcplx>>::try_from(&robj)?;

--- a/extendr-api/tests/optional/serde/deserializer.rs
+++ b/extendr-api/tests/optional/serde/deserializer.rs
@@ -216,7 +216,7 @@ fn test_deserialize_complex_named_list() {
         let end_file = RRunEndFile {
             start: "2024-01-01T00:00:00Z".into(),
             end: "2024-01-01T01:00:00Z".into(),
-            runtime_ms: 3600_000.0,
+            runtime_ms: 3_600_000.0,
             files_copied,
             output_files_rewrites,
             output_files_hashes: vec![OutputFileHash {

--- a/extendr-api/tests/optional/serde/serializer.rs
+++ b/extendr-api/tests/optional/serde/serializer.rs
@@ -57,13 +57,13 @@ fn test_serialize_robj() {
         struct Null(Robj);
         let s = Null(r!(NULL));
         let expected = r!(NULL);
-        assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+        assert_eq!(to_robj(&s).unwrap(), expected);
 
         #[derive(Serialize)]
         struct Sym(Symbol);
         let s = Sym(sym!(xyz).try_into()?);
         let expected = r!("xyz");
-        assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+        assert_eq!(to_robj(&s).unwrap(), expected);
 
         #[derive(Serialize)]
         struct Plist(Pairlist);
@@ -75,25 +75,25 @@ fn test_serialize_robj() {
         struct Rstr1(Rstr);
         let s = Rstr1(Rstr::from("xyz"));
         let expected = r!("xyz");
-        assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+        assert_eq!(to_robj(&s).unwrap(), expected);
 
         #[derive(Serialize)]
         struct Int(Integers);
         let s = Int(Integers::from_values([1]));
         let expected = r!(1);
-        assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+        assert_eq!(to_robj(&s).unwrap(), expected);
 
         #[derive(Serialize)]
         struct Int2(Integers);
         let s = Int2(Integers::from_values([1, 2]));
         let expected = r!(list![1, 2]);
-        assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+        assert_eq!(to_robj(&s).unwrap(), expected);
 
         #[derive(Serialize)]
         struct Dbl2(Doubles);
         let s = Dbl2(Doubles::from_values([1.0, 2.0]));
         let expected = r!(list![1.0, 2.0]);
-        assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+        assert_eq!(to_robj(&s).unwrap(), expected);
 
         // BUG! Will probably be fixed by "better-debug"
         //
@@ -113,42 +113,42 @@ fn test_serialize_robj() {
         struct Raw1(Raw);
         let s = Raw1(Raw::from_bytes(&[1, 2, 3]));
         let expected = r!(Raw::from_bytes(&[1, 2, 3]));
-        assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+        assert_eq!(to_robj(&s).unwrap(), expected);
 
         #[derive(Serialize)]
         struct Rint1(Rint);
         let s = Rint1(Rint::from(1));
         let expected = r!(1);
-        assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+        assert_eq!(to_robj(&s).unwrap(), expected);
 
         #[derive(Serialize)]
         struct Rint2(Rint);
         let s = Rint2(Rint::na());
         let expected = r!(());
-        assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+        assert_eq!(to_robj(&s).unwrap(), expected);
 
         #[derive(Serialize)]
         struct Rfloat1(Rfloat);
         let s = Rfloat1(Rfloat::from(1.0));
         let expected = r!(1.0);
-        assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+        assert_eq!(to_robj(&s).unwrap(), expected);
 
         #[derive(Serialize)]
         struct Rfloat2(Rfloat);
         let s = Rfloat2(Rfloat::na());
         let expected = r!(());
-        assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+        assert_eq!(to_robj(&s).unwrap(), expected);
 
         #[derive(Serialize)]
         struct Rbool1(Rbool);
         let s = Rbool1(Rbool::from(true));
         let expected = r!(true);
-        assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+        assert_eq!(to_robj(&s).unwrap(), expected);
 
         #[derive(Serialize)]
         struct Rbool2(Rbool);
         let s = Rbool2(Rbool::na());
         let expected = r!(());
-        assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+        assert_eq!(to_robj(&s).unwrap(), expected);
     }
 }

--- a/justfile
+++ b/justfile
@@ -150,3 +150,7 @@ r-cmd-check *args:
     && ARGS="'--as-cran','--no-manual'" \
     && if [ "$NO_VIGNETTES" = "1" ]; then ARGS="${ARGS},'--no-build-vignettes'"; fi \
     && Rscript -e "rcmdcheck::rcmdcheck(args = c(${ARGS}), error_on = '${ERROR_ON}', check_dir = ${CHECK_DIR_ARG})"
+
+# Bump version
+bump version:
+    cargo release version {{version}} --execute


### PR DESCRIPTION
This PR: 

- bumps the version of extendr
- fixes clippy lints
- adds a new justfile rule to bump crate package versions `just bump {version}` 