### PR TITLE
fix(extendr-ffi): emit consistent cfgs and version exports when R is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 ### Fixed
 
 - `throw_r_error()` no longer segfaults when the message contains `%` characters. <https://github.com/extendr/extendr/issues/1058> behavior now in line with cpp11 and Rcpp
+- `extendr-ffi` now emits a complete set of cfg flags and `DEP_R_R_VERSION_*` exports when R cannot be found, so R-less builds (docs.rs, rust-analyzer, CI without R) no longer panic in `extendr-api`'s build script or miscompile version-gated items.
 
 ## 0.9.0 — 2026-04-16
 

--- a/extendr-api/src/graphics/device_driver.rs
+++ b/extendr-api/src/graphics/device_driver.rs
@@ -8,7 +8,7 @@ use extendr_ffi::{
 };
 
 #[cfg(use_r_ge_version_17)]
-use extendr_ffi::{GEcreateDD, GEfreeDD};
+use extendr_ffi::GEcreateDD;
 /// The underlying C structure `DevDesc` has two fields related to clipping:
 ///
 /// - `canClip`

--- a/extendr-ffi/build.rs
+++ b/extendr-ffi/build.rs
@@ -166,6 +166,43 @@ impl InstallationPaths {
     }
 }
 
+/// Emits the R-version-derived build flags: the `rustc-cfg` flags consumed by
+/// this crate and the `DEP_R_R_VERSION_*` exports consumed by dependents such
+/// as extendr-api. Both the detected-R path and the no-R fallback go through
+/// here so the two can never disagree.
+fn emit_r_version_flags(version: &Version) {
+    // used by extendr-api
+    println!("cargo:r_version_major={}", version.major);
+    println!("cargo:r_version_minor={}", version.minor);
+    println!("cargo:r_version_patch={}", version.patch);
+
+    // Set R version specfic config flags
+    // use r_4_4 config
+    if (version.major, version.minor) >= (4, 4) {
+        println!("cargo:rustc-cfg=r_4_4")
+    }
+
+    // use r_4_5 config
+    if (version.major, version.minor) >= (4, 5) {
+        println!("cargo:rustc-cfg=r_4_5")
+    }
+
+    // Graphics engine version 15 was introduced in R 4.2
+    if (version.major, version.minor) >= (4, 2) {
+        println!("cargo:rustc-cfg=use_r_ge_version_15")
+    }
+
+    // Graphics engine version 16 was introduced in R 4.3
+    if (version.major, version.minor) >= (4, 3) {
+        println!("cargo:rustc-cfg=use_r_ge_version_16")
+    }
+
+    // Graphics engine version 17 was introduced in R 4.6
+    if (version.major, version.minor) >= (4, 6) {
+        println!("cargo:rustc-cfg=use_r_ge_version_17")
+    }
+}
+
 fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rustc-check-cfg=cfg(r_4_4)");
     println!("cargo:rustc-check-cfg=cfg(r_4_5)");
@@ -177,8 +214,18 @@ fn main() -> Result<(), Box<dyn Error>> {
     let r_paths = match InstallationPaths::try_new() {
         Ok(v) => v,
         Err(_) => {
-            warn!("Cannot fetch R version from R. Defaulting to most recent configure flag");
-            println!("cargo:rustc-cfg=r_4_5");
+            warn!("Cannot fetch R version from R. Defaulting to the newest known R version");
+            // Without a detected R there is nothing to link against, so this
+            // build only serves type-checking surfaces (docs.rs, rust-analyzer,
+            // clippy CI). Default to the newest R version this build script
+            // knows about, so every version-gated API is enabled rather than
+            // an arbitrary older subset. Bump this together with any new
+            // version flag added to emit_r_version_flags.
+            emit_r_version_flags(&Version {
+                major: 4,
+                minor: 6,
+                patch: 0,
+            });
             return Ok(());
         }
     };
@@ -187,10 +234,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:r_home={}", r_paths.r_home.display());
     println!("cargo:rustc-env=R_HOME={}", r_paths.r_home.display());
 
-    // used by extendr-api
-    println!("cargo:r_version_major={}", r_paths.version.major);
-    println!("cargo:r_version_minor={}", r_paths.version.minor);
-    println!("cargo:r_version_patch={}", r_paths.version.patch);
+    emit_r_version_flags(&r_paths.version);
 
     let pkg_target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
 
@@ -213,32 +257,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     println!("cargo:rustc-link-lib=dylib=R");
-
-    // Set R version specfic config flags
-    // use r_4_4 config
-    if (r_paths.version.major, r_paths.version.minor) >= (4, 4) {
-        println!("cargo:rustc-cfg=r_4_4")
-    }
-
-    // use r_4_5 config
-    if (r_paths.version.major, r_paths.version.minor) >= (4, 5) {
-        println!("cargo:rustc-cfg=r_4_5")
-    }
-
-    // Graphics engine version 15 was introduced in R 4.2
-    if (r_paths.version.major, r_paths.version.minor) >= (4, 2) {
-        println!("cargo:rustc-cfg=use_r_ge_version_15")
-    }
-
-    // Graphics engine version 16 was introduced in R 4.3
-    if (r_paths.version.major, r_paths.version.minor) >= (4, 3) {
-        println!("cargo:rustc-cfg=use_r_ge_version_16")
-    }
-
-    // Graphics engine version 17 was introduced in R 4.6
-    if (r_paths.version.major, r_paths.version.minor) >= (4, 6) {
-        println!("cargo:rustc-cfg=use_r_ge_version_17")
-    }
 
     // Only re-run if the include directory changes
     println!("cargo:rerun-if-env-changed=R_INCLUDE_DIR");


### PR DESCRIPTION
This avoids getting cargo lint warnings just because the detection of active R version failed. Does not improve much, but slightly less annoying when starting out.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- The no-R fallback in `extendr-ffi/build.rs` set only the `r_4_5` cfg and returned early without emitting `cargo:r_version_major/minor/patch`.
- `extendr-api`'s build script reads `DEP_R_R_VERSION_*` with `.unwrap()`, so any R-less build of `extendr-api` (docs.rs, rust-analyzer on machines without R, CI without R) panicked in the build script. Items gated on `r_4_4` or the graphics engine cfgs were also inconsistent with the 4.5.1 default the fallback claims.
- The version-derived cfg flags and `DEP_R_R_VERSION_*` exports now come from a single helper used by both the detected-R path and the no-R fallback, so the two can never disagree. Note `r_4_4`/`r_4_5` are independent cfg flags, not cumulative: `r_4_5` alone does not enable `#[cfg(r_4_4)]` items such as `SEXPTYPE::OBJSXP`.
- A build without a detected R has nothing to link against, so it only serves type-checking surfaces (docs.rs, rust-analyzer, clippy CI). The fallback therefore passes the newest R version the build script knows about (currently 4.6), enabling every version-gated API rather than an arbitrary older subset.
- Drops the unused `GEfreeDD` import (unused since #981), which warns on every build where `use_r_ge_version_17` is active.
- Same fix as shipped on the 0.8 line in #1107, where the equivalent bug (there it surfaced as `SEXPTYPE::OBJSXP` not found) had the `build-no-r` job failing on every run of `patch_release_0.8.1` since July 2025.

## Test plan
- [x] `cargo build` of `tests/extendrtests/src/rust` with R removed from PATH and `R_HOME` unset reaches the fallback and no longer panics in `extendr-api`'s build script
- [x] Normal with-R `cargo check -p extendr-ffi -p extendr-api` unaffected
- [ ] CI on this PR

---
_Drafted by Claude (claude-fable-5). Reviewed by the author._

</details>


