### PR TITLE
feat: implement From<Option<&str>> for Rstr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `Environment` gains `base()`, `empty()`, and `global()` associated methods. <https://github.com/extendr/extendr/pull/1075>
 - Implement `TryFrom<Robj> for Option<Environment>` <https://github.com/extendr/extendr/pull/1075>
 - Added `Rf_errorcall` and `Rf_warningcall` to extendr-ffi <https://github.com/extendr/extendr/pull/1075>
+- Implement `From<Option<&str>> for Rstr` <https://github.com/extendr/extendr/pull/1098>
 
 ### Changed
 

--- a/extendr-api/src/wrapper/rstr.rs
+++ b/extendr-api/src/wrapper/rstr.rs
@@ -125,6 +125,16 @@ impl From<Option<String>> for Rstr {
     }
 }
 
+impl From<Option<&str>> for Rstr {
+    fn from(value: Option<&str>) -> Self {
+        if let Some(string_ref) = value {
+            Self::from(string_ref)
+        } else {
+            Self { robj: na_string() }
+        }
+    }
+}
+
 impl Deref for Rstr {
     type Target = str;
 
@@ -214,6 +224,13 @@ mod tests {
             let chr = r!(Rstr::from("xyz"));
             let x = chr.as_char().unwrap();
             assert_eq!(x.as_ref(), "xyz");
+        }
+    }
+
+    #[test]
+    fn test_rstr_from_str_ref() {
+        test! {
+            assert_eq!(Rstr::from(Some("value")), Rstr::from("value"));
         }
     }
 }


### PR DESCRIPTION
## Summary

feat: implement From<Option<&str>> for Rstr

<!-- What does this solve? -->

Get the value or NA string out of an Option<&str>

## Checklist

- [x] format via `just fmt`
- [x] tested with `just test`
- [] integration tests added (new features only)
- [x] CHANGELOG.md updated

## Resolves

- Closes #1096 
