### PR TITLE
refactor: deprecate parse in favor of Expressions::from_str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - **Breaking**: bumps MSRV to 1.77 <https://github.com/extendr/extendr/pull/1075>
 - **Breaking**: deprecates and removed `global_env()`, `base_env()`, and `empty_env()` from the `prelude`  <https://github.com/extendr/extendr/pull/1075>
 - **Breaking**: non-API items `global_var()`, `local_var()`, `global!()` have been removed  <https://github.com/extendr/extendr/pull/1075>
+- **Deprecates** `parse()` in favor of the idiomatic `FromStr` trait. Replace `parse(code)` with `Expressions::from_str(code)` <https://github.com/extendr/extendr/pull/1100>
 
 ### Fixed
 

--- a/extendr-api/src/functions.rs
+++ b/extendr-api/src/functions.rs
@@ -152,25 +152,13 @@ pub fn blank_scalar_string() -> Robj {
 /// ```
 /// use extendr_api::prelude::*;
 /// test! {
-///    let expr = parse("1 + 2").unwrap();
+///    let expr = Expressions::from_str("1 + 2").unwrap();
 ///    assert!(expr.is_expressions());
 /// }
 /// ```
+#[deprecated(since = "0.10.0", note = "Use Expressions::from_str() instead")]
 pub fn parse(code: &str) -> Result<Expressions> {
-    single_threaded(|| unsafe {
-        use extendr_ffi::{ParseStatus, R_NilValue, R_ParseVector};
-        let mut status = ParseStatus::PARSE_NULL;
-        let status_ptr = (&mut status) as *mut _;
-        let codeobj: Robj = code.into();
-        let parsed = Robj::from_sexp(R_ParseVector(codeobj.get(), -1, status_ptr, R_NilValue));
-        match status {
-            ParseStatus::PARSE_OK => parsed.try_into(),
-            _ => Err(Error::ParseError {
-                status,
-                code: code.into(),
-            }),
-        }
-    })
+    Expressions::from_str(code)
 }
 
 /// Parse a string into an R executable object and run it.
@@ -184,7 +172,7 @@ pub fn parse(code: &str) -> Result<Expressions> {
 /// ```
 pub fn eval_string(code: &str) -> Result<Robj> {
     single_threaded(|| {
-        let expr = parse(code)?;
+        let expr = Expressions::from_str(code)?;
         let mut res = Robj::from(());
         if let Some(expr) = expr.as_expressions() {
             for lang in expr.values() {
@@ -214,7 +202,7 @@ pub fn eval_string_with_params(code: &str, values: &[&Robj]) -> Result<Robj> {
             env.set_local(key, v);
         }
 
-        let expr = parse(code)?;
+        let expr = Expressions::from_str(code)?;
         let mut res = Robj::from(());
         if let Some(expr) = expr.as_expressions() {
             for lang in expr.values() {

--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -328,6 +328,7 @@ pub use robj::Robj;
 pub use std::convert::{TryFrom, TryInto};
 pub use std::ops::Deref;
 pub use std::ops::DerefMut;
+pub use std::str::FromStr;
 
 #[cfg(feature = "serde")]
 pub mod serializer;

--- a/extendr-api/src/prelude.rs
+++ b/extendr-api/src/prelude.rs
@@ -4,10 +4,11 @@
 //! using deprecated features.
 
 pub use super::error::Error;
+pub use super::functions::parse;
 pub use super::functions::{
     base_namespace, blank_scalar_string, blank_string, eval_string, eval_string_with_params,
     find_namespace, find_namespaced_function, global_function, na_string, new_env, nil_value,
-    parse, srcref,
+    srcref,
 };
 pub use super::{
     print_r_error, print_r_output, CanBeNA, Rtype, FALSE, NA_INTEGER, NA_LOGICAL, NA_REAL,
@@ -58,6 +59,7 @@ pub use extendr_macros::{
     call, extendr, extendr_module, pairlist, IntoDataFrameRow, IntoList, Rraw, TryFromList, R,
 };
 pub use std::convert::{TryFrom, TryInto};
+pub use std::str::FromStr;
 
 #[cfg(feature = "ndarray")]
 pub use ::ndarray;

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -256,7 +256,7 @@ pub trait Types: GetSexp {
     ///     assert_eq!(r!(1.0).rtype(), Rtype::Doubles);
     ///     assert_eq!(r!("1").rtype(), Rtype::Strings);
     ///     assert_eq!(r!(List::from_values(&[1, 2])).rtype(), Rtype::List);
-    ///     assert_eq!(parse("x + y")?.rtype(), Rtype::Expressions);
+    ///     assert_eq!(Expressions::from_str("x + y")?.rtype(), Rtype::Expressions);
     ///     assert_eq!(r!(Raw::from_bytes(&[1_u8, 2, 3])).rtype(), Rtype::Raw);
     /// }
     /// ```

--- a/extendr-api/src/robj/tests.rs
+++ b/extendr-api/src/robj/tests.rs
@@ -217,7 +217,7 @@ fn test_to_robj() {
 #[test]
 fn parse_test() {
     test! {
-    let p = parse("print(1L);print(1L);")?;
+    let p = Expressions::from_str("print(1L);print(1L);")?;
     let q = Expressions::from_values(&[
         r!(Language::from_values(&[r!(Symbol::from_string("print")), r!(1)])),
         r!(Language::from_values(&[r!(Symbol::from_string("print")), r!(1)]))

--- a/extendr-api/src/wrapper/expr.rs
+++ b/extendr-api/src/wrapper/expr.rs
@@ -50,3 +50,24 @@ impl std::fmt::Debug for Expressions {
             .finish()
     }
 }
+
+impl std::str::FromStr for Expressions {
+    type Err = Error;
+
+    fn from_str(code: &str) -> Result<Expressions> {
+        single_threaded(|| unsafe {
+            use extendr_ffi::{ParseStatus, R_NilValue, R_ParseVector};
+            let mut status = ParseStatus::PARSE_NULL;
+            let status_ptr = (&mut status) as *mut _;
+            let codeobj: Robj = code.into();
+            let parsed = Robj::from_sexp(R_ParseVector(codeobj.get(), -1, status_ptr, R_NilValue));
+            match status {
+                ParseStatus::PARSE_OK => parsed.try_into(),
+                _ => Err(Error::ParseError {
+                    status,
+                    code: code.into(),
+                }),
+            }
+        })
+    }
+}

--- a/extendr-api/tests/debug_tests.rs
+++ b/extendr-api/tests/debug_tests.rs
@@ -55,7 +55,7 @@ fn test_debug() {
         assert_eq!(format!("{:?}", r), "list!(1, 2)");
         let r : List = list!(1, b=2);
         assert_eq!(format!("{:?}", r), "list!(1, b=2)");
-        let r : Expressions = parse("1 + 2").unwrap();
+        let r : Expressions = Expressions::from_str("1 + 2").unwrap();
         assert_eq!(format!("{:?}", r), "Expressions { values: [lang!(sym!(+), 1.0, 2.0)] }");
         let r : Raw = Raw::new(2);
         assert_eq!(format!("{:02x?}", r), "Raw[00, 00]");

--- a/extendr-api/tests/parse_tests.rs
+++ b/extendr-api/tests/parse_tests.rs
@@ -4,7 +4,7 @@ use extendr_ffi::ParseStatus;
 #[test]
 fn parse_reports_error_for_invalid_syntax() {
     test! {
-        let err = parse("c(10 42,20)").unwrap_err();
+        let err = Expressions::from_str("c(10 42,20)").unwrap_err();
         let msg = err.to_string();
         match err {
             Error::ParseError {
@@ -19,7 +19,7 @@ fn parse_reports_error_for_invalid_syntax() {
 #[test]
 fn parse_reports_error_for_incomplete_input() {
     test! {
-        let err = parse("c(10").unwrap_err();
+        let err = Expressions::from_str("c(10").unwrap_err();
         let msg = err.to_string();
         match err {
             Error::ParseError {


### PR DESCRIPTION
## Summary

refactor: deprecate parse function in favor of Expressions::from_str

## Checklist

- [x] format via `just fmt`
- [x] tested with `just test`
- [ ] integration tests added (new features only)
- [x] CHANGELOG.md updated

## Resolves

- Closes #1081 
