### PR TITLE
feat(macros): support item-level `#[cfg(...)]` in `extendr_module!`

### DIFF
--- a/extendr-api/tests/extendr_module_tests.rs
+++ b/extendr-api/tests/extendr_module_tests.rs
@@ -39,3 +39,48 @@ mod adjacent_module {
         fn foo;
     }
 }
+
+/// Regression test: `extendr_module!` must accept item-level `#[cfg(...)]`
+/// attributes on `fn` entries, and the generated metadata call must carry the
+/// same attribute so that a cfg'd-out function does not leave a dangling
+/// reference to a non-existent `meta__` helper.
+///
+/// `cfg(test)` is always true here and `cfg(not(test))` always false, so the
+/// assertions are deterministic without relying on a Cargo feature flag.
+mod cfg_gated_module {
+    use super::*;
+
+    #[cfg(test)]
+    #[extendr]
+    fn included_fn() {}
+
+    #[cfg(not(test))]
+    #[extendr]
+    fn excluded_fn() {}
+
+    extendr_module! {
+        mod cfg_gated_module;
+        #[cfg(test)]
+        fn included_fn;
+        #[cfg(not(test))]
+        fn excluded_fn;
+    }
+
+    #[test]
+    fn cfg_gated_fn_entries_respect_attributes() {
+        let names: Vec<&str> = get_cfg_gated_module_metadata()
+            .functions
+            .iter()
+            .map(|f| f.rust_name)
+            .collect();
+
+        assert!(
+            names.contains(&"included_fn"),
+            "cfg(test) fn should be present, got {names:?}"
+        );
+        assert!(
+            !names.contains(&"excluded_fn"),
+            "cfg(not(test)) fn should be compiled out, got {names:?}"
+        );
+    }
+}

--- a/extendr-macros/src/extendr_module.rs
+++ b/extendr-macros/src/extendr_module.rs
@@ -1,7 +1,7 @@
 use crate::wrappers;
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
-use syn::{parse::ParseStream, parse_macro_input, Ident, Token, Type};
+use syn::{parse::ParseStream, parse_macro_input, Attribute, Ident, Token, Type};
 
 pub fn extendr_module(item: TokenStream) -> TokenStream {
     let module = parse_macro_input!(item as Module);
@@ -28,16 +28,25 @@ pub fn extendr_module(item: TokenStream) -> TokenStream {
     let wrap_make_module_wrappers_string = wrap_make_module_wrappers.to_string();
     let write_make_module_wrappers = format_ident!("write__make_{}_wrappers", modname);
 
-    let fnmetanames = fnnames
-        .iter()
-        .map(|id| format_ident!("{}{}", wrappers::META_PREFIX, id));
-    let implmetanames = implnames
-        .iter()
-        .map(|id| format_ident!("{}{}", wrappers::META_PREFIX, wrappers::type_name(id)));
-    let usemetanames = usenames
-        .iter()
-        .map(|id| format_ident!("get_{}_metadata", id))
-        .collect::<Vec<Ident>>();
+    // Each statement is prefixed with its item's `#[cfg(...)]` (and other)
+    // attributes, so that `cfg`-gating an item in `extendr_module!` compiles out
+    // both the item and the metadata call that references it.
+    let fnmeta_stmts = fnnames.iter().map(|(attrs, id)| {
+        let meta = format_ident!("{}{}", wrappers::META_PREFIX, id);
+        quote! { #(#attrs)* #meta(&mut functions); }
+    });
+    let implmeta_stmts = implnames.iter().map(|(attrs, ty)| {
+        let meta = format_ident!("{}{}", wrappers::META_PREFIX, wrappers::type_name(ty));
+        quote! { #(#attrs)* #meta(&mut impls); }
+    });
+    let use_fn_stmts = usenames.iter().map(|(attrs, id)| {
+        let meta = format_ident!("get_{}_metadata", id);
+        quote! { #(#attrs)* functions.extend(#id::#meta().functions); }
+    });
+    let use_impl_stmts = usenames.iter().map(|(attrs, id)| {
+        let meta = format_ident!("get_{}_metadata", id);
+        quote! { #(#attrs)* impls.extend(#id::#meta().impls); }
+    });
 
     TokenStream::from(quote! {
         #[no_mangle]
@@ -47,12 +56,12 @@ pub fn extendr_module(item: TokenStream) -> TokenStream {
             let mut impls = Vec::new();
 
             // Pushes metadata (eg. extendr_api::metadata::Func) to functions and impl vectors.
-            #( #fnmetanames(&mut functions); )*
-            #( #implmetanames(&mut impls); )*
+            #( #fnmeta_stmts )*
+            #( #implmeta_stmts )*
 
             // Extends functions and impls with the submodules metadata
-            #( functions.extend(#usenames::#usemetanames().functions); )*
-            #( impls.extend(#usenames::#usemetanames().impls); )*
+            #( #use_fn_stmts )*
+            #( #use_impl_stmts )*
 
             // Add this function to the list, but set hidden: true.
             functions.push(extendr_api::metadata::Func {
@@ -166,9 +175,9 @@ pub fn extendr_module(item: TokenStream) -> TokenStream {
 #[derive(Debug)]
 struct Module {
     modname: Option<Ident>,
-    fnnames: Vec<Ident>,
-    implnames: Vec<Type>,
-    usenames: Vec<Ident>,
+    fnnames: Vec<(Vec<Attribute>, Ident)>,
+    implnames: Vec<(Vec<Attribute>, Type)>,
+    usenames: Vec<(Vec<Attribute>, Ident)>,
 }
 
 // Custom parser for the module.
@@ -182,18 +191,25 @@ impl syn::parse::Parse for Module {
             usenames: Vec::new(),
         };
         while !input.is_empty() {
+            // Outer attributes (e.g. `#[cfg(...)]`) preceding an item are
+            // captured and forwarded to the generated metadata call, so that
+            // `cfg`-gating an item here matches the item's own compilation.
+            let attrs = input.call(Attribute::parse_outer)?;
             if let Ok(kmod) = input.parse::<Token![mod]>() {
+                if !attrs.is_empty() {
+                    return Err(syn::Error::new(kmod.span(), "attributes are not supported on `mod`"));
+                }
                 let name: Ident = input.parse()?;
                 if res.modname.is_some() {
                     return Err(syn::Error::new(kmod.span(), "only one mod allowed"));
                 }
                 res.modname = Some(name);
             } else if input.parse::<Token![fn]>().is_ok() {
-                res.fnnames.push(input.parse()?);
+                res.fnnames.push((attrs, input.parse()?));
             } else if input.parse::<Token![impl]>().is_ok() {
-                res.implnames.push(input.parse()?);
+                res.implnames.push((attrs, input.parse()?));
             } else if input.parse::<Token![use]>().is_ok() {
-                res.usenames.push(input.parse()?);
+                res.usenames.push((attrs, input.parse()?));
             } else {
                 return Err(syn::Error::new(input.span(), "expected mod, fn or impl"));
             }


### PR DESCRIPTION
`extendr_module!` previously rejected any attribute on its `mod`/`fn`/ `impl`/`use` entries, because the custom parser only accepted those four keywords. This made it impossible to conditionally compile an individual exported function: gating the `fn` definition with `#[cfg(...)]` while leaving the `extendr_module! { fn foo; }` entry unconditional caused the generated metadata call (`meta__foo(&mut functions);`) to reference a function that no longer exists, breaking the build.

Parse optional outer attributes before each entry via `Attribute::parse_outer` and forward them to the generated metadata statement for `fn`/`impl`/`use` entries, so a cfg'd-out item and its metadata call are compiled out together. Attributes on `mod` are rejected, since gating the module name is meaningless.

Add a regression test using `cfg(test)` / `cfg(not(test))` to deterministically verify that a gated `fn` entry is included/excluded in the module metadata without relying on a Cargo feature flag.

## Summary

`extendr_module!` previously rejected any attribute on its `mod` / `fn` /
`impl` / `use` entries: the custom parser only accepted those four keywords, so
a leading `#` produced `expected mod, fn or impl`.

This made it impossible to conditionally compile an individual exported
function. Gating the `fn` definition with `#[cfg(...)]` while leaving the
`extendr_module! { fn foo; }` entry unconditional causes the generated metadata
call (`meta__foo(&mut functions);`) to reference a function that no longer
exists, breaking the build under that cfg.

## Changes

- Parse optional outer attributes before each entry via
  `Attribute::parse_outer`, and forward them to the generated metadata
  statement for `fn` / `impl` / `use` entries. A cfg'd-out item and its
  metadata call are now compiled out together.
- Reject attributes on `mod`, since gating the module name is meaningless.
- Add a regression test using `cfg(test)` / `cfg(not(test))` to
  deterministically verify a gated `fn` entry is included/excluded in the
  module metadata, without relying on a Cargo feature flag.

## Testing

- `cargo test -p extendr-api --features tests --target x86_64-pc-windows-gnu`
  — full suite passes (200+ tests, 0 failed), including the new
  `cfg_gated_fn_entries_respect_attributes` test.
- Existing `mod` / `fn` / `use` entries in `extendr_module_tests.rs` continue
  to compile unchanged (backward compatible).

## Motivation

Enables gating an individual R-exported function behind a feature (e.g. an
AHRS helper that needs an optional `nalgebra` dependency) while keeping the
rest of the module's bindings available when that feature is off.

