### PR TITLE
chore: add issue and pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,0 +1,62 @@
+name: Bug Report
+description: File a bug report
+title: "fix: "
+labels: ["bug"]
+body:
+  - type: checkboxes
+    id: existing-issue
+    attributes:
+      label: Pre-flight checklist
+      options:
+        - label: I have searched existing issues and this is not a duplicate
+          required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: current-behavior
+    attributes:
+      label: Current behavior
+      description: What actually happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        <!-- Provide a minimal reproducible example -->
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    id: possible-solution
+    attributes:
+      label: Possible solution
+      placeholder: "<!-- Optional: any ideas on what might be causing this or how to fix it? -->"
+    validations:
+      required: false
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: |
+        <!-- Fill in what is relevant -->
+        - extendr version:
+        - Rust version (`rustc --version`):
+        - R version (`R --version`):
+        - OS:
+        - Link to project (if applicable):
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,0 +1,45 @@
+name: Feature Request
+description: Propose a new feature or enhancement
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: checkboxes
+    id: existing-issue
+    attributes:
+      label: Pre-flight checklist
+      options:
+        - label: I have searched existing issues and this is not a duplicate
+          required: true
+
+  - type: textarea
+    id: feature-description
+    attributes:
+      label: Feature description
+      description: What would you like to see added or changed?
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem-solved
+    attributes:
+      label: What problem does this solve?
+      description: What use case or pain point does this address?
+    validations:
+      required: true
+
+  - type: textarea
+    id: current-workaround
+    attributes:
+      label: Why is the current API not sufficient?
+      placeholder: <!-- Describe what you currently have to do and why it falls short -->
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-api
+    attributes:
+      label: Proposed API or design
+      placeholder: |
+        <!-- Optional: sketch out what the ideal API might look like -->
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/3-docs.yml
+++ b/.github/ISSUE_TEMPLATE/3-docs.yml
@@ -1,0 +1,43 @@
+name: Documentation Issue
+description: Report an issue with the documentation
+title: "docs: "
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > [!NOTE]
+        > If the documentation issue is **not** related to the Rust API (e.g. guides, tutorials, the extendr website), please open an issue at https://github.com/extendr/extendr.github.io instead.
+
+  - type: checkboxes
+    id: existing-issue
+    attributes:
+      label: Pre-flight checklist
+      options:
+        - label: I have searched existing issues and this is not a duplicate
+          required: true
+        - label: This issue is about the Rust API docs, not the extendr website
+          required: true
+
+  - type: textarea
+    id: location
+    attributes:
+      label: Where is the documentation issue?
+      placeholder: <!-- Link to the relevant docs page, or describe where to find it -->
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is wrong or missing?
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested improvement
+      placeholder: "<!-- Optional: what should it say instead? -->"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/4-other.yml
+++ b/.github/ISSUE_TEMPLATE/4-other.yml
@@ -1,0 +1,18 @@
+name: Other
+description: Something that doesn't fit the other categories
+title: ""
+body:
+  - type: checkboxes
+    id: existing-issue
+    attributes:
+      label: Pre-flight checklist
+      options:
+        - label: I have searched existing issues and this is not a duplicate
+          required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- PR type: feat | fix | docs | refactor | enh -->
+
+<!-- What does this solve? -->
+
+## Checklist
+
+- [ ] format via `just fmt`
+- [ ] tested with `just test`
+- [ ] integration tests added (new features only)
+- [ ] CHANGELOG.md updated
+
+## Resolves
+
+<!-- Link to outstanding issues with "Closes #<issue-number>" -->
+
+- Closes #

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Summary
 
-<!-- PR type: feat | fix | docs | refactor | enh -->
+<!-- PR type: feat | fix | chore | docs | refactor | enh -->
 
 <!-- What does this solve? -->
 


### PR DESCRIPTION
As the project grows, we need more structure to our GitHub issues and PRs.

This adds structure to our GH issues via templates and PR template.

The PR template is very minimal but ensures that people are formatting their code and adding changelog entries.