### PR TITLE
chore(deps): ignore optional deps in dependabot to gate bumps behind a strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,23 @@
 version: 2
 updates:
   - package-ecosystem: cargo
-    directories: 
+    directories:
       - "/"
       - "tests/extendrtests/src/rust/"
     schedule:
       interval: daily
+    # All optional deps of extendr-api are exposed in its public surface (via
+    # `optional/`, `conversions/`, scalar/Rcplx, derive macros). Bumping any
+    # of them is a breaking change for downstream R packages, so they need a
+    # deliberate multi-version feature-flag strategy rather than straight
+    # version bumps. Keep this list in sync with the `optional = true`
+    # entries in extendr-api/Cargo.toml.
+    ignore:
+      - dependency-name: "either"
+      - dependency-name: "faer"
+      - dependency-name: "ndarray"
+      - dependency-name: "num-complex"
+      - dependency-name: "serde"
 
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
Optional deps in `extendr-api` (`either`, `faer`, `ndarray`, `num-complex`, `serde`) all leak into the crate's public API surface — via the modules under `optional/`, the conversions in `conversions/`, `Rcplx`, `IntoDataFrameRow`, etc. — so a bump on any of them is a breaking change for downstream R packages that re-export those types. Dependabot has been opening straight version-bump PRs for these (#1040 faer 0.20→0.24, #1036 ndarray 0.16.1→0.17.2) and the right answer to those PRs isn't "merge" or "rebase", it's "we need a multi-version feature-flag strategy first." This PR adds an `ignore:` block for those five crates so dependabot stops surfacing them until we have that strategy.

<details>
<summary><h4>AI-written details</h4></summary>

## Summary
- Adds `ignore:` entries for `either`, `faer`, `ndarray`, `num-complex`, `serde` to the cargo updater in `.github/dependabot.yml`.
- Applies to both configured directories (`/` and `tests/extendrtests/src/rust/`) since the `ignore:` block is shared across both.
- Inline comment notes that this list should track the `optional = true` entries in `extendr-api/Cargo.toml`, so the next time we add or remove an optional dep we can update both in the same commit.
- No other dependabot behavior changes: github-actions updater and the daily schedule are unchanged.

## Why these five and not others

`grep "optional = true" extendr-api/Cargo.toml` returns exactly these five. None of the workspace's required deps (`extendr-ffi`, `extendr-macros`, `paste`, `once_cell`, `readonly`) reach the public API in a way that breaks downstream on a minor bump, so they stay on the normal dependabot cadence.

## Follow-up (not in this PR)

- Close #1040 and #1036 once this lands (a comment pointing here is fine; they'll stop being recreated).
- Build the multi-version feature-flag strategy (`ndarray_0_16` / `ndarray_0_17` style aliases with per-version Cargo features gating adapter modules). Tracked separately.

## Notes

- This is a holding pattern, not a final answer. The day the multi-version strategy lands, this ignore block should be revisited — some of these deps will be safe to auto-bump again, some won't.

---
_Drafted by Claude (claude-opus-4-7). Reviewed by the author._

</details>
