### PR TITLE
feat: create and return condition objects 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- `Condition`, `RCondition`, `ConditionKind`, and `ConditionBuilder` in `extendr_api::conditions` for creating, converting, and round-tripping R condition objects. `Condition` is the Rust-native representation; `RCondition` is the R-boundary type wrapping a validated `List`. Conversions between all four types are provided via `From`/`TryFrom`. <https://github.com/extendr/extendr/pull/1082>
+- `From<Strings> for Vec<String>` and `From<Strings> for StrIter` conversions. <https://github.com/extendr/extendr/pull/1082>
 - `stop()` is an alias for `throw_r_error()` 
 - `abort!()` and `warn!()` macros for rlang-style error and warning conditions with no rlang dependency. Supports optional body bullets and caller environment attribution: `abort!("msg", &["detail"], call = env)` and `abort!("msg", call = env)`. <https://github.com/extendr/extendr/pull/1075>
 - `Environment::call()` retrieves the call associated with an environment by matching against the R call stack, mirroring `rlang::frame_call()` <https://github.com/extendr/extendr/pull/1075>

--- a/extendr-api/src/conditions/mod.rs
+++ b/extendr-api/src/conditions/mod.rs
@@ -1,3 +1,195 @@
+use crate::{
+    AsStrIter, Attributes, Environment, Error, IntoRobj, Language, List, Operators, Result, Robj,
+    Rstr, StrIter, Strings,
+};
+
+/// Discriminates the kind of R condition being constructed.
+#[derive(Copy, Debug, Clone, PartialEq)]
+pub enum ConditionKind {
+    Condition,
+    Message,
+    Warning,
+    Error,
+}
+
+/// Rust-native representation of an R condition.
+///
+/// Holds Rust types and is converted into an R condition list via
+/// `From<Condition> for Robj` or `From<Condition> for RCondition`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Condition {
+    pub message: Vec<String>,
+    pub kind: ConditionKind,
+    pub class: Option<Vec<String>>,
+    pub call: Option<Language>,
+}
+
+impl From<Condition> for List {
+    fn from(value: Condition) -> Self {
+        let msg = Strings::from_values(value.message).into_robj();
+
+        let call_robj = value.call.map(|v| v.into()).unwrap_or(Robj::from(()));
+
+        let mut cnd = List::from_pairs([("message", msg), ("call", call_robj)]);
+
+        let base_classes: &[&str] = match value.kind {
+            ConditionKind::Condition => &["simpleCondition", "condition"],
+            ConditionKind::Message => &["simpleMessage", "message", "condition"],
+            ConditionKind::Warning => &["simpleWarning", "warning", "condition"],
+            ConditionKind::Error => &["simpleError", "error", "condition"],
+        };
+
+        let mut class = value.class.unwrap_or_default();
+        class.extend(base_classes.iter().map(|s| s.to_string()));
+        cnd.set_class(&class)
+            .expect("set_class on a list should never fail");
+        cnd
+    }
+}
+
+impl From<Condition> for RCondition {
+    fn from(value: Condition) -> Self {
+        Self(List::from(value))
+    }
+}
+
+impl From<Condition> for Robj {
+    fn from(value: Condition) -> Self {
+        Robj::from(List::from(value))
+    }
+}
+
+impl TryFrom<&Robj> for Condition {
+    type Error = Error;
+
+    fn try_from(value: &Robj) -> std::result::Result<Self, Self::Error> {
+        let list = List::try_from(value)?;
+
+        let message = Strings::try_from(list.dollar("message")?)?.into();
+
+        let cls: Vec<String> = list
+            .class()
+            .map(|inner| inner.map(|s| s.to_string()).collect())
+            .unwrap_or_default();
+
+        if !cls.iter().any(|c| c == "condition") {
+            return Err(Error::Other(
+                "object does not inherit from `condition`".into(),
+            ));
+        }
+
+        let base_kinds = ["error", "warning", "message"];
+        let matched: Vec<&str> = base_kinds
+            .iter()
+            .copied()
+            .filter(|k| cls.iter().any(|c| c == k))
+            .collect();
+
+        if matched.len() > 1 {
+            return Err(Error::Other(format!(
+                "ambiguous condition: inherits from multiple base kinds: {}",
+                matched.join(", ")
+            )));
+        }
+
+        let kind = match matched.first().copied() {
+            Some("error") => ConditionKind::Error,
+            Some("warning") => ConditionKind::Warning,
+            Some("message") => ConditionKind::Message,
+            _ => ConditionKind::Condition,
+        };
+
+        // Strip the base classes to recover user-defined prefix classes
+        let base_classes: &[&str] = match kind {
+            ConditionKind::Condition => &["simpleCondition", "condition"],
+            ConditionKind::Message => &["simpleMessage", "message", "condition"],
+            ConditionKind::Warning => &["simpleWarning", "warning", "condition"],
+            ConditionKind::Error => &["simpleError", "error", "condition"],
+        };
+        let user_class: Vec<String> = cls
+            .iter()
+            .filter(|c| !base_classes.contains(&c.as_str()))
+            .cloned()
+            .collect();
+        let class = if user_class.is_empty() {
+            None
+        } else {
+            Some(user_class)
+        };
+
+        let call = list
+            .dollar("call")
+            .ok()
+            .and_then(|v| Language::try_from(&v).ok());
+
+        Ok(Condition {
+            message,
+            kind,
+            class,
+            call,
+        })
+    }
+}
+
+/// A wrapper around an R condition object (`Robj`).
+///
+/// This represents an actual R condition list as it exists in R memory.
+pub struct RCondition(pub List);
+
+/// Builder for constructing a [`Condition`].
+pub struct ConditionBuilder {
+    message: Vec<String>,
+    kind: ConditionKind,
+    class: Option<Vec<String>>,
+    call: Option<Language>,
+}
+
+impl ConditionBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn set_message(mut self, message: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.message = message.into_iter().map(|s| s.into()).collect();
+        self
+    }
+
+    pub fn set_kind(mut self, kind: ConditionKind) -> Self {
+        self.kind = kind;
+        self
+    }
+
+    pub fn set_class(mut self, class: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.class = Some(class.into_iter().map(|s| s.into()).collect());
+        self
+    }
+
+    pub fn set_call(mut self, call: Language) -> Self {
+        self.call = Some(call);
+        self
+    }
+
+    pub fn build(self) -> Condition {
+        Condition {
+            message: self.message,
+            kind: self.kind,
+            class: self.class,
+            call: self.call,
+        }
+    }
+}
+
+impl Default for ConditionBuilder {
+    fn default() -> Self {
+        Self {
+            message: Vec::new(),
+            kind: ConditionKind::Condition,
+            class: None,
+            call: None,
+        }
+    }
+}
+
 /// Format an error message with rlang-style bullets.
 pub fn format_cnd_message(header: &str, body: &[&str]) -> String {
     use std::io::IsTerminal;
@@ -114,6 +306,7 @@ macro_rules! abort {
 
 #[cfg(test)]
 mod tests {
+    use crate::conditions::{ConditionBuilder, RCondition};
 
     #[test]
     fn test_format_cnd_message_no_body() {
@@ -127,5 +320,16 @@ mod tests {
         assert!(msg.contains("something went wrong"));
         assert!(msg.contains("detail 1"));
         assert!(msg.contains("detail 2"));
+    }
+
+    #[test]
+    fn test_cnd() {
+        let cnd = ConditionBuilder::new()
+            .set_kind(super::ConditionKind::Message)
+            .set_message(["this is a custom message"])
+            .set_class(["class1", "class2"])
+            .build();
+
+        let rcnd = RCondition::from(cnd.clone());
     }
 }

--- a/extendr-api/src/conditions/mod.rs
+++ b/extendr-api/src/conditions/mod.rs
@@ -6,7 +6,8 @@
 //! - a class attribute including `"condition"` and optionally `"error"`,
 //!   `"warning"`, or `"message"`
 //!
-//! rlang-style conditions may include a traceback, which is not yet supported here.
+//! rlang-style conditions may include additional fields (`trace`, `parent`) which
+//! are not represented in [`Condition`] and will be dropped on round-trip.
 //!
 //! ## Types
 //!

--- a/extendr-api/src/conditions/mod.rs
+++ b/extendr-api/src/conditions/mod.rs
@@ -1,6 +1,40 @@
+//! # Condition objects
+//!
+//! In R, a condition is an S3 list with:
+//! - `message`: a character vector describing the condition
+//! - `call`: the call that triggered the condition, or `NULL`
+//! - a class attribute including `"condition"` and optionally `"error"`,
+//!   `"warning"`, or `"message"`
+//!
+//! rlang-style conditions may include a traceback, which is not yet supported here.
+//!
+//! ## Types
+//!
+//! This module provides four types:
+//!
+//! - [`ConditionKind`]: an enum discriminating the base R condition type
+//!   (`condition`, `message`, `warning`, `error`).
+//!
+//! - [`Condition`]: a Rust-native representation. Construct one with [`ConditionBuilder::default()`]. This is the primary type we encourage you to work with for its ergonomics due to its use of std types.
+//!
+//! - [`RCondition`]: a thin wrapper around a [`List`] that already exists in R
+//!   memory as a proper condition object. Use this when receiving or returning
+//!   condition objects at the R boundary.
+//!
+//! - [`ConditionBuilder`]: a builder for [`Condition`]. Create a builder with [`ConditionBuilder::default()`] to start, chain setters, and call `.build()` to produce a [`Condition`].
+//!
+//! ## Conversions
+//!
+//! | From \ To   | `List`  | `RCondition` | `Robj`  | `Condition` |
+//! |-------------|---------|--------------|---------|-------------|
+//! | `Condition` | `From`  | `From`       | `From`  | —           |
+//! | `List`      | —       | `From`       | blanket | `TryFrom`   |
+//! | `&List`     | —       | `From`       | —       | `TryFrom`   |
+//! | `RCondition`| `From`  | —            | `From`  | `TryFrom`   |
+//! | `Robj`      | —       | `TryFrom`    | —       | `TryFrom`   |
+//! | `&Robj`     | —       | `TryFrom`    | —       | `TryFrom`   |
 use crate::{
-    AsStrIter, Attributes, Environment, Error, IntoRobj, Language, List, Operators, Result, Robj,
-    Rstr, StrIter, Strings,
+    robj::Rinternals, Attributes, Error, IntoRobj, Language, List, Operators, Robj, Strings,
 };
 
 /// Discriminates the kind of R condition being constructed.
@@ -33,10 +67,10 @@ impl From<Condition> for List {
         let mut cnd = List::from_pairs([("message", msg), ("call", call_robj)]);
 
         let base_classes: &[&str] = match value.kind {
-            ConditionKind::Condition => &["simpleCondition", "condition"],
-            ConditionKind::Message => &["simpleMessage", "message", "condition"],
-            ConditionKind::Warning => &["simpleWarning", "warning", "condition"],
-            ConditionKind::Error => &["simpleError", "error", "condition"],
+            ConditionKind::Condition => &["condition"],
+            ConditionKind::Message => &["message", "condition"],
+            ConditionKind::Warning => &["warning", "condition"],
+            ConditionKind::Error => &["error", "condition"],
         };
 
         let mut class = value.class.unwrap_or_default();
@@ -59,13 +93,11 @@ impl From<Condition> for Robj {
     }
 }
 
-impl TryFrom<&Robj> for Condition {
+impl TryFrom<&List> for Condition {
     type Error = Error;
 
-    fn try_from(value: &Robj) -> std::result::Result<Self, Self::Error> {
-        let list = List::try_from(value)?;
-
-        let message = Strings::try_from(list.dollar("message")?)?.into();
+    fn try_from(list: &List) -> std::result::Result<Self, Self::Error> {
+        let message: Vec<String> = Strings::try_from(list.dollar("message")?)?.into();
 
         let cls: Vec<String> = list
             .class()
@@ -99,12 +131,11 @@ impl TryFrom<&Robj> for Condition {
             _ => ConditionKind::Condition,
         };
 
-        // Strip the base classes to recover user-defined prefix classes
         let base_classes: &[&str] = match kind {
-            ConditionKind::Condition => &["simpleCondition", "condition"],
-            ConditionKind::Message => &["simpleMessage", "message", "condition"],
-            ConditionKind::Warning => &["simpleWarning", "warning", "condition"],
-            ConditionKind::Error => &["simpleError", "error", "condition"],
+            ConditionKind::Condition => &["condition"],
+            ConditionKind::Message => &["message", "condition"],
+            ConditionKind::Warning => &["warning", "condition"],
+            ConditionKind::Error => &["error", "condition"],
         };
         let user_class: Vec<String> = cls
             .iter()
@@ -117,10 +148,13 @@ impl TryFrom<&Robj> for Condition {
             Some(user_class)
         };
 
-        let call = list
-            .dollar("call")
-            .ok()
-            .and_then(|v| Language::try_from(&v).ok());
+        let call = list.dollar("call").ok().and_then(|v| {
+            if v.is_null() {
+                None
+            } else {
+                Language::try_from(&v).ok()
+            }
+        });
 
         Ok(Condition {
             message,
@@ -131,10 +165,82 @@ impl TryFrom<&Robj> for Condition {
     }
 }
 
+impl TryFrom<List> for Condition {
+    type Error = Error;
+
+    fn try_from(value: List) -> std::result::Result<Self, Self::Error> {
+        Condition::try_from(&value)
+    }
+}
+
+impl TryFrom<&Robj> for Condition {
+    type Error = Error;
+
+    fn try_from(value: &Robj) -> std::result::Result<Self, Self::Error> {
+        Condition::try_from(List::try_from(value)?)
+    }
+}
+
+impl TryFrom<Robj> for Condition {
+    type Error = Error;
+
+    fn try_from(value: Robj) -> std::result::Result<Self, Self::Error> {
+        Condition::try_from(&value)
+    }
+}
+
 /// A wrapper around an R condition object (`Robj`).
 ///
 /// This represents an actual R condition list as it exists in R memory.
 pub struct RCondition(pub List);
+
+impl From<List> for RCondition {
+    fn from(value: List) -> Self {
+        RCondition(value)
+    }
+}
+
+impl From<&List> for RCondition {
+    fn from(value: &List) -> Self {
+        RCondition(value.clone())
+    }
+}
+
+impl From<RCondition> for List {
+    fn from(value: RCondition) -> Self {
+        value.0
+    }
+}
+
+impl From<RCondition> for Robj {
+    fn from(value: RCondition) -> Self {
+        Robj::from(value.0)
+    }
+}
+
+impl TryFrom<RCondition> for Condition {
+    type Error = Error;
+
+    fn try_from(value: RCondition) -> std::result::Result<Self, Self::Error> {
+        Condition::try_from(value.0)
+    }
+}
+
+impl TryFrom<&Robj> for RCondition {
+    type Error = Error;
+
+    fn try_from(value: &Robj) -> std::result::Result<Self, Self::Error> {
+        Ok(RCondition(List::try_from(value)?))
+    }
+}
+
+impl TryFrom<Robj> for RCondition {
+    type Error = Error;
+
+    fn try_from(value: Robj) -> std::result::Result<Self, Self::Error> {
+        RCondition::try_from(&value)
+    }
+}
 
 /// Builder for constructing a [`Condition`].
 pub struct ConditionBuilder {
@@ -145,10 +251,6 @@ pub struct ConditionBuilder {
 }
 
 impl ConditionBuilder {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     pub fn set_message(mut self, message: impl IntoIterator<Item = impl Into<String>>) -> Self {
         self.message = message.into_iter().map(|s| s.into()).collect();
         self
@@ -306,7 +408,12 @@ macro_rules! abort {
 
 #[cfg(test)]
 mod tests {
-    use crate::conditions::{ConditionBuilder, RCondition};
+    use extendr_engine::with_r;
+
+    use crate::{
+        conditions::{Condition, ConditionBuilder, ConditionKind, RCondition},
+        Attributes, List, Result, Robj,
+    };
 
     #[test]
     fn test_format_cnd_message_no_body() {
@@ -323,13 +430,113 @@ mod tests {
     }
 
     #[test]
-    fn test_cnd() {
-        let cnd = ConditionBuilder::new()
-            .set_kind(super::ConditionKind::Message)
-            .set_message(["this is a custom message"])
-            .set_class(["class1", "class2"])
-            .build();
+    fn roundtrip_with_class() -> Result<()> {
+        with_r(|| {
+            let cnd = ConditionBuilder::default()
+                .set_kind(ConditionKind::Message)
+                .set_message(["this is a custom message"])
+                .set_class(["class1", "class2"])
+                .build();
+            let c2 = Condition::try_from(RCondition::from(cnd.clone()))?;
+            assert_eq!(cnd, c2);
+            Ok(())
+        })
+    }
 
-        let rcnd = RCondition::from(cnd.clone());
+    #[test]
+    fn roundtrip_no_class() -> Result<()> {
+        with_r(|| {
+            let cnd = ConditionBuilder::default()
+                .set_kind(ConditionKind::Warning)
+                .set_message(["watch out"])
+                .build();
+            let c2 = Condition::try_from(RCondition::from(cnd.clone()))?;
+            assert_eq!(cnd, c2);
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn roundtrip_via_robj() -> Result<()> {
+        with_r(|| {
+            let cnd = ConditionBuilder::default()
+                .set_kind(ConditionKind::Error)
+                .set_message(["something failed"])
+                .set_class(["my_error"])
+                .build();
+            let robj = Robj::from(cnd.clone());
+            let c2 = Condition::try_from(robj)?;
+            assert_eq!(cnd, c2);
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn roundtrip_all_kinds() -> Result<()> {
+        with_r(|| {
+            for (kind, expected_base) in [
+                (ConditionKind::Condition, "condition"),
+                (ConditionKind::Message, "message"),
+                (ConditionKind::Warning, "warning"),
+                (ConditionKind::Error, "error"),
+            ] {
+                let cnd = ConditionBuilder::default()
+                    .set_kind(kind)
+                    .set_message(["msg"])
+                    .build();
+                let list = List::from(cnd);
+                let cls: Vec<_> = list.class().unwrap().collect();
+                assert!(cls.contains(&expected_base), "missing {expected_base}");
+                assert!(cls.contains(&"condition"), "missing condition");
+            }
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn err_not_a_condition() -> Result<()> {
+        with_r(|| {
+            let list = List::from_pairs([("message", Robj::from("oops"))]);
+            let result = Condition::try_from(&list);
+            assert!(result.is_err());
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn err_not_a_list() -> Result<()> {
+        with_r(|| {
+            let robj = Robj::from("just a string");
+            let result = Condition::try_from(&robj);
+            assert!(result.is_err());
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn err_ambiguous_kind() -> Result<()> {
+        with_r(|| {
+            let mut list =
+                List::from_pairs([("message", Robj::from("oops")), ("call", Robj::from(()))]);
+            list.set_class(&["error", "warning", "condition"]).unwrap();
+            let result = Condition::try_from(&list);
+            assert!(result.is_err());
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn roundtrip_rcondition_to_condition() -> Result<()> {
+        with_r(|| {
+            let cnd = ConditionBuilder::default()
+                .set_kind(ConditionKind::Error)
+                .set_message(["bad thing"])
+                .set_class(["my_err"])
+                .build();
+            let rcnd = RCondition::from(cnd.clone());
+            let c2 = Condition::try_from(rcnd)?;
+            assert_eq!(cnd, c2);
+            Ok(())
+        })
     }
 }

--- a/extendr-api/src/conditions/mod.rs
+++ b/extendr-api/src/conditions/mod.rs
@@ -6,8 +6,8 @@
 //! - a class attribute including `"condition"` and optionally `"error"`,
 //!   `"warning"`, or `"message"`
 //!
-//! rlang-style conditions may include additional fields (`trace`, `parent`) which
-//! are not represented in [`Condition`] and will be dropped on round-trip.
+//! rlang-style conditions may include `trace` and `parent` fields, which are
+//! represented as `Option<List>` and `Option<RCondition>` respectively.
 //!
 //! ## Types
 //!
@@ -29,8 +29,8 @@
 //! | From \ To   | `List`  | `RCondition` | `Robj`  | `Condition` |
 //! |-------------|---------|--------------|---------|-------------|
 //! | `Condition` | `From`  | `From`       | `From`  | —           |
-//! | `List`      | —       | `From`       | blanket | `TryFrom`   |
-//! | `&List`     | —       | `From`       | —       | `TryFrom`   |
+//! | `List`      | —       | `TryFrom`    | blanket | `TryFrom`   |
+//! | `&List`     | —       | `TryFrom`    | —       | `TryFrom`   |
 //! | `RCondition`| `From`  | —            | `From`  | `TryFrom`   |
 //! | `Robj`      | —       | `TryFrom`    | —       | `TryFrom`   |
 //! | `&Robj`     | —       | `TryFrom`    | —       | `TryFrom`   |
@@ -57,6 +57,8 @@ pub struct Condition {
     pub kind: ConditionKind,
     pub class: Option<Vec<String>>,
     pub call: Option<Language>,
+    pub parent: Option<RCondition>,
+    pub trace: Option<List>,
 }
 
 impl From<Condition> for List {
@@ -64,8 +66,18 @@ impl From<Condition> for List {
         let msg = Strings::from_values(value.message).into_robj();
 
         let call_robj = value.call.map(|v| v.into()).unwrap_or(Robj::from(()));
+        let parent_robj = value
+            .parent
+            .map(|v| Robj::from(v.0))
+            .unwrap_or(Robj::from(()));
+        let trace_robj = value.trace.map(|v| Robj::from(v)).unwrap_or(Robj::from(()));
 
-        let mut cnd = List::from_pairs([("message", msg), ("call", call_robj)]);
+        let mut cnd = List::from_pairs([
+            ("message", msg),
+            ("trace", trace_robj),
+            ("parent", parent_robj),
+            ("call", call_robj),
+        ]);
 
         let base_classes: &[&str] = match value.kind {
             ConditionKind::Condition => &["condition"],
@@ -157,11 +169,29 @@ impl TryFrom<&List> for Condition {
             }
         });
 
+        let parent = list.dollar("parent").ok().and_then(|v| {
+            if v.is_null() {
+                None
+            } else {
+                List::try_from(&v).ok().map(RCondition)
+            }
+        });
+
+        let trace = list.dollar("trace").ok().and_then(|v| {
+            if v.is_null() {
+                None
+            } else {
+                List::try_from(&v).ok()
+            }
+        });
+
         Ok(Condition {
             message,
             kind,
             class,
             call,
+            parent,
+            trace,
         })
     }
 }
@@ -193,17 +223,24 @@ impl TryFrom<Robj> for Condition {
 /// A wrapper around an R condition object (`Robj`).
 ///
 /// This represents an actual R condition list as it exists in R memory.
+#[derive(Clone, PartialEq, Debug)]
 pub struct RCondition(pub List);
 
-impl From<List> for RCondition {
-    fn from(value: List) -> Self {
-        RCondition(value)
+impl TryFrom<List> for RCondition {
+    type Error = Error;
+
+    fn try_from(value: List) -> std::result::Result<Self, Self::Error> {
+        Condition::try_from(&value)?;
+        Ok(RCondition(value))
     }
 }
 
-impl From<&List> for RCondition {
-    fn from(value: &List) -> Self {
-        RCondition(value.clone())
+impl TryFrom<&List> for RCondition {
+    type Error = Error;
+
+    fn try_from(value: &List) -> std::result::Result<Self, Self::Error> {
+        Condition::try_from(value)?;
+        Ok(RCondition(value.clone()))
     }
 }
 
@@ -249,6 +286,8 @@ pub struct ConditionBuilder {
     kind: ConditionKind,
     class: Option<Vec<String>>,
     call: Option<Language>,
+    parent: Option<RCondition>,
+    trace: Option<List>,
 }
 
 impl ConditionBuilder {
@@ -272,12 +311,25 @@ impl ConditionBuilder {
         self
     }
 
+    pub fn set_parent(mut self, parent: impl Into<RCondition>) -> Self {
+        self.parent = Some(parent.into());
+        self
+    }
+
+    /// Set the trace field. The structure of the list is not validated.
+    pub fn set_trace(mut self, trace: List) -> Self {
+        self.trace = Some(trace);
+        self
+    }
+
     pub fn build(self) -> Condition {
         Condition {
             message: self.message,
             kind: self.kind,
             class: self.class,
             call: self.call,
+            parent: self.parent,
+            trace: self.trace,
         }
     }
 }
@@ -289,6 +341,8 @@ impl Default for ConditionBuilder {
             kind: ConditionKind::Condition,
             class: None,
             call: None,
+            parent: None,
+            trace: None,
         }
     }
 }

--- a/extendr-api/src/conditions/mod.rs
+++ b/extendr-api/src/conditions/mod.rs
@@ -6,7 +6,7 @@
 //! - a class attribute including `"condition"` and optionally `"error"`,
 //!   `"warning"`, or `"message"`
 //!
-//! rlang-style conditions may include `trace` and `parent` fields, which are
+//! rlang conditions may include `trace` and `parent` fields, which are
 //! represented as `Option<List>` and `Option<RCondition>` respectively.
 //!
 //! ## Types
@@ -41,23 +41,36 @@ use crate::{
 /// Discriminates the kind of R condition being constructed.
 #[derive(Copy, Debug, Clone, PartialEq)]
 pub enum ConditionKind {
+    /// A generic condition. Base class: `"condition"`.
     Condition,
+    /// A message condition. Base classes: `"message"`, `"condition"`.
     Message,
+    /// A warning condition. Base classes: `"warning"`, `"condition"`.
     Warning,
+    /// An error condition. Base classes: `"error"`, `"condition"`.
     Error,
 }
 
 /// Rust-native representation of an R condition.
 ///
-/// Holds Rust types and is converted into an R condition list via
-/// `From<Condition> for Robj` or `From<Condition> for RCondition`.
+/// This is the primary type to work with. Construct one via
+/// [`ConditionBuilder::default()`] and convert it to R types via the
+/// `From`/`Into` impls. To read a condition from R, use `TryFrom<Robj>` or
+/// `TryFrom<List>`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Condition {
+    /// The condition message. Corresponds to the `message` character vector in R.
     pub message: Vec<String>,
+    /// The base kind of condition, used to set the R class hierarchy.
     pub kind: ConditionKind,
+    /// User-defined subclasses prepended to the base classes. `None` means no
+    /// custom classes beyond those implied by `kind`.
     pub class: Option<Vec<String>>,
+    /// The call that triggered the condition, or `None` for `NULL`.
     pub call: Option<Language>,
+    /// An optional parent condition, used to chain conditions with rlang.
     pub parent: Option<RCondition>,
+    /// An optional traceback. The structure is not validated.
     pub trace: Option<List>,
 }
 
@@ -112,9 +125,9 @@ impl TryFrom<&List> for Condition {
     fn try_from(list: &List) -> std::result::Result<Self, Self::Error> {
         let message: Vec<String> = Strings::try_from(list.dollar("message")?)?.into();
 
-        let cls: Vec<String> = list
+        let cls = list
             .class()
-            .map(|inner| inner.map(|s| s.to_string()).collect())
+            .map(|inner| inner.map(|s| s.to_string()).collect::<Vec<_>>())
             .unwrap_or_default();
 
         if !cls.iter().any(|c| c == "condition") {
@@ -220,9 +233,11 @@ impl TryFrom<Robj> for Condition {
     }
 }
 
-/// A wrapper around an R condition object (`Robj`).
+/// A validated R condition object held as a [`List`].
 ///
-/// This represents an actual R condition list as it exists in R memory.
+/// Use this as a function argument or return type when exchanging condition
+/// objects with R. To inspect or modify fields, convert to [`Condition`] via
+/// `TryFrom`.
 #[derive(Clone, PartialEq, Debug)]
 pub struct RCondition(pub List);
 
@@ -268,7 +283,7 @@ impl TryFrom<&Robj> for RCondition {
     type Error = Error;
 
     fn try_from(value: &Robj) -> std::result::Result<Self, Self::Error> {
-        Ok(RCondition(List::try_from(value)?))
+        RCondition::try_from(List::try_from(value)?)
     }
 }
 
@@ -291,37 +306,45 @@ pub struct ConditionBuilder {
 }
 
 impl ConditionBuilder {
+    /// Set the condition message. Accepts any iterable of strings.
     pub fn set_message(mut self, message: impl IntoIterator<Item = impl Into<String>>) -> Self {
         self.message = message.into_iter().map(|s| s.into()).collect();
         self
     }
 
+    /// Set the condition kind, which determines the base R class hierarchy.
     pub fn set_kind(mut self, kind: ConditionKind) -> Self {
         self.kind = kind;
         self
     }
 
+    /// Set user-defined subclasses. These are prepended to the base classes
+    /// derived from [`ConditionKind`].
     pub fn set_class(mut self, class: impl IntoIterator<Item = impl Into<String>>) -> Self {
         self.class = Some(class.into_iter().map(|s| s.into()).collect());
         self
     }
 
+    /// Set the call associated with the condition.
     pub fn set_call(mut self, call: Language) -> Self {
         self.call = Some(call);
         self
     }
 
+    /// Set a parent condition. Accepts anything that converts into [`RCondition`],
+    /// including a [`Condition`].
     pub fn set_parent(mut self, parent: impl Into<RCondition>) -> Self {
         self.parent = Some(parent.into());
         self
     }
 
-    /// Set the trace field. The structure of the list is not validated.
+    /// Set the traceback. The structure of the list is not validated.
     pub fn set_trace(mut self, trace: List) -> Self {
         self.trace = Some(trace);
         self
     }
 
+    /// Consume the builder and produce a [`Condition`].
     pub fn build(self) -> Condition {
         Condition {
             message: self.message,

--- a/extendr-api/src/iter.rs
+++ b/extendr-api/src/iter.rs
@@ -256,3 +256,21 @@ mod tests {
         })
     }
 }
+
+impl From<StrIter> for Vec<String> {
+    fn from(value: StrIter) -> Vec<String> {
+        value.map(|v| v.to_string()).collect()
+    }
+}
+
+impl From<Strings> for StrIter {
+    fn from(value: Strings) -> Self {
+        value.robj.as_str_iter().unwrap_or_default()
+    }
+}
+
+impl From<Strings> for Vec<String> {
+    fn from(value: Strings) -> Self {
+        StrIter::from(value).map(|s| s.to_string()).collect()
+    }
+}

--- a/tests/extendrtests/R/extendr-wrappers.R
+++ b/tests/extendrtests/R/extendr-wrappers.R
@@ -251,6 +251,12 @@ must_see_drop_msg_r_error_heap <- function() .Call(wrap__must_see_drop_msg_r_err
 
 must_see_drop_msg_panic_heap <- function() .Call(wrap__must_see_drop_msg_panic_heap)
 
+roundtrip_condition <- function(x) .Call(wrap__roundtrip_condition, x)
+
+condition_message <- function(x) .Call(wrap__condition_message, x)
+
+condition_has_call <- function(x) .Call(wrap__condition_has_call, x)
+
 cnd_warn <- function(msg) .Call(wrap__cnd_warn, msg)
 
 cnd_warn_with_body <- function(msg, body) .Call(wrap__cnd_warn_with_body, msg, body)

--- a/tests/extendrtests/src/rust/src/conditions.rs
+++ b/tests/extendrtests/src/rust/src/conditions.rs
@@ -1,4 +1,23 @@
+use extendr_api::conditions::{Condition, RCondition};
 use extendr_api::prelude::*;
+
+#[extendr]
+fn roundtrip_condition(x: RCondition) -> RCondition {
+    let cnd = Condition::try_from(x).expect("failed to parse condition");
+    RCondition::from(cnd)
+}
+
+#[extendr]
+fn condition_message(x: RCondition) -> Vec<String> {
+    let cnd = Condition::try_from(x).expect("failed to parse condition");
+    cnd.message
+}
+
+#[extendr]
+fn condition_has_call(x: RCondition) -> bool {
+    let cnd = Condition::try_from(x).expect("failed to parse condition");
+    cnd.call.is_some()
+}
 
 #[extendr]
 fn cnd_warn(msg: &str) {
@@ -35,6 +54,9 @@ fn throw_error_with_percent(msg: &str) {
 
 extendr_module! {
     mod conditions;
+    fn roundtrip_condition;
+    fn condition_message;
+    fn condition_has_call;
     fn cnd_warn;
     fn cnd_warn_with_body;
     fn cnd_abort;

--- a/tests/extendrtests/tests/testthat/test-conditions.R
+++ b/tests/extendrtests/tests/testthat/test-conditions.R
@@ -1,3 +1,64 @@
+test_that("rlang error_cnd round-trips", {
+  skip_if_not_installed("rlang")
+  cnd <- rlang::error_cnd("my_error", message = "something failed")
+  result <- roundtrip_condition(cnd)
+  expect_s3_class(result, "error")
+  expect_s3_class(result, "condition")
+  expect_equal(result$message, "something failed")
+})
+
+test_that("rlang warning_cnd round-trips", {
+  skip_if_not_installed("rlang")
+  cnd <- rlang::warning_cnd("my_warning", message = "watch out")
+  result <- roundtrip_condition(cnd)
+  expect_s3_class(result, "warning")
+  expect_s3_class(result, "condition")
+  expect_equal(result$message, "watch out")
+})
+
+test_that("rlang message_cnd round-trips", {
+  skip_if_not_installed("rlang")
+  cnd <- rlang::message_cnd("my_message", message = "hello")
+  result <- roundtrip_condition(cnd)
+  expect_s3_class(result, "message")
+  expect_s3_class(result, "condition")
+  expect_equal(result$message, "hello")
+})
+
+test_that("condition_message extracts message field", {
+  skip_if_not_installed("rlang")
+  cnd <- rlang::error_cnd(message = "oops")
+  expect_equal(condition_message(cnd), "oops")
+})
+
+test_that("condition_has_call detects call from rlang::current_call()", {
+  skip_if_not_installed("rlang")
+  my_fn <- function() {
+    cnd <- rlang::error_cnd(message = "oops", call = rlang::current_call())
+    condition_has_call(cnd)
+  }
+  expect_true(my_fn())
+})
+
+test_that("round-trip preserves message and call; rlang trace/parent are dropped", {
+  skip_if_not_installed("rlang")
+  my_fn <- function() {
+    rlang::error_cnd(message = "oops", call = rlang::current_call())
+  }
+  cnd <- my_fn()
+  c2 <- roundtrip_condition(cnd)
+  expect_identical(cnd$message, c2$message)
+  expect_identical(cnd$call, c2$call)
+  expect_null(c2$trace)
+  expect_null(c2$parent)
+})
+
+test_that("condition_has_call returns FALSE when call is NULL", {
+  skip_if_not_installed("rlang")
+  cnd <- rlang::error_cnd(message = "oops", call = NULL)
+  expect_false(condition_has_call(cnd))
+})
+
 test_that("warn! signals a plain warning message", {
   expect_warning(
     cnd_warn("something went wrong"),

--- a/tests/extendrtests/tests/testthat/test-conditions.R
+++ b/tests/extendrtests/tests/testthat/test-conditions.R
@@ -40,7 +40,7 @@ test_that("condition_has_call detects call from rlang::current_call()", {
   expect_true(my_fn())
 })
 
-test_that("round-trip preserves message and call; rlang trace/parent are dropped", {
+test_that("round-trip preserves message and call", {
   skip_if_not_installed("rlang")
   my_fn <- function() {
     rlang::error_cnd(message = "oops", call = rlang::current_call())
@@ -49,8 +49,34 @@ test_that("round-trip preserves message and call; rlang trace/parent are dropped
   c2 <- roundtrip_condition(cnd)
   expect_identical(cnd$message, c2$message)
   expect_identical(cnd$call, c2$call)
-  expect_null(c2$trace)
-  expect_null(c2$parent)
+})
+
+test_that("round-trip preserves parent condition", {
+  skip_if_not_installed("rlang")
+  cnd <- rlang::error_cnd(
+    message = "hi",
+    parent = rlang::error_cnd(class = "b")
+  )
+  c2 <- roundtrip_condition(cnd)
+  expect_identical(cnd$message, c2$message)
+  expect_identical(cnd$parent$message, c2$parent$message)
+  expect_identical(class(cnd$parent), class(c2$parent))
+})
+
+test_that("round-trip preserves trace", {
+  skip_if_not_installed("rlang")
+  f <- function() g()
+  g <- function() h()
+  h <- function() rlang::trace_back()
+  cnd <- rlang::error_cnd(
+    message = "hi",
+    parent = rlang::error_cnd(class = "b"),
+    trace = f()
+  )
+  c2 <- roundtrip_condition(cnd)
+  expect_identical(cnd$message, c2$message)
+  expect_identical(cnd$parent$message, c2$parent$message)
+  expect_identical(class(cnd$trace), class(c2$trace))
 })
 
 test_that("condition_has_call returns FALSE when call is NULL", {


### PR DESCRIPTION
## Summary

  Adds Rust-native types for creating, inspecting, and round-tripping R
  condition objects, with no dependency on rlang.

  Four new types in `extendr_api::conditions`:

  - `ConditionKind`: enum discriminating `condition`, `message`, `warning`,  `error`
  - `Condition`: Rust-native struct with `String`/`Vec` fields. The primary  working type.
  - `RCondition(List)`:  validated R condition at the boundary. Use as  function argument/return type.
  - `ConditionBuilder`: builder for `Condition` via  `ConditionBuilder::default()`

Condition objects support `rlang` condition objects out of the box via the fields: `message`, `class`, `call`, `parent`, and `trace`. rlang conditions (`error_cnd`, `warning_cnd`, `message_cnd`) are round tripped correctly maintaining `trace` and `parent`.

Also adds `From<Strings> for Vec<String>` and `From<Strings> for StrIter` for modest quality of life enhancement.

Closes #1080 

## Example

```rust
use extendr_api::{prelude::*, conditions::{Condition, RCondition}};

#[extendr]
fn roundtrip_condition(x: RCondition) -> RCondition {
    let cnd = Condition::try_from(x).expect("failed to parse condition");
    RCondition::from(cnd)
}

 let cnd = ConditionBuilder::default()
      .set_kind(ConditionKind::Error)
      .set_message(["bad thing"])
      .set_class(["my_err"])
      .build();
  let rcnd = RCondition::from(cnd.clone());
  let c2 = Condition::try_from(rcnd)?;
  assert_eq!(cnd, c2);
```