### PR TITLE
Release 0.8.2: backport non-breaking fixes from the 0.9 line

### DIFF
--- a/.github/workflows/trigger_rextendr_ci.yaml
+++ b/.github/workflows/trigger_rextendr_ci.yaml
@@ -1,19 +1,20 @@
 name: Trigger rextendr CI
+
 on:
-	pull_request:
-		types:
-			- closed
-		branches:
-			- master
+  pull_request:
+    types:
+      - closed
+    branches:
+      - master
 
 jobs:
-	dispatch-to-rextendr:
-		if: github.event.pull_request.merged == true
-		runs-on: ubuntu-latest
-		steps:
-			- name: Trigger rextendr test workflow
-				uses: peter-evans/repository-dispatch@v3
-				with:
-					token: ${{ secrets.GITHUB_TOKEN }}
-					repository: extendr/rextendr
-					event-type: extendr-pr-merged
+  dispatch-to-rextendr:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger rextendr test workflow
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: extendr/rextendr
+          event-type: extendr-pr-merged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.8.2
+## 0.8.2 — 2026-07-31
 
 Patch release backporting non-breaking fixes from the 0.9 development line onto 0.8.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## Unreleased
+## 0.8.2
+
+### Fixed
+
+- `extendr-ffi` can now be built for `aarch64-pc-windows-gnullvm` (Windows on ARM64); backport of [[#950]](https://github.com/extendr/extendr/pull/950)
+
+## 0.8.0
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,20 @@
 
 ## 0.8.2
 
+Patch release backporting non-breaking fixes from the 0.9 development line onto 0.8.
+
 ### Fixed
 
 - `extendr-ffi` can now be built for `aarch64-pc-windows-gnullvm` (Windows on ARM64); backport of [[#950]](https://github.com/extendr/extendr/pull/950)
+- Graphics devices now report the correct graphics engine version on R ≥ 4.3 (GE 16) and R ≥ 4.6 (GE 17), and use `GECreateDevDesc` where available; backports of [[#959]](https://github.com/extendr/extendr/pull/959) and [[#981]](https://github.com/extendr/extendr/pull/981)
+- Deserializing into borrowed strings via serde no longer panics with `unimplemented!()`; backport of [[#983]](https://github.com/extendr/extendr/pull/983)
+- Errors raised in `#[extendr]` functions no longer prepend a Rust traceback to the R error message (set `EXTENDR_BACKTRACE=1` to get the full traceback), and the panic hook is registered correctly; backport of [[#973]](https://github.com/extendr/extendr/pull/973)
+- Panics raised in `#[extendr]` functions are rethrown without prepending the `unwrap` message; backport of [[#1055]](https://github.com/extendr/extendr/pull/1055)
+- `Rf_isFrame` is routed through `extendr-ffi` backports for R C API compliance; backport of [[#1044]](https://github.com/extendr/extendr/pull/1044)
+
+### Changed
+
+- Compiler and clippy warnings on recent Rust toolchains have been cleaned up, and the workspace now declares `rust-version = "1.65"`; backport of [[#965]](https://github.com/extendr/extendr/pull/965)
 
 ## 0.8.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.1"
+version = "0.8.2"
 authors = [
     "andy-thomason <andy@andythomason.com>",
     "Thomas Down",
@@ -27,5 +27,5 @@ repository = "https://github.com/extendr/extendr"
 
 [workspace.dependencies]
 # When updating extendr's version, this version also needs to be updated
-extendr-macros = { path = "./extendr-macros", version = "0.8.0" }
-extendr-ffi = { path = "./extendr-ffi", version = "0.8.0" }
+extendr-macros = { path = "./extendr-macros", version = "0.8.2" }
+extendr-ffi = { path = "./extendr-ffi", version = "0.8.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ authors = [
     "Michael Milton <michael.r.milton@gmail.com>",
 ]
 edition = "2021"
+rust-version = "1.65"
 license = "MIT"
 repository = "https://github.com/extendr/extendr"
 

--- a/extendr-api/Cargo.toml
+++ b/extendr-api/Cargo.toml
@@ -4,11 +4,9 @@ description = "Safe and user friendly bindings to the R programming language."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-
-# Note: it seems cargo-msrv doesn't support rust-version.workspace = true.
-rust-version = "1.65"
 
 [dependencies]
 extendr-ffi = { workspace = true }

--- a/extendr-api/build.rs
+++ b/extendr-api/build.rs
@@ -3,8 +3,9 @@ use std::env;
 fn main() {
     println!("cargo:rustc-check-cfg=cfg(use_objsxp)");
     println!("cargo:rustc-check-cfg=cfg(use_r_newenv)");
-    println!("cargo:rustc-check-cfg=cfg(use_r_ge_version_14)");
     println!("cargo:rustc-check-cfg=cfg(use_r_ge_version_15)");
+    println!("cargo:rustc-check-cfg=cfg(use_r_ge_version_16)");
+    println!("cargo:rustc-check-cfg=cfg(use_r_ge_version_17)");
     println!("cargo:rustc-check-cfg=cfg(use_r_altlist)");
 
     // The R version information is needed to handle the API differences
@@ -22,15 +23,20 @@ fn main() {
         println!("cargo:rustc-cfg=use_r_newenv");
     }
 
-    // pattern fill was introduced in R 4.1
-    if &*major >= "4" && &*minor >= "1" {
-        println!("cargo:rustc-cfg=use_r_ge_version_14");
-    }
-
     // a few new features will be introduced in R 4.2
     // c.f. https://developer.r-project.org/Blog/public/2021/12/14/updating-graphics-devices-for-r-4.2.0/index.html
     if &*major >= "4" && &*minor >= "2" {
         println!("cargo:rustc-cfg=use_r_ge_version_15");
+    }
+
+    // Graphics engine version 16 was introduced in R 4.3
+    if &*major >= "4" && &*minor >= "3" {
+        println!("cargo:rustc-cfg=use_r_ge_version_16");
+    }
+
+    // Graphics engine version 17 was introduced in R 4.6
+    if &*major >= "4" && &*minor >= "6" {
+        println!("cargo:rustc-cfg=use_r_ge_version_17");
     }
 
     if &*major >= "4" && &*minor >= "3" {

--- a/extendr-api/src/deserializer.rs
+++ b/extendr-api/src/deserializer.rs
@@ -420,7 +420,7 @@ impl<'de> Deserializer<'de> for &'de Robj {
         let s = <&str>::try_from(self.clone())?;
         let mut c = s.chars();
         if let Some(ch) = c.next() {
-            if c.next() == None {
+            if c.next().is_none() {
                 return visitor.visit_char(ch);
             }
         }
@@ -467,7 +467,6 @@ impl<'de> Deserializer<'de> for &'de Robj {
     where
         V: Visitor<'de>,
     {
-        #![allow(clippy::if_same_then_else)]
         if let Rany::Null(_) = self.as_any() {
             visitor.visit_none()
         } else if self.is_na() {
@@ -522,15 +521,15 @@ impl<'de> Deserializer<'de> for &'de Robj {
                 Ok(visitor.visit_seq(lg)?)
             }
             Rany::Integers(val) => {
-                let lg = SliceGetter { list: &*val };
+                let lg = SliceGetter { list: val };
                 Ok(visitor.visit_seq(lg)?)
             }
             Rany::Doubles(val) => {
-                let lg = SliceGetter { list: &*val };
+                let lg = SliceGetter { list: val };
                 Ok(visitor.visit_seq(lg)?)
             }
             Rany::Logicals(val) => {
-                let lg = SliceGetter { list: &*val };
+                let lg = SliceGetter { list: val };
                 Ok(visitor.visit_seq(lg)?)
             }
             Rany::Strings(_val) => {

--- a/extendr-api/src/deserializer.rs
+++ b/extendr-api/src/deserializer.rs
@@ -161,11 +161,15 @@ impl<'de> Deserializer<'de> for Rbool {
 impl<'de> Deserializer<'de> for &'de Rstr {
     type Error = Error;
 
-    fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value>
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        unimplemented!()
+        if self.is_na() {
+            Err(Error::MustNotBeNA(self.robj.clone()))
+        } else {
+            visitor.visit_borrowed_str(self)
+        }
     }
 
     fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value>

--- a/extendr-api/src/graphics/device_driver.rs
+++ b/extendr-api/src/graphics/device_driver.rs
@@ -397,7 +397,7 @@ pub trait DeviceDriver: std::marker::Sized {
             // we just use `c.abs()`.
             //
             // [^1]: https://github.com/wch/r-source/blob/9bb47ca929c41a133786fa8fff7c70162bb75e50/src/include/R_ext/GraphicsDevice.h#L615-L617
-            if let Some(c) = std::char::from_u32(c.abs() as _) {
+            if let Some(c) = std::char::from_u32(c.unsigned_abs()) {
                 let data = ((*dd).deviceSpecific as *mut T).as_mut().unwrap();
                 let metric_info = data.char_metric(c, *gc, *dd);
                 *ascent = metric_info.ascent;

--- a/extendr-api/src/graphics/device_driver.rs
+++ b/extendr-api/src/graphics/device_driver.rs
@@ -615,7 +615,6 @@ pub trait DeviceDriver: std::marker::Sized {
             data.eventHelper(*dd, code);
         }
 
-        #[cfg(use_r_ge_version_14)]
         unsafe extern "C" fn device_driver_setPattern<T: DeviceDriver>(
             pattern: SEXP,
             dd: pDevDesc,
@@ -626,7 +625,6 @@ pub trait DeviceDriver: std::marker::Sized {
             R_NilValue
         }
 
-        #[cfg(use_r_ge_version_14)]
         unsafe extern "C" fn device_driver_releasePattern<T: DeviceDriver>(
             ref_: SEXP,
             dd: pDevDesc,
@@ -636,7 +634,6 @@ pub trait DeviceDriver: std::marker::Sized {
             // data.reelasePattern(ref_, *dd);
         }
 
-        #[cfg(use_r_ge_version_14)]
         unsafe extern "C" fn device_driver_setClipPath<T: DeviceDriver>(
             path: SEXP,
             ref_: SEXP,
@@ -648,7 +645,6 @@ pub trait DeviceDriver: std::marker::Sized {
             R_NilValue
         }
 
-        #[cfg(use_r_ge_version_14)]
         unsafe extern "C" fn device_driver_releaseClipPath<T: DeviceDriver>(
             ref_: SEXP,
             dd: pDevDesc,
@@ -658,7 +654,6 @@ pub trait DeviceDriver: std::marker::Sized {
             // data.releaseClipPath(ref_, *dd);
         }
 
-        #[cfg(use_r_ge_version_14)]
         unsafe extern "C" fn device_driver_setMask<T: DeviceDriver>(
             path: SEXP,
             ref_: SEXP,
@@ -670,7 +665,6 @@ pub trait DeviceDriver: std::marker::Sized {
             R_NilValue
         }
 
-        #[cfg(use_r_ge_version_14)]
         unsafe extern "C" fn device_driver_releaseMask<T: DeviceDriver>(ref_: SEXP, dd: pDevDesc) {
             let data = ((*dd).deviceSpecific as *mut T).as_mut().unwrap();
             // TODO
@@ -879,24 +873,21 @@ pub trait DeviceDriver: std::marker::Sized {
             // version 15 (i.e. R 4.2), the features in API v13 & v14 (i.e. R
             // 4.1) are not optional. We need to provide the placeholder
             // functions for it.
-            #[cfg(use_r_ge_version_14)]
-            {
-                (*p_dev_desc).setPattern = Some(device_driver_setPattern::<T>);
-                (*p_dev_desc).releasePattern = Some(device_driver_releasePattern::<T>);
+            (*p_dev_desc).setPattern = Some(device_driver_setPattern::<T>);
+            (*p_dev_desc).releasePattern = Some(device_driver_releasePattern::<T>);
 
-                (*p_dev_desc).setClipPath = Some(device_driver_setClipPath::<T>);
-                (*p_dev_desc).releaseClipPath = Some(device_driver_releaseClipPath::<T>);
+            (*p_dev_desc).setClipPath = Some(device_driver_setClipPath::<T>);
+            (*p_dev_desc).releaseClipPath = Some(device_driver_releaseClipPath::<T>);
 
-                (*p_dev_desc).setMask = Some(device_driver_setMask::<T>);
-                (*p_dev_desc).releaseMask = Some(device_driver_releaseMask::<T>);
+            (*p_dev_desc).setMask = Some(device_driver_setMask::<T>);
+            (*p_dev_desc).releaseMask = Some(device_driver_releaseMask::<T>);
 
-                (*p_dev_desc).deviceVersion = R_GE_definitions as _;
+            (*p_dev_desc).deviceVersion = R_GE_definitions as _;
 
-                (*p_dev_desc).deviceClip = match <T>::CLIPPING_STRATEGY {
-                    ClippingStrategy::Device => Rboolean::TRUE,
-                    _ => Rboolean::FALSE,
-                };
-            }
+            (*p_dev_desc).deviceClip = match <T>::CLIPPING_STRATEGY {
+                ClippingStrategy::Device => Rboolean::TRUE,
+                _ => Rboolean::FALSE,
+            };
 
             #[cfg(use_r_ge_version_15)]
             {

--- a/extendr-api/src/graphics/device_driver.rs
+++ b/extendr-api/src/graphics/device_driver.rs
@@ -8,7 +8,7 @@ use extendr_ffi::{
 };
 
 #[cfg(use_r_ge_version_17)]
-use extendr_ffi::{GEcreateDD, GEfreeDD};
+use extendr_ffi::GEcreateDD;
 /// The underlying C structure `DevDesc` has two fields related to clipping:
 ///
 /// - `canClip`

--- a/extendr-api/src/graphics/mod.rs
+++ b/extendr-api/src/graphics/mod.rs
@@ -405,7 +405,7 @@ impl Context {
     }
 
     pub(crate) fn context(&self) -> pGEcontext {
-        unsafe { std::mem::transmute(&self.context) }
+        &self.context as *const extendr_ffi::R_GE_gcontext as *mut extendr_ffi::R_GE_gcontext
     }
 
     // Affine transform.

--- a/extendr-api/src/graphics/mod.rs
+++ b/extendr-api/src/graphics/mod.rs
@@ -262,8 +262,6 @@ impl Context {
                 lineheight: 1.0,
                 fontface: 1,
                 fontfamily: [0; 201],
-
-                #[cfg(use_r_ge_version_14)]
                 patternFill: R_NilValue,
             };
 

--- a/extendr-api/src/io/load.rs
+++ b/extendr-api/src/io/load.rs
@@ -45,7 +45,7 @@ pub trait Load {
         }
 
         let read_ptr: *mut R = reader as &mut R;
-        let data = unsafe { std::mem::transmute(read_ptr) };
+        let data = read_ptr.cast::<std::ffi::c_void>();
 
         let (hook_func, hook_data) = if let Some(hook) = hook {
             (hook.func, hook.data)
@@ -67,9 +67,11 @@ pub trait Load {
             nat2utf8_obj: std::ptr::null_mut(),
         };
 
-        Ok(Robj::from_sexp(catch_r_error(move || unsafe {
-            R_Unserialize(&mut state as R_inpstream_t)
-        })?))
+        Ok(unsafe {
+            Robj::from_sexp(catch_r_error(move || {
+                R_Unserialize(&mut state as R_inpstream_t)
+            })?)
+        })
     }
 }
 

--- a/extendr-api/src/iter.rs
+++ b/extendr-api/src/iter.rs
@@ -76,9 +76,7 @@ impl Iterator for StrIter {
             let i = self.i;
             self.i += 1;
             let vector = self.vector.get();
-            if i >= self.len {
-                None
-            } else if TYPEOF(vector) == SEXPTYPE::NILSXP {
+            if i >= self.len || TYPEOF(vector) == SEXPTYPE::NILSXP {
                 None
             } else if TYPEOF(vector) == SEXPTYPE::STRSXP {
                 str_from_strsxp(vector, i)

--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -352,7 +352,7 @@ pub use functions::*;
 pub use lang_macros::*;
 pub use na::*;
 pub use robj::*;
-pub use thread_safety::{catch_r_error, handle_panic, single_threaded, throw_r_error};
+pub use thread_safety::{catch_r_error, single_threaded, throw_r_error};
 pub use wrapper::*;
 
 pub use extendr_macros::*;

--- a/extendr-api/src/lib.rs
+++ b/extendr-api/src/lib.rs
@@ -963,7 +963,7 @@ mod tests {
             assert_eq!(metadata.impls[0].methods.len(), 3);
 
             // R interface
-            let robj = unsafe { Robj::from_sexp(wrap__get_my_module_metadata()) };
+            let robj = Robj::from_sexp(wrap__get_my_module_metadata());
             let functions = robj.dollar("functions").unwrap();
             let impls = robj.dollar("impls").unwrap();
             assert_eq!(functions.len(), 3);

--- a/extendr-api/src/metadata.rs
+++ b/extendr-api/src/metadata.rs
@@ -385,11 +385,11 @@ impl Metadata {
         unsafe { Ok(String::from_utf8_unchecked(w)) }
     }
 
-    fn impl_names<'a>(&'a self) -> Vec<&'a str> {
+    fn impl_names(&self) -> Vec<&str> {
         let mut vec: Vec<&str> = vec![];
         for impls in &self.impls {
             if !vec.contains(&impls.name) {
-                vec.push(&impls.name)
+                vec.push(impls.name)
             }
         }
         vec

--- a/extendr-api/src/prelude.rs
+++ b/extendr-api/src/prelude.rs
@@ -53,7 +53,7 @@ pub use super::robj::{
     RobjItertools, Slices, Types,
 };
 
-pub use super::thread_safety::{catch_r_error, handle_panic, single_threaded, throw_r_error};
+pub use super::thread_safety::{catch_r_error, single_threaded, throw_r_error};
 
 pub use super::wrapper::{
     Complexes, Dataframe, Doubles, EnvIter, Environment, Expressions, ExternalPtr, FromList,

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -38,7 +38,9 @@ impl From<()> for Robj {
 
 /// Convert a [`Result`] to an [`Robj`].
 ///
-/// Panics if there is an error.
+/// By default, shows the Display method from the Error.
+/// If the environment variable `EXTENDR_BACKTRACE` is set to either `true` or `1`,
+/// then it displays the entire Rust panic traceback.
 ///
 /// To use the `?`-operator, an extendr-function must return either [`extendr_api::error::Result`] or [`std::result::Result`].
 /// Use of `panic!` in extendr is discouraged due to memory leakage.
@@ -51,7 +53,7 @@ impl From<()> for Robj {
 /// * `result_list`: `Ok(T)` is encoded as `list(ok = x_ok, err = NULL)` and `Err` as `list(ok = NULL, err = e_err)`.
 /// * `result_condition'`: `Ok(T)` is encoded as `x_ok` and `Err(E)` as `condition(msg="extendr_error", value = x_err, class=c("extendr_error", "error", "condition"))`
 /// * More than one enabled feature: Only one feature gate will take effect, the current order of precedence is [`result_list`, `result_condition`, ... ].
-/// * Neither of the above (default): `Ok(T)` is encoded as `x_ok`and `Err(E)` will trigger `throw_r_error()`, which is discouraged.
+/// * Neither of the above (default): `Ok(T)` is encoded as `x_ok` and `Err(E)` will trigger `throw_r_error()` with the error message.
 /// ```
 /// use extendr_api::prelude::*;
 /// fn my_func() -> Result<f64> {
@@ -68,10 +70,24 @@ impl From<()> for Robj {
 impl<T, E> From<std::result::Result<T, E>> for Robj
 where
     T: Into<Robj>,
-    E: std::fmt::Debug,
+    E: std::fmt::Debug + std::fmt::Display,
 {
     fn from(res: std::result::Result<T, E>) -> Self {
-        res.unwrap().into()
+        // if the envvar EXTENDR_BACKTRACE is set to true or 1
+        // then we panic and show the full thing
+        let show_traceback = std::env::var("EXTENDR_BACKTRACE")
+            .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
+            .unwrap_or(false);
+
+        if show_traceback {
+            res.unwrap().into()
+        } else {
+            // otherwise, we use throw_r_error here
+            match res {
+                Ok(val) => val.into(),
+                Err(err) => crate::throw_r_error(err.to_string()),
+            }
+        }
     }
 }
 

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -38,10 +38,6 @@ impl From<()> for Robj {
 
 /// Convert a [`Result`] to an [`Robj`].
 ///
-/// By default, shows the Display method from the Error.
-/// If the environment variable `EXTENDR_BACKTRACE` is set to either `true` or `1`,
-/// then it displays the entire Rust panic traceback.
-///
 /// To use the `?`-operator, an extendr-function must return either [`extendr_api::error::Result`] or [`std::result::Result`].
 /// Use of `panic!` in extendr is discouraged due to memory leakage.
 ///
@@ -73,21 +69,7 @@ where
     E: std::fmt::Debug + std::fmt::Display,
 {
     fn from(res: std::result::Result<T, E>) -> Self {
-        // if the envvar EXTENDR_BACKTRACE is set to true or 1
-        // then we panic and show the full thing
-        let show_traceback = std::env::var("EXTENDR_BACKTRACE")
-            .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
-            .unwrap_or(false);
-
-        if show_traceback {
-            res.unwrap().into()
-        } else {
-            // otherwise, we use throw_r_error here
-            match res {
-                Ok(val) => val.into(),
-                Err(err) => crate::throw_r_error(err.to_string()),
-            }
-        }
+        res.unwrap().into()
     }
 }
 

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -196,14 +196,14 @@ pub trait ToVectorValue {
     where
         Self: Sized,
     {
-        std::i32::MIN
+        i32::MIN
     }
 
     fn to_logical(&self) -> i32
     where
         Self: Sized,
     {
-        std::i32::MIN
+        i32::MIN
     }
 
     fn to_raw(&self) -> u8
@@ -649,9 +649,8 @@ macro_rules! impl_from_as_iterator {
 //     }
 // } //
 
-impl<'a, T, const N: usize> From<[T; N]> for Robj
+impl<T, const N: usize> From<[T; N]> for Robj
 where
-    Self: 'a,
     T: ToVectorValue,
 {
     fn from(val: [T; N]) -> Self {

--- a/extendr-api/src/robj/into_robj.rs
+++ b/extendr-api/src/robj/into_robj.rs
@@ -69,7 +69,10 @@ where
     E: std::fmt::Debug + std::fmt::Display,
 {
     fn from(res: std::result::Result<T, E>) -> Self {
-        res.unwrap().into()
+        match res {
+            Ok(val) => val.into(),
+            Err(err) => panic!("{}", err),
+        }
     }
 }
 

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -131,6 +131,9 @@ pub trait GetSexp {
     /// Access to a raw SEXP pointer can cause undefined behaviour and is not thread safe.
     unsafe fn get(&self) -> SEXP;
 
+    /// # Safety
+    ///
+    /// Access to a raw SEXP pointer can cause undefined behaviour and is not thread safe.
     unsafe fn get_mut(&mut self) -> SEXP;
 
     /// Get a reference to a Robj for this type.
@@ -218,22 +221,15 @@ pub trait Length: GetSexp {
 impl Length for Robj {}
 
 impl Robj {
-    pub fn from_sexp(sexp: SEXP) -> Self {
+    /// # Safety
+    ///
+    /// This function dereferences a raw SEXP pointer.
+    /// The caller must ensure that `sexp` is a valid SEXP pointer.
+    pub unsafe fn from_sexp(sexp: SEXP) -> Self {
         single_threaded(|| {
             unsafe { ownership::protect(sexp) };
             Robj { inner: sexp }
         })
-    }
-
-    /// A reference of an [`Robj`] can be constructed from a reference to a [`SEXP`]
-    /// as they have the same layout.
-    ///
-    /// # SAFETY
-    ///
-    /// Unlike [`from_sexp`], this does not protect the converted [`SEXP`]. Therefore, one
-    /// must invoke [`ownership::protect`] manually, if necessary.
-    pub(crate) unsafe fn from_sexp_ref(sexp: &SEXP) -> &Self {
-        unsafe { std::mem::transmute(sexp) }
     }
 }
 
@@ -298,38 +294,48 @@ pub trait Types: GetSexp {
         }
     }
 
-    fn as_any(&self) -> Rany {
+    fn as_any(&self) -> Rany<'_> {
         use SEXPTYPE::*;
         unsafe {
             match self.sexptype() {
-                NILSXP => Rany::Null(std::mem::transmute(self.as_robj())),
-                SYMSXP => Rany::Symbol(std::mem::transmute(self.as_robj())),
-                LISTSXP => Rany::Pairlist(std::mem::transmute(self.as_robj())),
-                CLOSXP => Rany::Function(std::mem::transmute(self.as_robj())),
-                ENVSXP => Rany::Environment(std::mem::transmute(self.as_robj())),
-                PROMSXP => Rany::Promise(std::mem::transmute(self.as_robj())),
-                LANGSXP => Rany::Language(std::mem::transmute(self.as_robj())),
-                SPECIALSXP => Rany::Special(std::mem::transmute(self.as_robj())),
-                BUILTINSXP => Rany::Builtin(std::mem::transmute(self.as_robj())),
-                CHARSXP => Rany::Rstr(std::mem::transmute(self.as_robj())),
-                LGLSXP => Rany::Logicals(std::mem::transmute(self.as_robj())),
-                INTSXP => Rany::Integers(std::mem::transmute(self.as_robj())),
-                REALSXP => Rany::Doubles(std::mem::transmute(self.as_robj())),
-                CPLXSXP => Rany::Complexes(std::mem::transmute(self.as_robj())),
-                STRSXP => Rany::Strings(std::mem::transmute(self.as_robj())),
-                DOTSXP => Rany::Dot(std::mem::transmute(self.as_robj())),
-                ANYSXP => Rany::Any(std::mem::transmute(self.as_robj())),
-                VECSXP => Rany::List(std::mem::transmute(self.as_robj())),
-                EXPRSXP => Rany::Expressions(std::mem::transmute(self.as_robj())),
-                BCODESXP => Rany::Bytecode(std::mem::transmute(self.as_robj())),
-                EXTPTRSXP => Rany::ExternalPtr(std::mem::transmute(self.as_robj())),
-                WEAKREFSXP => Rany::WeakRef(std::mem::transmute(self.as_robj())),
-                RAWSXP => Rany::Raw(std::mem::transmute(self.as_robj())),
+                NILSXP => Rany::Null(self.as_robj()),
+                SYMSXP => Rany::Symbol(std::mem::transmute::<&Robj, &Symbol>(self.as_robj())),
+                LISTSXP => Rany::Pairlist(std::mem::transmute::<&Robj, &Pairlist>(self.as_robj())),
+                CLOSXP => Rany::Function(std::mem::transmute::<&Robj, &Function>(self.as_robj())),
+                ENVSXP => {
+                    Rany::Environment(std::mem::transmute::<&Robj, &Environment>(self.as_robj()))
+                }
+                PROMSXP => Rany::Promise(std::mem::transmute::<&Robj, &Promise>(self.as_robj())),
+                LANGSXP => Rany::Language(std::mem::transmute::<&Robj, &Language>(self.as_robj())),
+                SPECIALSXP => {
+                    Rany::Special(std::mem::transmute::<&Robj, &Primitive>(self.as_robj()))
+                }
+                BUILTINSXP => {
+                    Rany::Builtin(std::mem::transmute::<&Robj, &Primitive>(self.as_robj()))
+                }
+                CHARSXP => Rany::Rstr(std::mem::transmute::<&Robj, &Rstr>(self.as_robj())),
+                LGLSXP => Rany::Logicals(std::mem::transmute::<&Robj, &Logicals>(self.as_robj())),
+                INTSXP => Rany::Integers(std::mem::transmute::<&Robj, &Integers>(self.as_robj())),
+                REALSXP => Rany::Doubles(std::mem::transmute::<&Robj, &Doubles>(self.as_robj())),
+                CPLXSXP => {
+                    Rany::Complexes(std::mem::transmute::<&Robj, &Complexes>(self.as_robj()))
+                }
+                STRSXP => Rany::Strings(std::mem::transmute::<&Robj, &Strings>(self.as_robj())),
+                DOTSXP => Rany::Dot(std::mem::transmute::<&Robj, &Robj>(self.as_robj())),
+                ANYSXP => Rany::Any(std::mem::transmute::<&Robj, &Robj>(self.as_robj())),
+                VECSXP => Rany::List(std::mem::transmute::<&Robj, &List>(self.as_robj())),
+                EXPRSXP => {
+                    Rany::Expressions(std::mem::transmute::<&Robj, &Expressions>(self.as_robj()))
+                }
+                BCODESXP => Rany::Bytecode(std::mem::transmute::<&Robj, &Robj>(self.as_robj())),
+                EXTPTRSXP => Rany::ExternalPtr(std::mem::transmute::<&Robj, &Robj>(self.as_robj())),
+                WEAKREFSXP => Rany::WeakRef(std::mem::transmute::<&Robj, &Robj>(self.as_robj())),
+                RAWSXP => Rany::Raw(std::mem::transmute::<&Robj, &Raw>(self.as_robj())),
                 #[cfg(not(use_objsxp))]
                 S4SXP => Rany::S4(std::mem::transmute(self.as_robj())),
                 #[cfg(use_objsxp)]
-                OBJSXP => Rany::S4(std::mem::transmute(self.as_robj())),
-                _ => Rany::Unknown(std::mem::transmute(self.as_robj())),
+                OBJSXP => Rany::S4(std::mem::transmute::<&Robj, &S4>(self.as_robj())),
+                _ => Rany::Unknown(std::mem::transmute::<&Robj, &Robj>(self.as_robj())),
             }
         }
     }

--- a/extendr-api/src/robj/mod.rs
+++ b/extendr-api/src/robj/mod.rs
@@ -225,7 +225,9 @@ impl Robj {
     ///
     /// This function dereferences a raw SEXP pointer.
     /// The caller must ensure that `sexp` is a valid SEXP pointer.
-    pub unsafe fn from_sexp(sexp: SEXP) -> Self {
+    // Kept a safe `fn` on the 0.8 line for backwards compatibility; 0.9 makes it `unsafe`.
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    pub fn from_sexp(sexp: SEXP) -> Self {
         single_threaded(|| {
             unsafe { ownership::protect(sexp) };
             Robj { inner: sexp }

--- a/extendr-api/src/robj/rinternals.rs
+++ b/extendr-api/src/robj/rinternals.rs
@@ -1,11 +1,11 @@
 use crate::*;
 use extendr_ffi::{
-    get_var, R_CFinalizer_t, R_ExternalPtrAddr, R_ExternalPtrProtected, R_ExternalPtrTag,
-    R_GetCurrentSrcref, R_GetSrcFilename, R_IsNamespaceEnv, R_IsPackageEnv, R_MakeExternalPtr,
-    R_MissingArg, R_NamespaceEnvSpec, R_PackageEnvName, R_RegisterCFinalizerEx, R_UnboundValue,
-    R_xlen_t, Rboolean, Rf_PairToVectorList, Rf_VectorToPairList, Rf_allocMatrix, Rf_allocVector,
-    Rf_asChar, Rf_asCharacterFactor, Rf_coerceVector, Rf_conformable, Rf_duplicate, Rf_findFun,
-    Rf_isArray, Rf_isComplex, Rf_isEnvironment, Rf_isExpression, Rf_isFactor, Rf_isFrame,
+    get_var, is_data_frame, R_CFinalizer_t, R_ExternalPtrAddr, R_ExternalPtrProtected,
+    R_ExternalPtrTag, R_GetCurrentSrcref, R_GetSrcFilename, R_IsNamespaceEnv, R_IsPackageEnv,
+    R_MakeExternalPtr, R_MissingArg, R_NamespaceEnvSpec, R_PackageEnvName, R_RegisterCFinalizerEx,
+    R_UnboundValue, R_xlen_t, Rboolean, Rf_PairToVectorList, Rf_VectorToPairList, Rf_allocMatrix,
+    Rf_allocVector, Rf_asChar, Rf_asCharacterFactor, Rf_coerceVector, Rf_conformable, Rf_duplicate,
+    Rf_findFun, Rf_isArray, Rf_isComplex, Rf_isEnvironment, Rf_isExpression, Rf_isFactor,
     Rf_isFunction, Rf_isInteger, Rf_isLanguage, Rf_isList, Rf_isLogical, Rf_isMatrix, Rf_isNewList,
     Rf_isNull, Rf_isNumber, Rf_isObject, Rf_isPrimitive, Rf_isReal, Rf_isS4, Rf_isString,
     Rf_isSymbol, Rf_isTs, Rf_isUserBinop, Rf_isVector, Rf_isVectorAtomic, Rf_isVectorList,
@@ -312,7 +312,7 @@ pub trait Rinternals: Types + Conversions {
 
     /// Return true if this is a data frame.
     fn is_frame(&self) -> bool {
-        unsafe { Rf_isFrame(self.get()).into() }
+        unsafe { is_data_frame(self.get()).into() }
     }
 
     /// Return true if this is a function or a primitive (CLOSXP, BUILTINSXP or SPECIALSXP)

--- a/extendr-api/src/robj/try_from_robj.rs
+++ b/extendr-api/src/robj/try_from_robj.rs
@@ -671,7 +671,63 @@ impl_try_from_robj_for_arrays!(i32);
 impl_try_from_robj_for_arrays!(f64);
 
 // Choosing arity 12.. As the Rust compiler did for these [Tuple to array conversion](https://doc.rust-lang.org/stable/std/primitive.tuple.html#trait-implementations-1)
-impl_try_from_robj_tuples!((1, 12));
+// Single-element tuple manually implemented to avoid clippy::needless_question_mark
+
+// We implement the 1-length tuple variant manually
+// so that we avoid clippy needless Ok(?) lint
+impl<T0> TryFrom<&Robj> for (T0,)
+where
+    T0: for<'a> TryFrom<&'a Robj, Error = Error>,
+{
+    type Error = Error;
+
+    fn try_from(robj: &Robj) -> Result<Self> {
+        let list: List = robj.try_into()?;
+        if list.len() != 1 {
+            return Err(Error::ExpectedLength(1));
+        }
+        Ok(((&list.elt(0)?).try_into()?,))
+    }
+}
+
+impl<T0> TryFrom<Robj> for (T0,)
+where
+    T0: for<'a> TryFrom<&'a Robj, Error = Error>,
+{
+    type Error = Error;
+
+    fn try_from(robj: Robj) -> Result<Self> {
+        Self::try_from(&robj)
+    }
+}
+
+impl<T0> TryFrom<&Robj> for Option<(T0,)>
+where
+    T0: for<'a> TryFrom<&'a Robj, Error = Error>,
+{
+    type Error = Error;
+
+    fn try_from(robj: &Robj) -> Result<Self> {
+        if robj.is_null() || robj.is_na() {
+            Ok(None)
+        } else {
+            <(T0,)>::try_from(robj).map(Some)
+        }
+    }
+}
+
+impl<T0> TryFrom<Robj> for Option<(T0,)>
+where
+    T0: for<'a> TryFrom<&'a Robj, Error = Error>,
+{
+    type Error = Error;
+
+    fn try_from(robj: Robj) -> Result<Self> {
+        Self::try_from(&robj)
+    }
+}
+
+impl_try_from_robj_tuples!((2, 12));
 
 // The following is necessary because it is impossible to define `TryFrom<Robj> for &Robj` as
 // it requires returning a reference to a owned (moved) value

--- a/extendr-api/src/thread_safety.rs
+++ b/extendr-api/src/thread_safety.rs
@@ -46,24 +46,6 @@ where
     result
 }
 
-/// This function is used by the wrapper logic to catch
-/// panics on return.
-///
-#[doc(hidden)]
-pub fn handle_panic<F, R>(err_str: &str, f: F) -> R
-where
-    F: FnOnce() -> R,
-    F: std::panic::UnwindSafe,
-{
-    match std::panic::catch_unwind(f) {
-        Ok(res) => res,
-        Err(_) => {
-            let err_str = CString::new(err_str).unwrap();
-            unsafe { Rf_error(err_str.as_ptr()) }
-        }
-    }
-}
-
 static mut R_ERROR_BUF: Option<std::ffi::CString> = None;
 
 pub fn throw_r_error<S: AsRef<str>>(s: S) -> ! {

--- a/extendr-api/src/thread_safety.rs
+++ b/extendr-api/src/thread_safety.rs
@@ -118,3 +118,29 @@ where
         res
     })
 }
+
+/// This function registers a configurable print panic hook, for use in extendr-based R-packages.
+/// If the environment variable `EXTENDR_BACKTRACE` is set to either `true` or `1`,
+/// then it displays the entire Rust panic traceback (default hook), otherwise it omits the panic backtrace.
+#[no_mangle]
+pub extern "C" fn register_extendr_panic_hook() {
+    static RUN_ONCE: std::sync::Once = std::sync::Once::new();
+    RUN_ONCE.call_once_force(|x| {
+        // just ignore repeated calls to this function
+        if x.is_poisoned() {
+            println!("warning: extendr panic hook info registration was done more than once");
+            return;
+        }
+        let default_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |x| {
+            let show_traceback = std::env::var("EXTENDR_BACKTRACE")
+                .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
+                .unwrap_or(false);
+            if show_traceback {
+                default_hook(x)
+            } else {
+                return;
+            }
+        }));
+    });
+}

--- a/extendr-api/src/wrapper/altrep.rs
+++ b/extendr-api/src/wrapper/altrep.rs
@@ -2,6 +2,34 @@ use super::*;
 use extendr_ffi::*;
 use prelude::{Rbool, Rcplx, Rfloat, Rint, Scalar};
 
+macro_rules! make_from_iterator_impl {
+    ($impl : ident, $scalar_type : ident) => {
+        impl<Iter: ExactSizeIterator + std::fmt::Debug + Clone> $impl for Iter
+        where
+            Iter::Item: Into<$scalar_type>,
+        {
+            fn elt(&self, index: usize) -> $scalar_type {
+                $scalar_type::from(self.clone().nth(index).unwrap().into())
+            }
+
+            fn get_region(&self, index: usize, data: &mut [$scalar_type]) -> usize {
+                let len = self.len();
+                if index > len {
+                    0
+                } else {
+                    let mut iter = self.clone().skip(index);
+                    let num_elems = data.len().min(len - index);
+                    let dest = &mut data[0..num_elems];
+                    for d in dest.iter_mut() {
+                        *d = $scalar_type::from(iter.next().unwrap().into());
+                    }
+                    num_elems
+                }
+            }
+        }
+    };
+}
+
 macro_rules! make_from_iterator {
     ($fn_name : ident, $make_class : ident, $impl : ident, $scalar_type : ident, $prim_type : ty) => {
         pub fn $fn_name<Iter>(iter: Iter) -> Altrep
@@ -9,30 +37,6 @@ macro_rules! make_from_iterator {
             Iter: ExactSizeIterator + std::fmt::Debug + Clone + 'static + std::any::Any,
             Iter::Item: Into<$scalar_type>,
         {
-            impl<Iter: ExactSizeIterator + std::fmt::Debug + Clone> $impl for Iter
-            where
-                Iter::Item: Into<$scalar_type>,
-            {
-                fn elt(&self, index: usize) -> $scalar_type {
-                    $scalar_type::from(self.clone().nth(index).unwrap().into())
-                }
-
-                fn get_region(&self, index: usize, data: &mut [$scalar_type]) -> usize {
-                    let len = self.len();
-                    if index > len {
-                        0
-                    } else {
-                        let mut iter = self.clone().skip(index);
-                        let num_elems = data.len().min(len - index);
-                        let dest = &mut data[0..num_elems];
-                        for d in dest.iter_mut() {
-                            *d = $scalar_type::from(iter.next().unwrap().into());
-                        }
-                        num_elems
-                    }
-                }
-            }
-
             let class = Altrep::$make_class::<Iter>(std::any::type_name::<Iter>(), "extendr");
             let robj: Robj = Altrep::from_state_and_class(iter, class, false).into();
             Altrep { robj }
@@ -51,6 +55,11 @@ pub struct Altrep {
 pub trait AltrepImpl: Clone + std::fmt::Debug {
     #[cfg(feature = "non-api")]
     /// Constructor that is called when loading an Altrep object from a file.
+    ///
+    /// # Safety
+    ///
+    /// Access to a raw SEXP pointer can cause undefined behaviour and is not thread safe.
+    /// Note that we use a thread lock to ensure this doesn't occur.
     unsafe fn unserialize_ex(
         class: Robj,
         state: Robj,
@@ -92,7 +101,7 @@ pub trait AltrepImpl: Clone + std::fmt::Debug {
     /// Duplicate this object. Called by Rf_duplicate.
     /// Currently this manifests the array but preserves the original object.
     fn duplicate(x: SEXP, _deep: bool) -> Robj {
-        Robj::from_sexp(manifest(x))
+        unsafe { Robj::from_sexp(manifest(x)) }
     }
 
     /// Coerce this object into some other type, if possible.
@@ -117,7 +126,12 @@ pub trait AltrepImpl: Clone + std::fmt::Debug {
 
     /// Get the data pointer for this vector, possibly expanding the
     /// compact representation into a full R vector.
-    fn dataptr(x: SEXP, _writeable: bool) -> *mut u8 {
+    ///
+    /// # Safety
+    ///
+    /// This function dereferences a raw SEXP pointer.
+    /// The caller must ensure that `x` is a valid SEXP pointer.
+    unsafe fn dataptr(x: SEXP, _writeable: bool) -> *mut u8 {
         single_threaded(|| unsafe {
             let data2 = R_altrep_data2(x);
             if data2 == R_NilValue || TYPEOF(data2) != TYPEOF(x) {
@@ -132,7 +146,12 @@ pub trait AltrepImpl: Clone + std::fmt::Debug {
 
     /// Get the data pointer for this vector, returning NULL
     /// if the object is unmaterialized.
-    fn dataptr_or_null(x: SEXP) -> *const u8 {
+    ///
+    /// # Safety
+    ///
+    /// This function dereferences a raw SEXP pointer.
+    /// The caller must ensure that `x` is a valid SEXP pointer.
+    unsafe fn dataptr_or_null(x: SEXP) -> *const u8 {
         unsafe {
             let data2 = R_altrep_data2(x);
             if data2 == R_NilValue || TYPEOF(data2) != TYPEOF(x) {
@@ -442,6 +461,12 @@ pub trait AltComplexImpl: AltrepImpl {
     }
 }
 
+// Implement the trait methods for iterators
+make_from_iterator_impl!(AltIntegerImpl, Rint);
+make_from_iterator_impl!(AltLogicalImpl, Rbool);
+make_from_iterator_impl!(AltRealImpl, Rfloat);
+make_from_iterator_impl!(AltComplexImpl, Rcplx);
+
 pub trait AltStringImpl {
     /// Get a single element from this vector.
     fn elt(&self, _index: usize) -> Rstr;
@@ -571,8 +596,8 @@ impl Altrep {
                 Robj::from_sexp(class),
                 Robj::from_sexp(state),
                 Robj::from_sexp(attr),
-                objf as i32,
-                levs as i32,
+                objf,
+                levs,
             )
             .get()
         }

--- a/extendr-api/src/wrapper/altrep.rs
+++ b/extendr-api/src/wrapper/altrep.rs
@@ -101,7 +101,7 @@ pub trait AltrepImpl: Clone + std::fmt::Debug {
     /// Duplicate this object. Called by Rf_duplicate.
     /// Currently this manifests the array but preserves the original object.
     fn duplicate(x: SEXP, _deep: bool) -> Robj {
-        unsafe { Robj::from_sexp(manifest(x)) }
+        Robj::from_sexp(manifest(x))
     }
 
     /// Coerce this object into some other type, if possible.
@@ -131,7 +131,9 @@ pub trait AltrepImpl: Clone + std::fmt::Debug {
     ///
     /// This function dereferences a raw SEXP pointer.
     /// The caller must ensure that `x` is a valid SEXP pointer.
-    unsafe fn dataptr(x: SEXP, _writeable: bool) -> *mut u8 {
+    // Kept a safe `fn` on the 0.8 line for backwards compatibility; 0.9 makes it `unsafe`.
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    fn dataptr(x: SEXP, _writeable: bool) -> *mut u8 {
         single_threaded(|| unsafe {
             let data2 = R_altrep_data2(x);
             if data2 == R_NilValue || TYPEOF(data2) != TYPEOF(x) {
@@ -151,7 +153,9 @@ pub trait AltrepImpl: Clone + std::fmt::Debug {
     ///
     /// This function dereferences a raw SEXP pointer.
     /// The caller must ensure that `x` is a valid SEXP pointer.
-    unsafe fn dataptr_or_null(x: SEXP) -> *const u8 {
+    // Kept a safe `fn` on the 0.8 line for backwards compatibility; 0.9 makes it `unsafe`.
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    fn dataptr_or_null(x: SEXP) -> *const u8 {
         unsafe {
             let data2 = R_altrep_data2(x);
             if data2 == R_NilValue || TYPEOF(data2) != TYPEOF(x) {

--- a/extendr-api/src/wrapper/environment.rs
+++ b/extendr-api/src/wrapper/environment.rs
@@ -103,6 +103,9 @@ impl Environment {
 
     #[cfg(feature = "non-api")]
     /// Set the environment flags.
+    /// # Safety
+    ///
+    /// Setting environment flag uses R's C API and is inherently unsafe.
     pub unsafe fn set_envflags(&mut self, flags: i32) -> &mut Self {
         single_threaded(|| unsafe {
             let sexp = self.robj.get_mut();

--- a/extendr-api/src/wrapper/expr.rs
+++ b/extendr-api/src/wrapper/expr.rs
@@ -8,7 +8,7 @@ pub struct Expressions {
 impl Expressions {
     /// Wrapper for creating Expressions (EXPRSXP) objects.
     pub fn new() -> Self {
-        Expressions::from_values([Robj::from(()); 0])
+        Expressions::from_values([()])
     }
 
     /// Wrapper for creating Expressions (EXPRSXP) objects.

--- a/extendr-api/src/wrapper/integers.rs
+++ b/extendr-api/src/wrapper/integers.rs
@@ -180,8 +180,7 @@ mod tests {
     fn test_vec_i32_integers_conversion() {
         test! {
             let int_vec = vec![3,4,0,-2];
-            let int_vec_robj: Robj = int_vec.clone().try_into().unwrap();
-            // unsafe { extendr_ffi::Rf_PrintValue(rint_vec_robj.get())}
+            let int_vec_robj: Robj = int_vec.clone().into();
             assert_eq!(int_vec_robj.as_integer_slice().unwrap(), &int_vec);
         }
     }

--- a/extendr-api/src/wrapper/matrix.rs
+++ b/extendr-api/src/wrapper/matrix.rs
@@ -40,7 +40,7 @@ pub struct RArray<T, D> {
 
 impl<T, D> RArray<T, D> {
     pub fn get_dimnames(&self) -> List {
-        List::try_from(Robj::from_sexp(unsafe { Rf_GetArrayDimnames(self.get()) })).unwrap()
+        unsafe { List::try_from(Robj::from_sexp(Rf_GetArrayDimnames(self.get()))).unwrap() }
     }
 
     /// Set the names of the elements of an array.
@@ -127,7 +127,7 @@ impl<T> RMatrix<T> {
                 SEXPTYPE::NILSXP => None,
                 SEXPTYPE::STRSXP => {
                     let colnames = Robj::from_sexp(maybe_colnames);
-                    Some(std::mem::transmute(colnames))
+                    Strings::try_from(colnames).ok()
                 }
                 _ => unreachable!(
                     "This should not have occurred. Please report an error at https://github.com/extendr/extendr/issues"
@@ -142,7 +142,7 @@ impl<T> RMatrix<T> {
                 SEXPTYPE::NILSXP => None,
                 SEXPTYPE::STRSXP => {
                     let rownames = Robj::from_sexp(maybe_rownames);
-                    Some(std::mem::transmute(rownames))
+                    Strings::try_from(rownames).ok()
                 }
                 _ => unreachable!(
                     "This should not have occurred. Please report an error at https://github.com/extendr/extendr/issues"
@@ -257,8 +257,8 @@ where
     /// * `nrows` - the number of rows the returned matrix will have
     /// * `ncols` - the number of columns the returned matrix will have
     /// * `f` - a function that will be called for each entry of the matrix in order to populate it with values.
-    ///     It must return a scalar value that can be converted to an R scalar, such as `i32`, `u32`, or `f64`, i.e. see [ToVectorValue].
-    ///     It accepts two arguments:
+    ///   It must return a scalar value that can be converted to an R scalar, such as `i32`, `u32`, or `f64`, i.e. see [ToVectorValue].
+    ///   It accepts two arguments:
     ///     * `r` - the current row of the entry we are creating
     ///     * `c` - the current column of the entry we are creating
     pub fn new_matrix<F: Clone + FnMut(usize, usize) -> T>(

--- a/extendr-api/src/wrapper/promise.rs
+++ b/extendr-api/src/wrapper/promise.rs
@@ -94,7 +94,7 @@ impl std::fmt::Debug for Promise {
         #[cfg(feature = "non-api")]
         {
             let result = result.field("code", &self.code());
-            let result = result.field("environment", &self.environment());
+            let _result = result.field("environment", &self.environment());
         }
         result.finish()
     }

--- a/extendr-api/src/wrapper/rstr.rs
+++ b/extendr-api/src/wrapper/rstr.rs
@@ -40,7 +40,7 @@ impl Rstr {
     /// Make a character object from a string.
     pub fn from_string(val: &str) -> Self {
         Rstr {
-            robj: Robj::from_sexp(str_to_character(val)),
+            robj: unsafe { Robj::from_sexp(str_to_character(val)) },
         }
     }
 

--- a/extendr-api/src/wrapper/rstr.rs
+++ b/extendr-api/src/wrapper/rstr.rs
@@ -40,7 +40,7 @@ impl Rstr {
     /// Make a character object from a string.
     pub fn from_string(val: &str) -> Self {
         Rstr {
-            robj: unsafe { Robj::from_sexp(str_to_character(val)) },
+            robj: Robj::from_sexp(str_to_character(val)),
         }
     }
 

--- a/extendr-api/src/wrapper/strings.rs
+++ b/extendr-api/src/wrapper/strings.rs
@@ -74,9 +74,11 @@ impl Strings {
         if i >= self.len() {
             Rstr::na()
         } else {
-            Robj::from_sexp(unsafe { STRING_ELT(self.get(), i as R_xlen_t) })
-                .try_into()
-                .unwrap()
+            unsafe {
+                Robj::from_sexp(STRING_ELT(self.get(), i as R_xlen_t))
+                    .try_into()
+                    .unwrap()
+            }
         }
     }
 

--- a/extendr-api/src/wrapper/symbol.rs
+++ b/extendr-api/src/wrapper/symbol.rs
@@ -37,17 +37,17 @@ impl Symbol {
     pub fn from_string<S: AsRef<str>>(val: S) -> Self {
         let val = val.as_ref();
         Symbol {
-            robj: Robj::from_sexp(make_symbol(val)),
+            robj: unsafe { Robj::from_sexp(make_symbol(val)) },
         }
     }
 
     // Internal conversion for constant symbols.
-    fn from_sexp(sexp: SEXP) -> Symbol {
+    pub(crate) fn from_sexp(sexp: SEXP) -> Symbol {
         unsafe {
             assert!(TYPEOF(sexp) == SEXPTYPE::SYMSXP);
         }
         Symbol {
-            robj: Robj::from_sexp(sexp),
+            robj: unsafe { Robj::from_sexp(sexp) },
         }
     }
 

--- a/extendr-api/src/wrapper/symbol.rs
+++ b/extendr-api/src/wrapper/symbol.rs
@@ -37,7 +37,7 @@ impl Symbol {
     pub fn from_string<S: AsRef<str>>(val: S) -> Self {
         let val = val.as_ref();
         Symbol {
-            robj: unsafe { Robj::from_sexp(make_symbol(val)) },
+            robj: Robj::from_sexp(make_symbol(val)),
         }
     }
 
@@ -47,7 +47,7 @@ impl Symbol {
             assert!(TYPEOF(sexp) == SEXPTYPE::SYMSXP);
         }
         Symbol {
-            robj: unsafe { Robj::from_sexp(sexp) },
+            robj: Robj::from_sexp(sexp),
         }
     }
 

--- a/extendr-api/tests/altrep_tests.rs
+++ b/extendr-api/tests/altrep_tests.rs
@@ -259,10 +259,7 @@ fn test_altlist() {
 
         impl AltListImpl for VecUsize {
             fn elt(&self, index: usize) -> Robj {
-                let mut v = Vec::with_capacity(1usize);
-                v.push(self.0[index]);
-                let v = v;
-
+                let v = vec![self.0[index]];
                 Self(v).into_robj()
             }
         }

--- a/extendr-api/tests/debug_tests.rs
+++ b/extendr-api/tests/debug_tests.rs
@@ -87,8 +87,8 @@ fn test_debug_scalar() {
             f64::INFINITY,
             f64::NEG_INFINITY,
             f64::NAN,
-            3.141592653589793,
-            -3.141592653589793,
+            4.141592653589793,
+            -4.141592653589793,
         ];
         for val in test_data {
             assert_eq!(format!("{:?}", Rfloat::from(val)), format!("{:?}", val));

--- a/extendr-api/tests/deserializer_tests.rs
+++ b/extendr-api/tests/deserializer_tests.rs
@@ -132,15 +132,15 @@ mod test {
             // The Deserialize trait for Robj can also be used to generate
             // JSON and other formats for Robj.
             #[derive(Deserialize, PartialEq, Debug)]
-            struct ROBJ(Robj);
-            assert_eq!(from_robj::<ROBJ>(&r!(TRUE)), Ok(ROBJ(r!(TRUE))));
-            assert_eq!(from_robj::<ROBJ>(&r!(1)), Ok(ROBJ(r!(1))));
-            assert_eq!(from_robj::<ROBJ>(&r!(1.0)), Ok(ROBJ(r!(1.0))));
-            assert_eq!(from_robj::<ROBJ>(&r!("xyz")), Ok(ROBJ(r!("xyz"))));
+            struct MyRobj(Robj);
+            assert_eq!(from_robj::<MyRobj>(&r!(TRUE)), Ok(MyRobj(r!(TRUE))));
+            assert_eq!(from_robj::<MyRobj>(&r!(1)), Ok(MyRobj(r!(1))));
+            assert_eq!(from_robj::<MyRobj>(&r!(1.0)), Ok(MyRobj(r!(1.0))));
+            assert_eq!(from_robj::<MyRobj>(&r!("xyz")), Ok(MyRobj(r!("xyz"))));
 
             // Sequences are always converted to lists.
-            assert_eq!(from_robj::<ROBJ>(&r!([TRUE, FALSE])), Ok(ROBJ(r!(list!(TRUE, FALSE)))));
-            assert_eq!(from_robj::<ROBJ>(&r!([1, 2])), Ok(ROBJ(r!(list!(1, 2)))));
+            assert_eq!(from_robj::<MyRobj>(&r!([TRUE, FALSE])), Ok(MyRobj(r!(list!(TRUE, FALSE)))));
+            assert_eq!(from_robj::<MyRobj>(&r!([1, 2])), Ok(MyRobj(r!(list!(1, 2)))));
 
             // If you use a wrapper type, conversions are more specific.
             #[derive(Deserialize, PartialEq, Debug)]

--- a/extendr-api/tests/deserializer_tests.rs
+++ b/extendr-api/tests/deserializer_tests.rs
@@ -171,4 +171,84 @@ mod test {
             // assert_eq!(from_robj::<RStrings>(&r!(0)).is_err(), true);
         }
     }
+
+    #[test]
+    fn test_deserialize_complex_named_list() {
+        use extendr_api::serializer::to_robj;
+        use serde::Serialize;
+        use std::collections::{HashMap, HashSet};
+
+        test! {
+            #[derive(Debug, PartialEq, Serialize, Deserialize)]
+            struct RunStartFile {
+                model: String,
+            }
+
+            #[derive(Debug, PartialEq, Serialize, Deserialize)]
+            struct OutputFileHash {
+                path: String,
+                hash: String,
+            }
+
+            #[derive(Debug, PartialEq, Serialize, Deserialize)]
+            struct RRunEndFile {
+                start: String,
+                end: String,
+                runtime_ms: f64,
+                files_copied: HashSet<String>,
+                output_files_rewrites: HashMap<String, String>,
+                output_files_hashes: Vec<OutputFileHash>,
+            }
+
+            #[derive(Debug, PartialEq, Serialize, Deserialize)]
+            struct ModelMetadata {
+                name: String,
+            }
+
+            #[derive(Debug, PartialEq, Serialize, Deserialize)]
+            struct RLineageTree {
+                nodes: HashMap<String, ModelMetadata>,
+                metadata: HashMap<String, (RunStartFile, Option<RRunEndFile>)>,
+            }
+
+            let mut files_copied = HashSet::new();
+            files_copied.insert("input.lst".to_string());
+
+            let mut output_files_rewrites = HashMap::new();
+            output_files_rewrites.insert("out.lst".to_string(), "rewritten.lst".to_string());
+
+            let end_file = RRunEndFile {
+                start: "2024-01-01T00:00:00Z".into(),
+                end: "2024-01-01T01:00:00Z".into(),
+                runtime_ms: 3600_000.0,
+                files_copied,
+                output_files_rewrites,
+                output_files_hashes: vec![OutputFileHash {
+                    path: "out.lst".into(),
+                    hash: "abc123".into(),
+                }],
+            };
+
+            let lineage = RLineageTree {
+                nodes: [("node_a".to_string(), ModelMetadata { name: "model_a".into() })]
+                    .into_iter()
+                    .collect(),
+                metadata: [(
+                    "node_a".to_string(),
+                    (
+                        RunStartFile {
+                            model: "model_a.mod".into(),
+                        },
+                        Some(end_file),
+                    ),
+                )]
+                .into_iter()
+                .collect(),
+            };
+
+            let robj = to_robj(&lineage)?;
+            let round_trip: RLineageTree = from_robj(&robj)?;
+            assert_eq!(lineage, round_trip);
+        }
+    }
 }

--- a/extendr-api/tests/extendr_macro.rs
+++ b/extendr-api/tests/extendr_macro.rs
@@ -19,29 +19,17 @@ fn test_i16(val: i16) -> i16 {
 
 #[extendr]
 fn test_option_i32(val: Option<i32>) -> i32 {
-    if let Some(i) = val {
-        i
-    } else {
-        -1
-    }
+    val.unwrap_or(-1)
 }
 
 #[extendr]
 fn test_option_f64(val: Option<f64>) -> f64 {
-    if let Some(i) = val {
-        i
-    } else {
-        -1.0
-    }
+    val.unwrap_or(-1f64)
 }
 
 #[extendr]
 fn test_option_i16(val: Option<i16>) -> i16 {
-    if let Some(i) = val {
-        i
-    } else {
-        -1
-    }
+    val.unwrap_or(-1i16)
 }
 
 #[extendr]

--- a/extendr-api/tests/graphics_tests.rs
+++ b/extendr-api/tests/graphics_tests.rs
@@ -94,8 +94,9 @@ mod graphics_tests {
                     assert!(("epilogue not found", false).1);
                 }
             } else {
-                std::thread::sleep(std::time::Duration::from_millis(2000));
-                assert!(false); // did we check in the flag as "false?"
+                // previous code was assert!(false)
+                // which always panics using unreachable instead
+                unreachable!("This shouldn't be reached?");
             }
         }
     }

--- a/extendr-api/tests/into_iterator_tests.rs
+++ b/extendr-api/tests/into_iterator_tests.rs
@@ -9,7 +9,7 @@ fn iterating_unamed_list() {
         assert_eq!(unamed_list.iter().len(), 5);
 
         let empty_strings = unamed_list.iter().map(|(si, _)| si).collect::<Strings>();
-        let na_strs = (0..5).into_iter().map(|_| Rstr::na()).collect::<Strings>();
+        let na_strs = (0..5).map(|_| Rstr::na()).collect::<Strings>();
         assert_eq!(empty_strings, na_strs);
 
         let unamed_list = List::from_values::<[i32; 0]>([]);

--- a/extendr-api/tests/ndarray_try_from_tests.rs
+++ b/extendr-api/tests/ndarray_try_from_tests.rs
@@ -74,7 +74,7 @@ mod ndarray_try_from_tests {
         test! {
              let robj = R!("matrix(c(1, 2, 3i, 4i, 5 + 5i, 6 - 6i), ncol = 2, nrow = 3, byrow = TRUE)")?;
 
-             let expected = vec![1, 2, 0, 0, 5, 6].iter().zip(vec![0, 0, 3, 4, 5, -6]).map(|(&re, im)| <c64>::new(re as f64, im as f64))
+             let expected = [1, 2, 0, 0, 5, 6].iter().zip(vec![0, 0, 3, 4, 5, -6]).map(|(&re, im)| <c64>::new(re as f64, im as f64))
              .collect::<Vec<_>>();
 
              let view = <ArrayView2<Rcplx>>::try_from(&robj)?;
@@ -161,7 +161,7 @@ mod ndarray_try_from_tests {
         test! {
              let robj = R!("matrix(c(1, 2, 3i, 4i, 5 + 5i, 6 - 6i), ncol = 1, nrow = 6)")?;
 
-             let expected = vec![1, 2, 0, 0, 5, 6].iter().zip(vec![0, 0, 3, 4, 5, -6]).map(|(&re, im)| <c64>::new(re as f64, im as f64))
+             let expected = [1, 2, 0, 0, 5, 6].iter().zip(vec![0, 0, 3, 4, 5, -6]).map(|(&re, im)| <c64>::new(re as f64, im as f64))
              .collect::<Vec<_>>();
 
              let view = <ArrayView1<Rcplx>>::try_from(&robj)?;

--- a/extendr-api/tests/non_api_tests.rs
+++ b/extendr-api/tests/non_api_tests.rs
@@ -1,15 +1,15 @@
 use extendr_api::prelude::*;
 use extendr_engine::with_r;
 
-#[cfg(test)]
+#[test]
 fn non_api_promise() {
     with_r(|| {
-        let special = r!(Primitive::from_string("if"));
-        let builtin = r!(Primitive::from_string("+"));
+        let _special = r!(Primitive::from_string("if"));
+        let _builtin = r!(Primitive::from_string("+"));
     });
 }
 
-#[cfg(test)]
+#[test]
 fn environment() {
     with_r(|| {
         let names_and_values = (0..100).map(|i| (format!("n{}", i), i));
@@ -38,7 +38,7 @@ fn environment() {
     });
 }
 
-#[cfg(test)]
+#[test]
 fn non_api_rinternals_promise() {
     with_r(|| {
         let iris_dataframe = global_env()
@@ -46,7 +46,7 @@ fn non_api_rinternals_promise() {
             .unwrap()
             .eval_promise()
             .unwrap();
-        assert_eq!(iris_dataframe.is_frame(), true);
+        assert!(iris_dataframe.is_frame());
         assert_eq!(iris_dataframe.len(), 5);
 
         // Note: this may crash on some versions of windows which don't support unwinding.
@@ -54,7 +54,7 @@ fn non_api_rinternals_promise() {
     });
 }
 
-#[cfg(test)]
+#[test]
 fn non_api_getsexp_rtype() {
     with_r(|| {
         assert_eq!(r!(Primitive::from_string("if")).rtype(), Rtype::Special);
@@ -62,35 +62,35 @@ fn non_api_getsexp_rtype() {
     });
 }
 
-#[cfg(test)]
+#[test]
 fn non_api_rmacros() {
     with_r(|| {
         // The "iris" dataset is a dataframe.
-        assert_eq!(global!(iris)?.is_frame(), true);
+        assert!(global!(iris).unwrap().is_frame());
     });
 }
 
 /// In `extendr-api/lib.rs` there was a section with this
 ///
 /// > You can call R functions and primitives using the [call!] macro.
-#[cfg(test)]
-fn non_api_lib_README() {
+#[test]
+fn non_api_lib_readme() {
     with_r(|| {
         // As one R! macro call
-        let confint1 = R!("confint(lm(weight ~ group - 1, PlantGrowth))")?;
+        let confint1 = R!("confint(lm(weight ~ group - 1, PlantGrowth))").unwrap();
 
         // As many parameterized calls.
         let mut formula = lang!("~", sym!(weight), lang!("-", sym!(group), 1.0));
-        formula.set_class(["formula"])?;
-        let plant_growth = global!(PlantGrowth)?;
-        let model = call!("lm", formula, plant_growth)?;
-        let confint2 = call!("confint", model)?;
+        formula.set_class(["formula"]).unwrap();
+        let plant_growth = global!(PlantGrowth).unwrap();
+        let model = call!("lm", formula, plant_growth).unwrap();
+        let confint2 = call!("confint", model).unwrap();
 
         assert_eq!(confint1.as_real_vector(), confint2.as_real_vector());
     });
 }
 
-#[cfg(test)]
+#[test]
 fn non_api_base_env() {
     with_r(|| {
         global_env().set_local(sym!(x), "hello");

--- a/extendr-api/tests/rng_tests.rs
+++ b/extendr-api/tests/rng_tests.rs
@@ -7,9 +7,9 @@
 //! These tests has to check two things:
 //!
 //! * That the seed is set and affects the sampling functions on the rust-side
-//! in the same way, as on the r-side.
+//!   in the same way, as on the r-side.
 //! * That the resulting sampled vector is not equal 0, as it would be that
-//! if `GetRNGstate()` is not called prior to sampling.
+//!   if `GetRNGstate()` is not called prior to sampling.
 //!
 //!
 use extendr_api::prelude::*;

--- a/extendr-api/tests/scalar_ordering_tests.rs
+++ b/extendr-api/tests/scalar_ordering_tests.rs
@@ -201,9 +201,11 @@ where
 
 #[test]
 fn collection_sort_bool() {
-    let raw = vec![true, false, true, false, true];
-    let ordered = vec![false, false, true, true, true];
+    let raw = [true, false, true, false, true];
+    let ordered = [false, false, true, true, true];
     let mut scalars: Vec<Rbool> = raw.iter().map(|&x| x.into()).collect();
     scalars.sort_by(|a, b| a.partial_cmp(b).unwrap());
-    assert!(ordered.eq(&scalars));
+    for (xi, yi) in ordered.iter().zip(scalars.iter()) {
+        assert_eq!(*xi, yi.to_bool());
+    }
 }

--- a/extendr-api/tests/scalar_tests.rs
+++ b/extendr-api/tests/scalar_tests.rs
@@ -256,11 +256,11 @@ fn test_rcplx() {
         assert_eq!(a / b, Rcplx::from(2.));
         assert_eq!(-a, Rcplx::from(-20.));
 
-        assert_eq!(&a + b, Rcplx::from(30.));
-        assert_eq!(&a - b, Rcplx::from(10.));
-        assert_eq!(&a * b, Rcplx::from(200.));
-        assert_eq!(&a / b, Rcplx::from(2.));
-        assert_eq!(-&a, Rcplx::from(-20.));
+        assert_eq!(a + b, Rcplx::from(30.));
+        assert_eq!(a - b, Rcplx::from(10.));
+        assert_eq!(a * b, Rcplx::from(200.));
+        assert_eq!(a / b, Rcplx::from(2.));
+        assert_eq!(-a, Rcplx::from(-20.));
 
         assert!(Rcplx::na().is_na());
 

--- a/extendr-api/tests/serializer_tests.rs
+++ b/extendr-api/tests/serializer_tests.rs
@@ -59,13 +59,13 @@ mod test {
             struct Null(Robj);
             let s = Null(r!(NULL));
             let expected = r!(NULL);
-            assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+            assert_eq!(to_robj(&s).unwrap(), expected);
 
             #[derive(Serialize)]
             struct Sym(Symbol);
             let s = Sym(sym!(xyz).try_into()?);
             let expected = r!("xyz");
-            assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+            assert_eq!(to_robj(&s).unwrap(), expected);
 
             #[derive(Serialize)]
             struct Plist(Pairlist);
@@ -77,25 +77,25 @@ mod test {
             struct Rstr1(Rstr);
             let s = Rstr1(Rstr::from("xyz"));
             let expected = r!("xyz");
-            assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+            assert_eq!(to_robj(&s).unwrap(), expected);
 
             #[derive(Serialize)]
             struct Int(Integers);
             let s = Int(Integers::from_values([1]));
             let expected = r!(1);
-            assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+            assert_eq!(to_robj(&s).unwrap(), expected);
 
             #[derive(Serialize)]
             struct Int2(Integers);
             let s = Int2(Integers::from_values([1, 2]));
             let expected = r!(list![1, 2]);
-            assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+            assert_eq!(to_robj(&s).unwrap(), expected);
 
             #[derive(Serialize)]
             struct Dbl2(Doubles);
             let s = Dbl2(Doubles::from_values([1.0, 2.0]));
             let expected = r!(list![1.0, 2.0]);
-            assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+            assert_eq!(to_robj(&s).unwrap(), expected);
 
             // BUG! Will probably be fixed by "better-debug"
             //
@@ -115,43 +115,43 @@ mod test {
             struct Raw1(Raw);
             let s = Raw1(Raw::from_bytes(&[1, 2, 3]));
             let expected = r!(Raw::from_bytes(&[1, 2, 3]));
-            assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+            assert_eq!(to_robj(&s).unwrap(), expected);
 
             #[derive(Serialize)]
             struct Rint1(Rint);
             let s = Rint1(Rint::from(1));
             let expected = r!(1);
-            assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+            assert_eq!(to_robj(&s).unwrap(), expected);
 
             #[derive(Serialize)]
             struct Rint2(Rint);
             let s = Rint2(Rint::na());
             let expected = r!(());
-            assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+            assert_eq!(to_robj(&s).unwrap(), expected);
 
             #[derive(Serialize)]
             struct Rfloat1(Rfloat);
             let s = Rfloat1(Rfloat::from(1.0));
             let expected = r!(1.0);
-            assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+            assert_eq!(to_robj(&s).unwrap(), expected);
 
             #[derive(Serialize)]
             struct Rfloat2(Rfloat);
             let s = Rfloat2(Rfloat::na());
             let expected = r!(());
-            assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+            assert_eq!(to_robj(&s).unwrap(), expected);
 
             #[derive(Serialize)]
             struct Rbool1(Rbool);
             let s = Rbool1(Rbool::from(true));
             let expected = r!(true);
-            assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+            assert_eq!(to_robj(&s).unwrap(), expected);
 
             #[derive(Serialize)]
             struct Rbool2(Rbool);
             let s = Rbool2(Rbool::na());
             let expected = r!(());
-            assert_eq!(to_robj(&s).unwrap(), Robj::from(expected));
+            assert_eq!(to_robj(&s).unwrap(), expected);
         }
     }
 }

--- a/extendr-api/tests/vector_tests.rs
+++ b/extendr-api/tests/vector_tests.rs
@@ -314,7 +314,7 @@ mod num_complex {
     fn iter_mut() {
         test! {
             let mut vec = Complexes::from_values([0.0, 1.0, 2.0, 3.0]);
-            vec.iter_mut().for_each(|v| *v = *v + Rcplx::from(1.0));
+            vec.iter_mut().for_each(|v| *v += Rcplx::from(1.0));
             assert_eq!(vec, Complexes::from_values([1.0, 2.0, 3.0, 4.0]));
         }
     }

--- a/extendr-engine/Cargo.toml
+++ b/extendr-engine/Cargo.toml
@@ -4,6 +4,7 @@ description = "Safe and user friendly bindings to the R programming language."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 

--- a/extendr-ffi/Cargo.toml
+++ b/extendr-ffi/Cargo.toml
@@ -4,6 +4,7 @@ description = "Barebone bindings to `libR` for use in extendr."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 links = "R"

--- a/extendr-ffi/README.md
+++ b/extendr-ffi/README.md
@@ -5,3 +5,49 @@
 ## Motivation
 
 extendr has historically relied on [libR-sys](https://github.com/extendr/libR-sys) to interface with R's C API. As R has moved towards standardizing and stabilizing the C API, relying on libR-sys' generated bindings has presented challenges. Among them are that the bindings are cumbersome to generate, platform specific, and does not provide backports to address the maturing R C API.
+
+## Creating backports
+
+As R's C API moves into stabilization, many macros and functions that we previously used are being moved to **non-API** status. This means the use of them will create a NOTE or WARNING during `R CMD check`. To address this, we create **backports**.
+
+To create a backport: 
+
+- Ensure there is a version `cfg` flag in `extendr-ffi/build.rs`
+- Move now non-API C binding to `src/backports.rs`'s `extern "C"` block
+- Add `#[cfg(not(r_maj_min))]` to old function
+- Add new replaced function with `#[cfg(r_maj_min)]`
+- Create a new inline function to be used in `extendr-api`
+- Replace old function calls in `extendr-api` with new backport
+
+For example, in R 4.5 `Rf_isFrame` is replaced by `Rf_isDataFrame`.
+In `backports.rs`
+
+```
+extern "C" {
+    // all the other backports...
+    
+    #[cfg(not(r_4_5))]
+    fn Rf_isFrame(x: SEXP) -> Rboolean;
+
+    #[cfg(r_4_5)]
+    fn Rf_isDataFrame(x: SEXP) -> Rboolean;
+}
+
+/// Check is data.frame
+///
+/// # Safety
+///
+/// This function dereferences a raw SEXP pointer.
+/// The caller must ensure that `x` is a valid SEXP pointer.
+#[inline]
+pub unsafe fn is_data_frame(x: SEXP) -> Rboolean {
+    #[cfg(not(r_4_5))]
+    {
+        Rf_isFrame(x)
+    }
+    #[cfg(r_4_5)]
+    {
+        Rf_isDataFrame(x)
+    }
+}
+```

--- a/extendr-ffi/build.rs
+++ b/extendr-ffi/build.rs
@@ -114,7 +114,7 @@ impl Version {
             }
         };
 
-        let r_ver = read_r_ver(&Path::new(&include_dir))?;
+        let r_ver = read_r_ver(Path::new(&include_dir))?;
 
         Ok(r_ver)
     }

--- a/extendr-ffi/build.rs
+++ b/extendr-ffi/build.rs
@@ -166,6 +166,43 @@ impl InstallationPaths {
     }
 }
 
+/// Emits the R-version-derived build flags: the `rustc-cfg` flags consumed by
+/// this crate and the `DEP_R_R_VERSION_*` exports consumed by dependents such
+/// as extendr-api. Both the detected-R path and the no-R fallback go through
+/// here so the two can never disagree.
+fn emit_r_version_flags(version: &Version) {
+    // used by extendr-api
+    println!("cargo:r_version_major={}", version.major);
+    println!("cargo:r_version_minor={}", version.minor);
+    println!("cargo:r_version_patch={}", version.patch);
+
+    // Set R version specfic config flags
+    // use r_4_4 config
+    if (version.major, version.minor) >= (4, 4) {
+        println!("cargo:rustc-cfg=r_4_4")
+    }
+
+    // use r_4_5 config
+    if (version.major, version.minor) >= (4, 5) {
+        println!("cargo:rustc-cfg=r_4_5")
+    }
+
+    // Graphics engine version 15 was introduced in R 4.2
+    if (version.major, version.minor) >= (4, 2) {
+        println!("cargo:rustc-cfg=use_r_ge_version_15")
+    }
+
+    // Graphics engine version 16 was introduced in R 4.3
+    if (version.major, version.minor) >= (4, 3) {
+        println!("cargo:rustc-cfg=use_r_ge_version_16")
+    }
+
+    // Graphics engine version 17 was introduced in R 4.6
+    if (version.major, version.minor) >= (4, 6) {
+        println!("cargo:rustc-cfg=use_r_ge_version_17")
+    }
+}
+
 fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rustc-check-cfg=cfg(r_4_4)");
     println!("cargo:rustc-check-cfg=cfg(r_4_5)");
@@ -177,11 +214,18 @@ fn main() -> Result<(), Box<dyn Error>> {
     let r_paths = match InstallationPaths::try_new() {
         Ok(v) => v,
         Err(_) => {
-            warn!("Cannot fetch R version from R. Defaulting to most recent configure flag");
-            println!("cargo:rustc-cfg=r_4_5");
-            println!("cargo:r_version_major=4");
-            println!("cargo:r_version_minor=5");
-            println!("cargo:r_version_patch=1");
+            warn!("Cannot fetch R version from R. Defaulting to the newest known R version");
+            // Without a detected R there is nothing to link against, so this
+            // build only serves type-checking surfaces (docs.rs, rust-analyzer,
+            // clippy CI). Default to the newest R version this build script
+            // knows about, so every version-gated API is enabled rather than
+            // an arbitrary older subset. Bump this together with any new
+            // version flag added to emit_r_version_flags.
+            emit_r_version_flags(&Version {
+                major: 4,
+                minor: 6,
+                patch: 0,
+            });
             return Ok(());
         }
     };
@@ -190,10 +234,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:r_home={}", r_paths.r_home.display());
     println!("cargo:rustc-env=R_HOME={}", r_paths.r_home.display());
 
-    // used by extendr-api
-    println!("cargo:r_version_major={}", r_paths.version.major);
-    println!("cargo:r_version_minor={}", r_paths.version.minor);
-    println!("cargo:r_version_patch={}", r_paths.version.patch);
+    emit_r_version_flags(&r_paths.version);
 
     let pkg_target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
 
@@ -216,32 +257,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     println!("cargo:rustc-link-lib=dylib=R");
-
-    // Set R version specfic config flags
-    // use r_4_4 config
-    if (r_paths.version.major, r_paths.version.minor) >= (4, 4) {
-        println!("cargo:rustc-cfg=r_4_4")
-    }
-
-    // use r_4_5 config
-    if (r_paths.version.major, r_paths.version.minor) >= (4, 5) {
-        println!("cargo:rustc-cfg=r_4_5")
-    }
-
-    // Graphics engine version 15 was introduced in R 4.2
-    if (r_paths.version.major, r_paths.version.minor) >= (4, 2) {
-        println!("cargo:rustc-cfg=use_r_ge_version_15")
-    }
-
-    // Graphics engine version 16 was introduced in R 4.3
-    if (r_paths.version.major, r_paths.version.minor) >= (4, 3) {
-        println!("cargo:rustc-cfg=use_r_ge_version_16")
-    }
-
-    // Graphics engine version 17 was introduced in R 4.6
-    if (r_paths.version.major, r_paths.version.minor) >= (4, 6) {
-        println!("cargo:rustc-cfg=use_r_ge_version_17")
-    }
 
     // Only re-run if the include directory changes
     println!("cargo:rerun-if-env-changed=R_INCLUDE_DIR");

--- a/extendr-ffi/build.rs
+++ b/extendr-ffi/build.rs
@@ -169,6 +169,9 @@ impl InstallationPaths {
 fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rustc-check-cfg=cfg(r_4_4)");
     println!("cargo:rustc-check-cfg=cfg(r_4_5)");
+    println!("cargo:rustc-check-cfg=cfg(use_r_ge_version_15)");
+    println!("cargo:rustc-check-cfg=cfg(use_r_ge_version_16)");
+    println!("cargo:rustc-check-cfg=cfg(use_r_ge_version_17)");
 
     // Fetch R_HOME and R version
     let r_paths = match InstallationPaths::try_new() {
@@ -223,6 +226,21 @@ fn main() -> Result<(), Box<dyn Error>> {
     // use r_4_5 config
     if (r_paths.version.major, r_paths.version.minor) >= (4, 5) {
         println!("cargo:rustc-cfg=r_4_5")
+    }
+
+    // Graphics engine version 15 was introduced in R 4.2
+    if (r_paths.version.major, r_paths.version.minor) >= (4, 2) {
+        println!("cargo:rustc-cfg=use_r_ge_version_15")
+    }
+
+    // Graphics engine version 16 was introduced in R 4.3
+    if (r_paths.version.major, r_paths.version.minor) >= (4, 3) {
+        println!("cargo:rustc-cfg=use_r_ge_version_16")
+    }
+
+    // Graphics engine version 17 was introduced in R 4.6
+    if (r_paths.version.major, r_paths.version.minor) >= (4, 6) {
+        println!("cargo:rustc-cfg=use_r_ge_version_17")
     }
 
     // Only re-run if the include directory changes

--- a/extendr-ffi/build.rs
+++ b/extendr-ffi/build.rs
@@ -198,6 +198,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         // For Windows
         (true, "x86_64") => Path::new(&r_paths.r_home).join("bin").join("x64"),
         (true, "x86") => Path::new(&r_paths.r_home).join("bin").join("i386"),
+        (true, "aarch64") => Path::new(&r_paths.r_home).join("bin"),
         (true, _) => {
             return Err("Cannot build extendr-ffi for unknown architecture".into());
         }

--- a/extendr-ffi/src/backports.rs
+++ b/extendr-ffi/src/backports.rs
@@ -56,6 +56,11 @@ extern "C" {
 }
 
 /// Returns the enclosing environment of env, which will usually be of type ENVSXP, except for the special environment R_EmptyEnv, which terminates the environment chain; its enclosing environment is R_NilValue.
+///
+/// # Safety
+///
+/// This function dereferences a raw SEXP pointer.
+/// The caller must ensure that `x` is a valid SEXP pointer to an environment.
 #[inline]
 pub unsafe fn get_parent_env(x: SEXP) -> SEXP {
     #[cfg(not(r_4_5))]
@@ -69,6 +74,11 @@ pub unsafe fn get_parent_env(x: SEXP) -> SEXP {
 }
 
 /// Returns a variable from an environment
+///
+/// # Safety
+///
+/// This function dereferences raw SEXP pointers.
+/// The caller must ensure that `symbol` and `env` are valid SEXP pointers.
 #[inline]
 pub unsafe fn get_var(symbol: SEXP, env: SEXP) -> SEXP {
     #[cfg(not(r_4_5))]
@@ -82,6 +92,11 @@ pub unsafe fn get_var(symbol: SEXP, env: SEXP) -> SEXP {
 }
 
 /// Returns the value of the requested variable in an environment
+///
+/// # Safety
+///
+/// This function dereferences raw SEXP pointers.
+/// The caller must ensure that `symbol` and `env` are valid SEXP pointers.
 #[inline]
 pub unsafe fn get_var_in_frame(symbol: SEXP, env: SEXP) -> SEXP {
     #[cfg(not(r_4_5))]
@@ -95,6 +110,11 @@ pub unsafe fn get_var_in_frame(symbol: SEXP, env: SEXP) -> SEXP {
 }
 
 /// Return the environment of a closure
+///
+/// # Safety
+///
+/// This function dereferences a raw SEXP pointer.
+/// The caller must ensure that `x` is a valid SEXP pointer to a closure.
 #[inline]
 pub unsafe fn get_closure_env(x: SEXP) -> SEXP {
     #[cfg(not(r_4_5))]
@@ -108,6 +128,11 @@ pub unsafe fn get_closure_env(x: SEXP) -> SEXP {
 }
 
 /// Return the body of a closure
+///
+/// # Safety
+///
+/// This function dereferences a raw SEXP pointer.
+/// The caller must ensure that `x` is a valid SEXP pointer to a closure.
 #[inline]
 pub unsafe fn get_closure_body(x: SEXP) -> SEXP {
     #[cfg(not(r_4_5))]
@@ -121,6 +146,11 @@ pub unsafe fn get_closure_body(x: SEXP) -> SEXP {
 }
 
 /// Access a closure's arguments
+///
+/// # Safety
+///
+/// This function dereferences a raw SEXP pointer.
+/// The caller must ensure that `x` is a valid SEXP pointer to a closure.
 #[inline]
 pub unsafe fn get_closure_formals(x: SEXP) -> SEXP {
     #[cfg(not(r_4_5))]
@@ -134,6 +164,11 @@ pub unsafe fn get_closure_formals(x: SEXP) -> SEXP {
 }
 
 /// Access a DATAPTR
+///
+/// # Safety
+///
+/// This function dereferences a raw SEXP pointer.
+/// The caller must ensure that `x` is a valid SEXP pointer.
 #[inline]
 pub unsafe fn dataptr(x: SEXP) -> *const ::std::os::raw::c_void {
     #[cfg(not(r_4_5))]

--- a/extendr-ffi/src/backports.rs
+++ b/extendr-ffi/src/backports.rs
@@ -9,8 +9,8 @@
 // R 4.5 backports notes saved in wayback machine here:
 // https://web.archive.org/web/20250325171443/https://rstudio.github.io/r-manuals/r-exts/The-R-API.html#moving-into-c-api-compliance
 
-use crate::SEXP;
-// In your extern "C" block:
+use crate::{Rboolean, SEXP};
+
 extern "C" {
     #[cfg(not(r_4_5))]
     fn ENCLOS(x: SEXP) -> SEXP;
@@ -53,6 +53,12 @@ extern "C" {
 
     #[cfg(r_4_5)]
     fn DATAPTR_RO(x: SEXP) -> *const ::std::os::raw::c_void;
+
+    #[cfg(not(r_4_5))]
+    fn Rf_isFrame(x: SEXP) -> Rboolean;
+
+    #[cfg(r_4_5)]
+    fn Rf_isDataFrame(x: SEXP) -> Rboolean;
 }
 
 /// Returns the enclosing environment of env, which will usually be of type ENVSXP, except for the special environment R_EmptyEnv, which terminates the environment chain; its enclosing environment is R_NilValue.
@@ -178,5 +184,23 @@ pub unsafe fn dataptr(x: SEXP) -> *const ::std::os::raw::c_void {
     #[cfg(r_4_5)]
     {
         DATAPTR_RO(x)
+    }
+}
+
+/// Check is data.frame
+///
+/// # Safety
+///
+/// This function dereferences a raw SEXP pointer.
+/// The caller must ensure that `x` is a valid SEXP pointer.
+#[inline]
+pub unsafe fn is_data_frame(x: SEXP) -> Rboolean {
+    #[cfg(not(r_4_5))]
+    {
+        Rf_isFrame(x)
+    }
+    #[cfg(r_4_5)]
+    {
+        Rf_isDataFrame(x)
     }
 }

--- a/extendr-ffi/src/graphics.rs
+++ b/extendr-ffi/src/graphics.rs
@@ -1,7 +1,14 @@
 //! Graphics Engine support
 use super::*;
 
+#[cfg(use_r_ge_version_17)]
+pub const R_GE_version: u32 = 17;
+
+#[cfg(all(use_r_ge_version_16, not(use_r_ge_version_17)))]
 pub const R_GE_version: u32 = 16;
+
+#[cfg(all(not(use_r_ge_version_16), not(use_r_ge_version_17)))]
+pub const R_GE_version: u32 = 15;
 // Types
 pub type DevDesc = _DevDesc;
 pub type pDevDesc = *mut DevDesc;

--- a/extendr-ffi/src/graphics.rs
+++ b/extendr-ffi/src/graphics.rs
@@ -398,7 +398,11 @@ extern "C" {
     pub fn GEaddDevice2(arg1: pGEDevDesc, arg2: *const ::std::os::raw::c_char);
     pub fn GECap(dd: pGEDevDesc) -> SEXP;
     pub fn GECircle(x: f64, y: f64, radius: f64, gc: pGEcontext, dd: pGEDevDesc);
+    #[cfg(use_r_ge_version_17)]
+    pub fn GEcreateDD() -> pDevDesc;
     pub fn GEcreateDevDesc(dev: pDevDesc) -> pGEDevDesc;
+    #[cfg(use_r_ge_version_17)]
+    pub fn GEfreeDD(dd: pDevDesc);
     pub fn GEcurrentDevice() -> pGEDevDesc;
     pub fn GEdeviceNumber(arg1: pGEDevDesc) -> ::std::os::raw::c_int;
     pub fn GEExpressionHeight(expr: SEXP, gc: pGEcontext, dd: pGEDevDesc) -> f64;

--- a/extendr-ffi/src/lib.rs
+++ b/extendr-ffi/src/lib.rs
@@ -462,6 +462,10 @@ extern "C" {
 
 }
 
+/// # Safety
+///
+/// This function dereferences a raw SEXP pointer.
+/// The caller must ensure that `x` is a valid SEXP.
 pub unsafe fn Rf_isS4(arg1: SEXP) -> Rboolean {
     unsafe {
         if secret::Rf_isS4_original(arg1) == 0 {

--- a/extendr-ffi/src/lib.rs
+++ b/extendr-ffi/src/lib.rs
@@ -397,7 +397,6 @@ extern "C" {
     pub fn Rf_isEnvironment(s: SEXP) -> Rboolean;
     pub fn Rf_isExpression(s: SEXP) -> Rboolean;
     pub fn Rf_isFactor(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isFrame(arg1: SEXP) -> Rboolean;
     pub fn Rf_isFunction(arg1: SEXP) -> Rboolean;
     pub fn Rf_isInteger(arg1: SEXP) -> Rboolean;
     pub fn Rf_isLanguage(arg1: SEXP) -> Rboolean;

--- a/extendr-ffi/src/lib.rs
+++ b/extendr-ffi/src/lib.rs
@@ -15,6 +15,20 @@ pub use symbols::*;
 pub mod backports;
 pub use backports::*;
 
+/// Check if an object is a data.frame.
+///
+/// Kept on the 0.8 line for backwards compatibility; prefer [`is_data_frame`],
+/// which stays within the current R API on all R versions.
+///
+/// # Safety
+///
+/// This function dereferences a raw SEXP pointer.
+/// The caller must ensure that `arg1` is a valid SEXP pointer.
+#[allow(non_snake_case)]
+pub unsafe extern "C" fn Rf_isFrame(arg1: SEXP) -> Rboolean {
+    is_data_frame(arg1)
+}
+
 #[cfg(feature = "non-api")]
 mod non_api;
 #[cfg(feature = "non-api")]

--- a/extendr-ffi/src/non_api.rs
+++ b/extendr-ffi/src/non_api.rs
@@ -1,8 +1,6 @@
 // Functions used by the non-api feature of extendr
 use crate::{Rboolean, SEXP, SEXPTYPE};
 extern "C" {
-    #[doc = "Unbound marker"]
-    pub static R_UnboundValue: SEXP;
     pub fn Rf_isValidString(arg1: SEXP) -> Rboolean;
     pub fn Rf_isValidStringF(arg1: SEXP) -> Rboolean;
     pub fn SYMVALUE(x: SEXP) -> SEXP;

--- a/extendr-macros/Cargo.toml
+++ b/extendr-macros/Cargo.toml
@@ -4,6 +4,7 @@ description = "Generate bindings from R to Rust."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 

--- a/extendr-macros/src/lib.rs
+++ b/extendr-macros/src/lib.rs
@@ -376,7 +376,7 @@ pub fn impl_try_from_robj_tuples(input: TokenStream) -> TokenStream {
                     if robj.is_null() || robj.is_na() {
                         Ok(None)
                     } else {
-                        Ok(Some(<(#(#types,)*)>::try_from(robj)?))
+                        <(#(#types,)*)>::try_from(robj).map(Some)
                     }
                 }
             }

--- a/extendr-macros/src/wrappers.rs
+++ b/extendr-macros/src/wrappers.rs
@@ -138,22 +138,24 @@ pub(crate) fn make_function_wrappers(
     //     }
     // }
     // ```
-    let rng_start = opts
-        .use_rng
-        .then(|| {
+    let rng_start = if opts.use_rng {
+        {
             quote!(single_threaded(|| unsafe {
                 extendr_api::GetRNGstate();
             });)
-        })
-        .unwrap_or_default();
-    let rng_end = opts
-        .use_rng
-        .then(|| {
+        }
+    } else {
+        Default::default()
+    };
+    let rng_end = if opts.use_rng {
+        {
             quote!(single_threaded(|| unsafe {
                 extendr_api::PutRNGstate();
             });)
-        })
-        .unwrap_or_default();
+        }
+    } else {
+        Default::default()
+    };
 
     // figure out if
     // -> &Self

--- a/extendr-macros/src/wrappers.rs
+++ b/extendr-macros/src/wrappers.rs
@@ -246,18 +246,17 @@ pub(crate) fn make_function_wrappers(
                 }
                 // any panic (induced by user func code or if user func yields a Result-Err as return value)
                 Err(unwind_err) => {
-                    drop(unwind_err); //did not notice any difference if dropped or not.
-                    // It should be possible to downcast the unwind_err Any type to the error
-                    // included in panic. The advantage would be the panic cause could be included
-                    // in the R terminal error message and not only via std-err.
-                    // but it should be handled in a separate function and not in-lined here.
-                    let err_string = format!("User function panicked: {}", #r_name_str);
-                    // cannot use throw_r_error here for some reason.
-                    // handle_panic() exports err string differently than throw_r_error.
-                    extendr_api::handle_panic(err_string.as_str(), || panic!());
+                    let panic_msg = if let Some(s) = unwind_err.downcast_ref::<&str>() {
+                        (*s).to_string()
+                    } else if let Some(s) = unwind_err.downcast_ref::<String>() {
+                        s.clone()
+                    } else {
+                        format!("User function panicked: {}", #r_name_str)
+                    };
+
+                    extendr_api::throw_r_error(&panic_msg);
                 }
             }
-            unreachable!("internal extendr error, this should never happen.")
         }
     ));
 

--- a/extendr-macros/tests/cases/case-extendr-macro.stderr
+++ b/extendr-macros/tests/cases/case-extendr-macro.stderr
@@ -1,3 +1,23 @@
+error: inherent impls cannot be default
+  --> tests/cases/case-extendr-macro.rs:31:14
+   |
+31 | default impl FooStruct {}
+   | -------      ^^^^^^^^^ inherent impl for this type
+   | |
+   | default because of this
+   |
+   = note: only trait implementations may be annotated with `default`
+
+error[E0197]: inherent impls cannot be unsafe
+  --> tests/cases/case-extendr-macro.rs:34:13
+   |
+34 | unsafe impl FooStruct {}
+   | ------      ^^^^^^^^^ inherent impl for this type
+   | |
+   | unsafe because of this
+   |
+   = note: only trait implementations may be annotated with `unsafe`
+
 error: Unexpected key
  --> tests/cases/case-extendr-macro.rs:4:11
   |

--- a/tests/extendrtests/R/extendr-wrappers.R
+++ b/tests/extendrtests/R/extendr-wrappers.R
@@ -90,6 +90,18 @@ test_derive_into_dataframe <- function() .Call(wrap__test_derive_into_dataframe)
 
 test_into_robj_dataframe <- function() .Call(wrap__test_into_robj_dataframe)
 
+error_simple <- function() invisible(.Call(wrap__error_simple))
+
+error_parse_int <- function(s) invisible(.Call(wrap__error_parse_int, s))
+
+error_success <- function() invisible(.Call(wrap__error_success))
+
+error_division <- function(numerator, denominator) invisible(.Call(wrap__error_division, numerator, denominator))
+
+error_chain <- function(s) invisible(.Call(wrap__error_chain, s))
+
+error_long_message <- function() invisible(.Call(wrap__error_long_message))
+
 test_hm_string <- function(x) .Call(wrap__test_hm_string, x)
 
 test_hm_i32 <- function(x) .Call(wrap__test_hm_i32, x)

--- a/tests/extendrtests/R/extendr-wrappers.R
+++ b/tests/extendrtests/R/extendr-wrappers.R
@@ -102,6 +102,8 @@ error_chain <- function(s) invisible(.Call(wrap__error_chain, s))
 
 error_long_message <- function() invisible(.Call(wrap__error_long_message))
 
+error_on_panic <- function() invisible(.Call(wrap__error_on_panic))
+
 test_hm_string <- function(x) .Call(wrap__test_hm_string, x)
 
 test_hm_i32 <- function(x) .Call(wrap__test_hm_i32, x)

--- a/tests/extendrtests/R/extendr-wrappers.R
+++ b/tests/extendrtests/R/extendr-wrappers.R
@@ -104,6 +104,8 @@ error_long_message <- function() invisible(.Call(wrap__error_long_message))
 
 error_on_panic <- function() invisible(.Call(wrap__error_on_panic))
 
+error_anyhow <- function() invisible(.Call(wrap__error_anyhow))
+
 test_hm_string <- function(x) .Call(wrap__test_hm_string, x)
 
 test_hm_i32 <- function(x) .Call(wrap__test_hm_i32, x)

--- a/tests/extendrtests/src/entrypoint.c
+++ b/tests/extendrtests/src/entrypoint.c
@@ -2,7 +2,10 @@
 // to avoid the linker removing the static library.
 
 void R_init_extendrtests_extendr(void *dll);
+void register_extendr_panic_hook(void);
 
 void R_init_extendrtests(void *dll) {
+  register_extendr_panic_hook();
+
   R_init_extendrtests_extendr(dll);
 }

--- a/tests/extendrtests/src/rust/Cargo.toml
+++ b/tests/extendrtests/src/rust/Cargo.toml
@@ -23,6 +23,7 @@ graphics = []
 ndarray = []
 
 [dependencies]
+anyhow = "1"
 extendr-api = { version = "*", features = [
     "graphics",
     "ndarray",

--- a/tests/extendrtests/src/rust/build.rs
+++ b/tests/extendrtests/src/rust/build.rs
@@ -1,8 +1,9 @@
 use std::path::PathBuf;
 
 fn main() {
+    println!("cargo:rustc-check-cfg=cfg(use_r_altlist)");
     println!("cargo:rerun-if-env-changed=R_HOME");
-    println!("cargo::rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=build.rs");
 
     let r_home_env = std::env::var_os("R_HOME");
     let r_home_env = r_home_env.map(PathBuf::from);

--- a/tests/extendrtests/src/rust/src/errors.rs
+++ b/tests/extendrtests/src/rust/src/errors.rs
@@ -48,6 +48,11 @@ fn error_long_message() -> Result<()> {
     ))
 }
 
+#[extendr]
+fn error_on_panic() {
+    panic!("this does circumvents the hook mechanism");
+}
+
 extendr_module! {
     mod errors;
     fn error_simple;
@@ -56,4 +61,5 @@ extendr_module! {
     fn error_division;
     fn error_chain;
     fn error_long_message;
+    fn error_on_panic;
 }

--- a/tests/extendrtests/src/rust/src/errors.rs
+++ b/tests/extendrtests/src/rust/src/errors.rs
@@ -1,0 +1,59 @@
+use extendr_api::prelude::*;
+
+#[extendr]
+fn error_simple() -> Result<i32> {
+    Err(Error::Other("This is a simple error message".to_string()))
+}
+
+#[extendr]
+fn error_parse_int(s: &str) -> Result<i32> {
+    let parsed: i32 = s.parse().map_err(|e| Error::Other(format!("{e}")))?;
+    Ok(parsed)
+}
+
+#[extendr]
+fn error_success() -> Result<i32> {
+    Ok(42)
+}
+
+#[extendr]
+fn error_division(numerator: f64, denominator: f64) -> Result<f64> {
+    if denominator == 0.0 {
+        Err(Error::Other("Division by zero is not allowed".to_string()))
+    } else {
+        Ok(numerator / denominator)
+    }
+}
+
+// this function illustrates that we can chain errors together and not get a panic
+#[extendr]
+fn error_chain(s: &str) -> Result<f64> {
+    let num: i32 = s
+        .parse()
+        .map_err(|e| Error::Other(format!("Parse error: {}", e)))?;
+    if num < 0 {
+        Err(Error::Other("Negative numbers not allowed".to_string()))
+    } else {
+        Ok(num as f64)
+    }
+}
+
+#[extendr]
+fn error_long_message() -> Result<()> {
+    Err(Error::Other(
+        "This is a longer error message that describes in detail what went wrong. \
+         It includes multiple sentences and provides context about the failure. \
+         This helps test how longer error messages are displayed to users."
+            .to_string(),
+    ))
+}
+
+extendr_module! {
+    mod errors;
+    fn error_simple;
+    fn error_parse_int;
+    fn error_success;
+    fn error_division;
+    fn error_chain;
+    fn error_long_message;
+}

--- a/tests/extendrtests/src/rust/src/errors.rs
+++ b/tests/extendrtests/src/rust/src/errors.rs
@@ -1,3 +1,4 @@
+use anyhow::bail;
 use extendr_api::prelude::*;
 
 #[extendr]
@@ -53,6 +54,11 @@ fn error_on_panic() {
     panic!("this does circumvents the hook mechanism");
 }
 
+#[extendr]
+fn error_anyhow() -> anyhow::Result<()> {
+    bail!("This is an anyhow error");
+}
+
 extendr_module! {
     mod errors;
     fn error_simple;
@@ -62,4 +68,5 @@ extendr_module! {
     fn error_chain;
     fn error_long_message;
     fn error_on_panic;
+    fn error_anyhow;
 }

--- a/tests/extendrtests/src/rust/src/lib.rs
+++ b/tests/extendrtests/src/rust/src/lib.rs
@@ -3,6 +3,7 @@ use extendr_api::{graphics::*, prelude::*};
 mod altrep;
 mod attributes;
 mod dataframe;
+mod errors;
 mod externalptr;
 mod graphic_device;
 mod hashmap;
@@ -353,6 +354,7 @@ extendr_module! {
     use altrep;
     use attributes;
     use dataframe;
+    use errors;
     use hashmap;
     use memory_leaks;
     use optional_either;

--- a/tests/extendrtests/tests/testthat/_snaps/macro-snapshot.md
+++ b/tests/extendrtests/tests/testthat/_snaps/macro-snapshot.md
@@ -135,10 +135,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "new_usize"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -216,8 +215,7 @@
           impl AltStringImpl for StringInts {
               fn elt(&self, index: usize) -> Rstr {
                   ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(format_args!("{0}", index));
-                          res
+                          ::alloc::fmt::format(format_args!("{0}", index))
                       })
                       .into()
               }
@@ -254,10 +252,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "tst_altstring"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -385,10 +382,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "tst_altinteger"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -550,10 +546,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "dbls_named"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -637,10 +632,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "strings_named"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -728,10 +722,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "list_named"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -973,13 +966,12 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!(
                                   "User function panicked: {0}",
                                   "test_derive_into_dataframe",
                               ),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -1062,13 +1054,12 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!(
                                   "User function panicked: {0}",
                                   "test_into_robj_dataframe",
                               ),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -1346,10 +1337,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "new"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -1431,10 +1421,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "set_a"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -1522,10 +1511,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "a"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -1610,10 +1598,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "me_owned"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -1707,10 +1694,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "me_ref"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -1804,10 +1790,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "me_mut"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -1901,10 +1886,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "me_explicit_ref"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -1998,10 +1982,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "me_explicit_mut"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -2109,10 +2092,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "max_ref"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -2242,10 +2224,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "max_ref_offset"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -2363,10 +2344,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "max_ref2"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -2471,13 +2451,12 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!(
                                   "User function panicked: {0}",
                                   "externalptr_use_ref_manually",
                               ),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -2559,13 +2538,12 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!(
                                   "User function panicked: {0}",
                                   "create_numeric_externalptr",
                               ),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -2652,13 +2630,12 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!(
                                   "User function panicked: {0}",
                                   "sum_integer_externalptr",
                               ),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -2750,10 +2727,9 @@
                       Err(unwind_err) => {
                           drop(unwind_err);
                           let err_string = ::alloc::__export::must_use({
-                              let res = ::alloc::fmt::format(
+                              ::alloc::fmt::format(
                                   format_args!("User function panicked: {0}", "a_10"),
-                              );
-                              res
+                              )
                           });
                           extendr_api::handle_panic(
                               err_string.as_str(),
@@ -2976,10 +2952,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "new_dog"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -3047,10 +3022,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "new_cat"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -3130,10 +3104,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "speak"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -3286,10 +3259,9 @@
                   let welcome_message = self.welcome_message;
                   print_r_output(
                       ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("message from device: {0}", welcome_message),
-                          );
-                          res
+                          )
                       }),
                   );
                   print_r_output("\n");
@@ -3297,8 +3269,7 @@
               fn close(&mut self, _dd: DevDesc) {
                   print_r_output(
                       ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(format_args!("good bye..."));
-                          res
+                          ::alloc::fmt::format(format_args!("good bye..."))
                       }),
                   );
                   print_r_output("\n");
@@ -3342,10 +3313,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "test_hm_string"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -3425,10 +3395,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "test_hm_i32"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -3537,13 +3506,12 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!(
                                   "User function panicked: {0}",
                                   "test_hm_custom_try_from",
                               ),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -3705,10 +3673,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "fetch_dimnames"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -3787,10 +3754,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "fetch_rownames"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -3869,10 +3835,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "fetch_colnames"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -3957,10 +3922,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "change_dimnames"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -4039,10 +4003,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "matrix_3d_return"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -4121,10 +4084,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "matrix_4d_return"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -4203,10 +4165,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "matrix_5d_return"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -4383,13 +4344,12 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!(
                                   "User function panicked: {0}",
                                   "leak_arg2_try_implicit_strings",
                               ),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -4486,13 +4446,12 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!(
                                   "User function panicked: {0}",
                                   "leak_arg2_try_implicit_doubles",
                               ),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -4581,13 +4540,12 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!(
                                   "User function panicked: {0}",
                                   "leak_unwrap_strings",
                               ),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -4668,13 +4626,12 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!(
                                   "User function panicked: {0}",
                                   "leak_unwrap_doubles",
                               ),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -4759,13 +4716,12 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!(
                                   "User function panicked: {0}",
                                   "leak_positive_control",
                               ),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -4850,13 +4806,12 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!(
                                   "User function panicked: {0}",
                                   "leak_negative_control",
                               ),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -5026,10 +4981,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "type_aware_sum"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -5192,10 +5146,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "mat_to_mat"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -5274,10 +5227,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "mat_to_rmat"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -5356,10 +5308,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "mat_to_robj"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -5438,10 +5389,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "mat_to_rmatfloat"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -5520,10 +5470,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "rmat_to_mat"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -5602,10 +5551,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "robj_to_mat"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -5684,10 +5632,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "matref_to_mat"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -5964,10 +5911,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "euclidean_dist"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -6139,13 +6085,12 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!(
                                   "User function panicked: {0}",
                                   "raw_identifier_in_fn_args",
                               ),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -6224,10 +6169,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "r#true"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -6305,10 +6249,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "r#false"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -6471,10 +6414,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "hello_submodule"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -6640,10 +6582,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "new"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -6725,10 +6666,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "set_a"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -6818,10 +6758,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "a"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -7012,10 +6951,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "to_unique_rstr"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -7111,10 +7049,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "to_unique_str"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -7281,10 +7218,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "sum_triplet_ints"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -7408,10 +7344,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "sum_points"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -7492,13 +7427,12 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!(
                                   "User function panicked: {0}",
                                   "round_trip_array_u8",
                               ),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -7583,13 +7517,12 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!(
                                   "User function panicked: {0}",
                                   "round_trip_array_f64",
                               ),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -7674,13 +7607,12 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!(
                                   "User function panicked: {0}",
                                   "round_trip_array_i32",
                               ),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -7765,13 +7697,12 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!(
                                   "User function panicked: {0}",
                                   "round_trip_array_rint",
                               ),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -7856,13 +7787,12 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!(
                                   "User function panicked: {0}",
                                   "round_trip_array_rfloat",
                               ),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -7947,13 +7877,12 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!(
                                   "User function panicked: {0}",
                                   "round_trip_array_rbool",
                               ),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -8038,13 +7967,12 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!(
                                   "User function panicked: {0}",
                                   "round_trip_array_rcplx",
                               ),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -8217,10 +8145,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "middle_zero"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -8309,10 +8236,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "logicals_sum"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -8405,10 +8331,9 @@
                   Err(unwind_err) => {
                       drop(unwind_err);
                       let err_string = ::alloc::__export::must_use({
-                          let res = ::alloc::fmt::format(
+                          ::alloc::fmt::format(
                               format_args!("User function panicked: {0}", "floats_mean"),
-                          );
-                          res
+                          )
                       });
                       extendr_api::handle_panic(
                           err_string.as_str(),
@@ -8567,10 +8492,9 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
+                      ::alloc::fmt::format(
                           format_args!("User function panicked: {0}", "hello_world"),
-                      );
-                      res
+                      )
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),
@@ -8639,10 +8563,9 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
+                      ::alloc::fmt::format(
                           format_args!("User function panicked: {0}", "do_nothing"),
-                      );
-                      res
+                      )
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),
@@ -8716,10 +8639,9 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
+                      ::alloc::fmt::format(
                           format_args!("User function panicked: {0}", "double_scalar"),
-                      );
-                      res
+                      )
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),
@@ -8798,10 +8720,9 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
+                      ::alloc::fmt::format(
                           format_args!("User function panicked: {0}", "int_scalar"),
-                      );
-                      res
+                      )
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),
@@ -8880,10 +8801,9 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
+                      ::alloc::fmt::format(
                           format_args!("User function panicked: {0}", "bool_scalar"),
-                      );
-                      res
+                      )
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),
@@ -8962,10 +8882,9 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
+                      ::alloc::fmt::format(
                           format_args!("User function panicked: {0}", "char_scalar"),
-                      );
-                      res
+                      )
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),
@@ -9044,10 +8963,9 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
+                      ::alloc::fmt::format(
                           format_args!("User function panicked: {0}", "char_vec"),
-                      );
-                      res
+                      )
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),
@@ -9126,10 +9044,9 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
+                      ::alloc::fmt::format(
                           format_args!("User function panicked: {0}", "double_vec"),
-                      );
-                      res
+                      )
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),
@@ -9205,10 +9122,9 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
+                      ::alloc::fmt::format(
                           format_args!("User function panicked: {0}", "try_rfloat_na"),
-                      );
-                      res
+                      )
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),
@@ -9279,10 +9195,9 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
+                      ::alloc::fmt::format(
                           format_args!("User function panicked: {0}", "try_rint_na"),
-                      );
-                      res
+                      )
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),
@@ -9356,10 +9271,9 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
+                      ::alloc::fmt::format(
                           format_args!("User function panicked: {0}", "check_rfloat_na"),
-                      );
-                      res
+                      )
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),
@@ -9438,10 +9352,9 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
+                      ::alloc::fmt::format(
                           format_args!("User function panicked: {0}", "check_rint_na"),
-                      );
-                      res
+                      )
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),
@@ -9528,10 +9441,9 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
+                      ::alloc::fmt::format(
                           format_args!("User function panicked: {0}", "get_doubles_element"),
-                      );
-                      res
+                      )
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),
@@ -9623,10 +9535,9 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
+                      ::alloc::fmt::format(
                           format_args!("User function panicked: {0}", "get_integers_element"),
-                      );
-                      res
+                      )
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),
@@ -9718,10 +9629,9 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
+                      ::alloc::fmt::format(
                           format_args!("User function panicked: {0}", "get_logicals_element"),
-                      );
-                      res
+                      )
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),
@@ -9809,10 +9719,9 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
+                      ::alloc::fmt::format(
                           format_args!("User function panicked: {0}", "doubles_square"),
-                      );
-                      res
+                      )
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),
@@ -9895,10 +9804,9 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
+                      ::alloc::fmt::format(
                           format_args!("User function panicked: {0}", "complexes_square"),
-                      );
-                      res
+                      )
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),
@@ -9981,10 +9889,9 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
+                      ::alloc::fmt::format(
                           format_args!("User function panicked: {0}", "integers_square"),
-                      );
-                      res
+                      )
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),
@@ -10067,10 +9974,9 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
+                      ::alloc::fmt::format(
                           format_args!("User function panicked: {0}", "logicals_not"),
-                      );
-                      res
+                      )
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),
@@ -10149,10 +10055,9 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
+                      ::alloc::fmt::format(
                           format_args!("User function panicked: {0}", "check_default"),
-                      );
-                      res
+                      )
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),
@@ -10244,10 +10149,9 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
+                      ::alloc::fmt::format(
                           format_args!("User function panicked: {0}", "special_param_names"),
-                      );
-                      res
+                      )
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),
@@ -10330,13 +10234,12 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
+                      ::alloc::fmt::format(
                           format_args!(
                               "User function panicked: {0}",
                               "__00__special_function_name",
                           ),
-                      );
-                      res
+                      )
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),
@@ -10407,10 +10310,9 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
+                      ::alloc::fmt::format(
                           format_args!("User function panicked: {0}", "test.rename.rlike"),
-                      );
-                      res
+                      )
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),
@@ -10484,10 +10386,9 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
+                      ::alloc::fmt::format(
                           format_args!("User function panicked: {0}", "get_default_value"),
-                      );
-                      res
+                      )
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),
@@ -10566,10 +10467,9 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
+                      ::alloc::fmt::format(
                           format_args!("User function panicked: {0}", "add_5_if_not_null"),
-                      );
-                      res
+                      )
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),
@@ -10736,10 +10636,7 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
-                          format_args!("User function panicked: {0}", "new"),
-                      );
-                      res
+                      ::alloc::fmt::format(format_args!("User function panicked: {0}", "new"))
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),
@@ -10821,10 +10718,9 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
+                      ::alloc::fmt::format(
                           format_args!("User function panicked: {0}", "set_a"),
-                      );
-                      res
+                      )
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),
@@ -10912,10 +10808,7 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
-                          format_args!("User function panicked: {0}", "a"),
-                      );
-                      res
+                      ::alloc::fmt::format(format_args!("User function panicked: {0}", "a"))
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),
@@ -11004,10 +10897,7 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
-                          format_args!("User function panicked: {0}", "me"),
-                      );
-                      res
+                      ::alloc::fmt::format(format_args!("User function panicked: {0}", "me"))
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),
@@ -11089,10 +10979,9 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
+                      ::alloc::fmt::format(
                           format_args!("User function panicked: {0}", "restore_from_robj"),
-                      );
-                      res
+                      )
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),
@@ -11174,10 +11063,9 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
+                      ::alloc::fmt::format(
                           format_args!("User function panicked: {0}", "get_default_value"),
-                      );
-                      res
+                      )
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),
@@ -11331,10 +11219,7 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
-                          format_args!("User function panicked: {0}", "new"),
-                      );
-                      res
+                      ::alloc::fmt::format(format_args!("User function panicked: {0}", "new"))
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),
@@ -11414,10 +11299,9 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
+                      ::alloc::fmt::format(
                           format_args!("User function panicked: {0}", "__name_test"),
-                      );
-                      res
+                      )
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),
@@ -11579,10 +11463,7 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
-                          format_args!("User function panicked: {0}", "new"),
-                      );
-                      res
+                      ::alloc::fmt::format(format_args!("User function panicked: {0}", "new"))
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),
@@ -11662,10 +11543,7 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
-                          format_args!("User function panicked: {0}", "a"),
-                      );
-                      res
+                      ::alloc::fmt::format(format_args!("User function panicked: {0}", "a"))
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),
@@ -11769,10 +11647,9 @@
               Err(unwind_err) => {
                   drop(unwind_err);
                   let err_string = ::alloc::__export::must_use({
-                      let res = ::alloc::fmt::format(
+                      ::alloc::fmt::format(
                           format_args!("User function panicked: {0}", "my_device"),
-                      );
-                      res
+                      )
                   });
                   extendr_api::handle_panic(
                       err_string.as_str(),

--- a/tests/extendrtests/tests/testthat/test-errors.R
+++ b/tests/extendrtests/tests/testthat/test-errors.R
@@ -193,3 +193,22 @@ test_that("Error handling does not leak memory", {
     Sys.setenv(EXTENDR_BACKTRACE = orig_val)
   }
 })
+
+test_that("Error handling on panic", {
+  # Save original EXTENDR_BACKTRACE value
+  orig_val <- Sys.getenv("EXTENDR_BACKTRACE", unset = NA)
+
+  # Test with default (no backtrace)
+  Sys.unsetenv("EXTENDR_BACKTRACE")
+
+  expect_error(
+    error_on_panic()
+  )
+  
+  # Restore original value
+  if (is.na(orig_val)) {
+    Sys.unsetenv("EXTENDR_BACKTRACE")
+  } else {
+    Sys.setenv(EXTENDR_BACKTRACE = orig_val)
+  }
+})

--- a/tests/extendrtests/tests/testthat/test-errors.R
+++ b/tests/extendrtests/tests/testthat/test-errors.R
@@ -1,0 +1,195 @@
+test_that("Error functions throw clean errors by default", {
+  # remove any extendr-backtrace env vars
+  Sys.unsetenv("EXTENDR_BACKTRACE")
+
+  expect_error(
+    error_simple(),
+    "This is a simple error message",
+    fixed = TRUE
+  )
+
+  expect_error(
+    error_parse_int("not_a_number"),
+    "invalid digit found in string"
+  )
+
+  expect_error(
+    error_division(10, 0),
+    "Division by zero is not allowed",
+    fixed = TRUE
+  )
+
+  expect_error(
+    error_chain("abc"),
+    "Parse error:"
+  )
+
+  expect_error(
+    error_chain("-5"),
+    "Negative numbers not allowed",
+    fixed = TRUE
+  )
+
+  expect_error(
+    error_long_message(),
+    "This is a longer error message"
+  )
+})
+
+test_that("Successful Result returns value correctly", {
+  expect_equal(error_success(), 42L)
+  expect_equal(error_division(10, 2), 5.0)
+  expect_equal(error_chain("42"), 42.0)
+})
+
+test_that("Error messages do not contain Rust traceback by default", {
+  Sys.unsetenv("EXTENDR_BACKTRACE")
+
+  err <- tryCatch(
+    error_simple(),
+    error = function(e) conditionMessage(e)
+  )
+
+  expect_false(grepl("thread 'main' panicked", err))
+  expect_false(grepl("stack backtrace:", err))
+  expect_false(grepl("at src/", err))
+
+  expect_true(grepl("This is a simple error message", err, fixed = TRUE))
+})
+
+test_that("EXTENDR_BACKTRACE=true shows full traceback", {
+  orig_val <- Sys.getenv("EXTENDR_BACKTRACE", unset = NA)
+
+  Sys.setenv(EXTENDR_BACKTRACE = "true")
+
+  # Capture the error
+  err <- tryCatch(
+    error_simple(),
+    error = function(e) conditionMessage(e)
+  )
+
+  if (is.na(orig_val)) {
+    Sys.unsetenv("EXTENDR_BACKTRACE")
+  } else {
+    Sys.setenv(EXTENDR_BACKTRACE = orig_val)
+  }
+
+  expect_true(grepl("unwrap.*Err", err, ignore.case = TRUE))
+  expect_true(grepl("This is a simple error message", err))
+})
+
+test_that("EXTENDR_BACKTRACE=1 also shows full traceback", {
+  orig_val <- Sys.getenv("EXTENDR_BACKTRACE", unset = NA)
+
+  # extendr backtrace should honor a value of 1 too
+  Sys.setenv(EXTENDR_BACKTRACE = "1")
+
+  err <- tryCatch(
+    error_simple(),
+    error = function(e) conditionMessage(e)
+  )
+
+  if (is.na(orig_val)) {
+    Sys.unsetenv("EXTENDR_BACKTRACE")
+  } else {
+    Sys.setenv(EXTENDR_BACKTRACE = orig_val)
+  }
+
+  expect_true(grepl("unwrap.*Err", err, ignore.case = TRUE))
+  expect_true(grepl("This is a simple error message", err))
+})
+
+test_that("EXTENDR_BACKTRACE=false shows clean error", {
+  orig_val <- Sys.getenv("EXTENDR_BACKTRACE", unset = NA)
+
+  Sys.setenv(EXTENDR_BACKTRACE = "false")
+
+  err <- tryCatch(
+    error_simple(),
+    error = function(e) conditionMessage(e)
+  )
+
+  if (is.na(orig_val)) {
+    Sys.unsetenv("EXTENDR_BACKTRACE")
+  } else {
+    Sys.setenv(EXTENDR_BACKTRACE = orig_val)
+  }
+
+  expect_true(grepl("This is a simple error message", err, fixed = TRUE))
+  expect_false(grepl("thread 'main' panicked", err))
+})
+
+test_that("Error handling does not leak memory", {
+  skip_if_not_installed("lobstr")
+
+  # Save original EXTENDR_BACKTRACE value
+  orig_val <- Sys.getenv("EXTENDR_BACKTRACE", unset = NA)
+
+  # Test with default (no backtrace)
+  Sys.unsetenv("EXTENDR_BACKTRACE")
+
+  # Measure memory before
+  mem_before <- lobstr::mem_used()
+
+  # Run error functions once
+  for (i in 1:10) {
+    tryCatch(error_simple(), error = function(e) NULL)
+    tryCatch(error_division(1, 0), error = function(e) NULL)
+    tryCatch(error_chain("abc"), error = function(e) NULL)
+  }
+
+  gc(verbose = FALSE)
+  mem_after <- lobstr::mem_used()
+
+  # Measure leak for repeated runs
+  mem_before_repeat <- lobstr::mem_used()
+  n_repeats <- 100
+
+  for (i in 1:n_repeats) {
+    tryCatch(error_simple(), error = function(e) NULL)
+    tryCatch(error_division(1, 0), error = function(e) NULL)
+    tryCatch(error_chain("abc"), error = function(e) NULL)
+  }
+
+  gc(verbose = FALSE)
+  mem_after_repeat <- lobstr::mem_used()
+
+  # Calculate leak per iteration
+  leak_per_iter <- as.numeric(mem_after_repeat - mem_before_repeat) / n_repeats
+
+  # Should not leak more than 256 bytes per iteration (same threshold as existing tests)
+  expect_true(
+    leak_per_iter <= 256,
+    info = sprintf("Leaked %f bytes per iteration", leak_per_iter)
+  )
+
+  # Test with EXTENDR_BACKTRACE=true
+  Sys.setenv(EXTENDR_BACKTRACE = "true")
+
+  mem_before_tb <- lobstr::mem_used()
+
+  for (i in 1:n_repeats) {
+    tryCatch(error_simple(), error = function(e) NULL)
+    tryCatch(error_division(1, 0), error = function(e) NULL)
+  }
+
+  gc(verbose = FALSE)
+  mem_after_tb <- lobstr::mem_used()
+
+  leak_per_iter_tb <- as.numeric(mem_after_tb - mem_before_tb) / n_repeats
+
+  expect_true(
+    leak_per_iter_tb <= 256,
+    info = sprintf(
+      "Leaked %f bytes per iteration with backtrace",
+      leak_per_iter_tb
+    )
+  )
+
+  # Restore original value
+  if (is.na(orig_val)) {
+    Sys.unsetenv("EXTENDR_BACKTRACE")
+  } else {
+    Sys.setenv(EXTENDR_BACKTRACE = orig_val)
+  }
+})

--- a/tests/extendrtests/tests/testthat/test-errors.R
+++ b/tests/extendrtests/tests/testthat/test-errors.R
@@ -74,7 +74,6 @@ test_that("EXTENDR_BACKTRACE=true shows full traceback", {
     Sys.setenv(EXTENDR_BACKTRACE = orig_val)
   }
 
-  expect_true(grepl("unwrap.*Err", err, ignore.case = TRUE))
   expect_true(grepl("This is a simple error message", err))
 })
 
@@ -95,7 +94,6 @@ test_that("EXTENDR_BACKTRACE=1 also shows full traceback", {
     Sys.setenv(EXTENDR_BACKTRACE = orig_val)
   }
 
-  expect_true(grepl("unwrap.*Err", err, ignore.case = TRUE))
   expect_true(grepl("This is a simple error message", err))
 })
 
@@ -192,6 +190,14 @@ test_that("Error handling does not leak memory", {
   } else {
     Sys.setenv(EXTENDR_BACKTRACE = orig_val)
   }
+})
+
+test_that("Foreign error types (anyhow) produce clean errors", {
+  Sys.unsetenv("EXTENDR_BACKTRACE")
+  err <- tryCatch(error_anyhow(), error = function(e) conditionMessage(e))
+  expect_true(grepl("This is an anyhow error", err, fixed = TRUE))
+  expect_false(grepl("called.*unwrap.*on an.*Err", err))
+  expect_false(grepl("stack backtrace", err, ignore.case = TRUE))
 })
 
 test_that("Error handling on panic", {


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Cuts a `0.8` maintenance branch from the `extendr-api-v0.8.1` tag and prepares a non-breaking 0.8.2 patch release, as requested in extendr/rextendr#531.
- Backports (cherry-picked with original authorship):
  - #950: `extendr-ffi` builds for `aarch64-pc-windows-gnullvm` (Windows ARM64), the fix Jeroen asked for.
  - #959 + #981: graphics devices report the correct graphics engine version on R >= 4.3 (GE 16) and R >= 4.6 (GE 17), and use `GECreateDevDesc` where available.
  - #973, the panic-hook registration fix, and #1055: R errors no longer carry Rust tracebacks or `unwrap` noise; `EXTENDR_BACKTRACE=1` restores the full traceback.
  - #983: serde deserialization of borrowed strings no longer panics with `unimplemented!()`.
  - #1044: `Rf_isFrame` routed through `extendr-ffi` backports for C API compliance.
  - #965: warning/clippy cleanup on current stable, `rust-version = "1.65"` declared.
  - Test hygiene already staged on `patch_release_0.8.1`: macro snapshot refresh, extendrtests `build.rs` lint fix. (The R-less build CI job and its 4.5.1-default fix were dropped per #1109's closure.)
- Bumps the workspace version to 0.8.2 and pins internal `extendr-ffi`/`extendr-macros` requirements to 0.8.2 so upgrading `extendr-api` guarantees the fixed `extendr-ffi`.
- Restores three public API items the backports had accidentally altered (caught by `cargo semver-checks`): `Robj::from_sexp` and `AltrepImpl::{dataptr, dataptr_or_null}` stay safe fns as in 0.8.1 (#965 had made them `unsafe`), and `extendr_ffi::Rf_isFrame` stays available at its old path with C ABI, now delegating to the `is_data_frame` backport (#1044 had removed it).
- Deliberately not backported: all breaking 0.9 changes (#898, #1000, #1005, #1018, #1020, #1028, #1067, #1069), additive features (#864, #871, #946, #955, #977, #985), deprecations (#952, #971, #972, #982), and the extendrtests Windows build rework (#1042).

## Test plan
- [x] `cargo semver-checks` vs the published 0.8.1 baselines: `extendr-api`, `extendr-ffi`, `extendr-engine` all report "no semver update required"
- [x] `cargo check --workspace --all-features --all-targets` clean on stable 1.97.1
- [x] Workspace test suite passes with `serde,ndarray,num-complex` (including the ported deserializer round-trip test)
- [x] extendr-macros trybuild snapshot refreshed and passing
- [x] `build-no-r` was green on this PR before the workflow was dropped per #1109's closure (the branch retains the cfg-consistency fix for the no-R fallback in `extendr-ffi`)

## Notes
- `graphics_tests::device_driver_test` segfaults locally under R 4.6, but it fails identically on the pristine `extendr-api-v0.8.1` tag and on `master`, so it is a pre-existing environment issue, not a regression from these backports.
- The old `patch_release_0.8.1` branch head has `master` merged into it (including breaking #898), which is why this branch is rebuilt from the tag instead.
- Suggested release order after merge: publish `extendr-ffi`, `extendr-macros`, `extendr-engine`, then `extendr-api`; tag as with 0.8.1.

---
_Drafted by Claude (claude-fable-5). Reviewed by the author._

</details>

