### PR TITLE
fix: align cargo invocations in extendrtests Makevars so deps build once (#1087)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 ### Fixed
 
 - `throw_r_error()` no longer segfaults when the message contains `%` characters. <https://github.com/extendr/extendr/issues/1058> behavior now in line with cpp11 and Rcpp
+- `tests/extendrtests/src/Makevars.in` and `Makevars.win.in` now pass identical `RUSTFLAGS`, `@PANIC_EXPORTS@` (Unix), and `@PROFILE@` to both `cargo build --lib` and `cargo run --bin document`. Without this, the second invocation has a different cargo fingerprint and rebuilds every dependency from scratch on `R CMD INSTALL`. Paired with the upstream template fix in `rextendr#515`. <https://github.com/extendr/extendr/issues/1087>
 
 ## 0.9.0 — 2026-04-16
 

--- a/tests/extendrtests/src/Makevars.in
+++ b/tests/extendrtests/src/Makevars.in
@@ -43,7 +43,7 @@ $(STATLIB):
 	# fresh fingerprint and rebuilds every dependency from scratch (#1087).
 	export CARGO_HOME=$(CARGOTMP) && \
 	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-	@PANIC_EXPORTS@RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo run @CRAN_FLAGS@ --bin document @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@
+	@PANIC_EXPORTS@RUSTFLAGS="$(RUSTFLAGS)" cargo run @CRAN_FLAGS@ --bin document @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@
 
 	# Always clean up CARGOTMP
 	rm -Rf $(CARGOTMP);

--- a/tests/extendrtests/src/Makevars.in
+++ b/tests/extendrtests/src/Makevars.in
@@ -38,9 +38,12 @@ $(STATLIB):
 	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
 	@PANIC_EXPORTS@RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --lib @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@
 
+	# NOTE: env (RUSTFLAGS, @PANIC_EXPORTS@) and @PROFILE@ must match the
+	# `cargo build --lib` invocation above; otherwise cargo treats this as a
+	# fresh fingerprint and rebuilds every dependency from scratch (#1087).
 	export CARGO_HOME=$(CARGOTMP) && \
 	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-	cargo run @CRAN_FLAGS@ --bin document --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@
+	@PANIC_EXPORTS@RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo run @CRAN_FLAGS@ --bin document @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@
 
 	# Always clean up CARGOTMP
 	rm -Rf $(CARGOTMP);

--- a/tests/extendrtests/src/Makevars.win.in
+++ b/tests/extendrtests/src/Makevars.win.in
@@ -36,10 +36,13 @@ $(STATLIB):
 	export LIBRARY_PATH="$(LIBRARY_PATH);$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \
 	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --target=$(TARGET) --lib @PROFILE@ --manifest-path=rust/Cargo.toml --target-dir=$(TARGET_DIR)
 
-	# Generate wrappers
+	# Generate wrappers.
+	# NOTE: RUSTFLAGS and @PROFILE@ must match the `cargo build --lib` invocation
+	# above; otherwise cargo treats this as a fresh fingerprint and rebuilds every
+	# dependency from scratch (#1087).
 	export CARGO_HOME=$(CARGOTMP) && \
 	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-	cargo run @CRAN_FLAGS@ --bin document --target $(TARGET) --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo run @CRAN_FLAGS@ --bin document --target $(TARGET) @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
 
 	# Always clean up CARGOTMP
 	rm -Rf $(CARGOTMP);


### PR DESCRIPTION
## Summary

Closes #1087.

The `tests/extendrtests/src/Makevars.in` and `Makevars.win.in` templates run
`cargo build --lib` with `RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs"`
and `@PROFILE@`, then `cargo run --bin document` with **neither**. The two
invocations therefore have different cargo fingerprints, so every dependency
is rebuilt from scratch on `R CMD INSTALL`.

This PR appends the same `RUSTFLAGS` (and `@PANIC_EXPORTS@` on Unix) and
`@PROFILE@` to the `cargo run --bin document` line, and adds an inline NOTE
documenting the invariant so the next refactor doesn't drop it again.

These Makevars files are a generated copy of the rextendr templates, so this
PR is **paired with** the upstream template fix in
[extendr/rextendr#515](https://github.com/extendr/rextendr/pull/515) — both
should land for the fix to be complete: rextendr#515 stops the bug at the
source so newly scaffolded packages don't inherit it; this PR stops the bug in
the in-tree integration package so the extendr CI matrix actually exercises
the fixed form.

Diagnosis and verified fix come from @aquasync in the issue thread; CGMossa
endorsed it there. CHANGELOG.md gets a `Fixed` entry under `## Development`.

## Out of scope

The deeper sibling issue #1086 (library size doubled in 0.9.0) wants the
`document` binary moved to an `examples/` target so it stops dragging the
lib's optional deps into the `.so`. That's a structural change to the
template — left for a separate effort.

## Checklist

- [x] format via `just fmt` (no Rust changes; n/a)
- [x] tested with `just test` (no Rust changes; n/a)
- [ ] integration tests added (not applicable for Makevars)
- [x] CHANGELOG.md updated

## Test plan

- [ ] CI green on \`R CMD check\` job — the extendrtests build path is exactly what this PR fixes.
- [ ] Eyeball the CI install log: only one cargo compile pass for each dep, not two.