### PR TITLE
feat: implement From conversions for scalar types and rust primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Infallible `From<T> for S` for extendr-scalar-type `T` and rust-scalar-type `S`.
 - `Condition`, `RCondition`, `ConditionKind`, and `ConditionBuilder` in `extendr_api::conditions` for creating, converting, and round-tripping R condition objects. `Condition` is the Rust-native representation; `RCondition` is the R-boundary type wrapping a validated `List`. Conversions between all four types are provided via `From`/`TryFrom`. <https://github.com/extendr/extendr/pull/1082>
 - `From<Strings> for Vec<String>` and `From<Strings> for StrIter` conversions. <https://github.com/extendr/extendr/pull/1082>
 - `stop()` is an alias for `throw_r_error()` 

--- a/extendr-api/src/robj/tests.rs
+++ b/extendr-api/src/robj/tests.rs
@@ -119,6 +119,17 @@ fn test_try_from_robj() {
         );
         assert!(<Option<String>>::try_from(&Robj::from(["1", "2"])).is_err());
 
+        assert_eq!(f64::from(Rfloat::from(1.0)), 1.0);
+        assert!(f64::from(Rfloat::na()).is_na());
+
+        assert_eq!(i32::from(Rint::from(1)), 1);
+        assert!(Rint::from(i32::from(Rint::na())).is_na());
+
+        assert_eq!(bool::from(Rbool::from(true)), true);
+        assert_eq!(bool::from(Rbool::from(false)), false);
+
+        assert_eq!(c64::from(Rcplx::from(c64::new(1.0, 2.0))), c64::new(1.0, 2.0));
+        assert!(c64::from(Rcplx::na()).is_na());
 
         // TODO: once related todos resolved in try_from_robj.rs, add tests for
         // Doubles to Integer successful case (e.g. 1.0 to 1) and failing case

--- a/extendr-api/src/scalar/rbool.rs
+++ b/extendr-api/src/scalar/rbool.rs
@@ -84,6 +84,12 @@ impl From<Rbool> for Option<bool> {
     }
 }
 
+impl From<Rbool> for bool {
+    fn from(v: Rbool) -> Self {
+        v.0 != 0
+    }
+}
+
 impl std::ops::Not for Rbool {
     type Output = Self;
 

--- a/extendr-api/src/scalar/rcplx_default.rs
+++ b/extendr-api/src/scalar/rcplx_default.rs
@@ -118,6 +118,12 @@ impl From<Rcplx> for Option<c64> {
     }
 }
 
+impl From<Rcplx> for c64 {
+    fn from(val: Rcplx) -> Self {
+        c64::new(val.re().0, val.im().0)
+    }
+}
+
 impl PartialEq<f64> for Rcplx {
     fn eq(&self, other: &f64) -> bool {
         self.re().0 == *other && self.im() == 0.0

--- a/extendr-api/src/scalar/rcplx_full.rs
+++ b/extendr-api/src/scalar/rcplx_full.rs
@@ -90,6 +90,12 @@ impl From<Rcplx> for Option<c64> {
     }
 }
 
+impl From<Rcplx> for c64 {
+    fn from(val: Rcplx) -> Self {
+        c64::new(val.re().0, val.im().0)
+    }
+}
+
 // `NA_real_` is a `NaN` with specific bit representation.
 // Check that underlying `f64` is `NA_real_`.
 gen_trait_impl!(Rcplx, c64, |x: &Rcplx| x.0.re.is_na(), c64::na());

--- a/extendr-api/src/scalar/rfloat.rs
+++ b/extendr-api/src/scalar/rfloat.rs
@@ -90,6 +90,12 @@ impl From<Rfloat> for Option<f64> {
     }
 }
 
+impl From<Rfloat> for f64 {
+    fn from(v: Rfloat) -> Self {
+        v.0
+    }
+}
+
 gen_sum_iter!(Rfloat);
 gen_partial_ord!(Rfloat, f64);
 

--- a/extendr-api/src/scalar/rint.rs
+++ b/extendr-api/src/scalar/rint.rs
@@ -71,6 +71,12 @@ impl From<Rint> for Option<i32> {
     }
 }
 
+impl From<Rint> for i32 {
+    fn from(v: Rint) -> Self {
+        v.0
+    }
+}
+
 gen_sum_iter!(Rint);
 gen_partial_ord!(Rint, i32);
 


### PR DESCRIPTION
## Summary

PR type: feature

What does this solve?
It just implements `From<T> for S` for extendr-scalar `T` and rust-scalar `S`, for example, `From<Rfloat> for f64`. So, now there is the safe method `let x: Option<f64> = v.into()` and the - shall we say - less safe method `let x: f64 = v.into()`. 

## Checklist

- [x] format via `just fmt`
- [x] tested with `just test`
- [ ] integration tests added (new features only)
- [x] CHANGELOG.md updated

## Resolves

<!-- Link to outstanding issues with "Closes #<issue-number>" -->

- Closes #1084 
