### PR TITLE
ci: build the Rust crate without R on PATH

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -1,0 +1,50 @@
+name: Rust crate build (no R allowed)
+
+on:
+  push:
+    paths:
+      - "extendr-api/**"
+      - "extendr-engine/**"
+      - "extendr-ffi/**"
+      - "extendr-macros/**"
+      - "tests/extendrtests/src/rust/**"
+      - ".github/workflows/test_rust.yml"
+  pull_request:
+    paths:
+      - "extendr-api/**"
+      - "extendr-engine/**"
+      - "extendr-ffi/**"
+      - "extendr-macros/**"
+      - "tests/extendrtests/src/rust/**"
+      - ".github/workflows/test_rust.yml"
+
+permissions:
+  contents: read
+jobs:
+  build-no-r:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Ensure R is NOT on PATH
+        run: |
+          if command -v R >/dev/null 2>&1; then
+            echo "❌ R is on PATH"
+            exit 1
+          fi
+          echo "✅ R not found on PATH"
+
+      - name: Ensure R_HOME is NOT set
+        run: |
+          if [ -n "${R_HOME:-}" ]; then
+            echo "❌ R_HOME is set: $R_HOME"
+            exit 1
+          fi
+          echo "✅ R_HOME not set"
+
+      - name: Build Rust crate
+        run: |
+          cd tests/extendrtests/src/rust
+          cargo build --verbose

--- a/tests/extendrtests/src/rust/build.rs
+++ b/tests/extendrtests/src/rust/build.rs
@@ -14,40 +14,49 @@ fn main() {
     } else {
         std::process::Command::new("R")
     };
-    let r_version = path_to_r
-        .arg("CMD")
-        .args(["config", "--version"])
-        .output()
-        .expect("failed to run `R CMD config --version`");
-    assert!(r_version.status.success());
-    use std::io::BufRead as _;
-    let r_version_line = r_version
-        .stdout
-        .lines()
-        .next()
-        .expect("there were no outputs from `R CMD config`")
-        .expect("failed to read the line with R version");
-    let raw_r_version = r_version_line
-        .split(':')
-        .nth(1)
-        .unwrap()
-        .trim()
-        // ignore commit
-        // only capture the first the major.minor.patch part of the version
-        .split_ascii_whitespace()
-        .next()
-        .unwrap();
-    let raw_r_version: Vec<u32> = raw_r_version
-        .split('.')
-        .map(|x| x.parse().unwrap())
-        .collect();
-    assert!(
-        raw_r_version.len() >= 3,
-        "R version was not detected properly"
-    );
-    let major = raw_r_version[0];
-    let minor = raw_r_version[1];
-    let patch = raw_r_version[2];
+    // default to  assumed R version
+    let mut major = 4;
+    let mut minor = 5;
+    let mut patch = 1;
+    if std::path::PathBuf::from(path_to_r.get_program().to_os_string()).exists() {
+        let r_version = path_to_r
+            .arg("CMD")
+            .args(["config", "--version"])
+            .output()
+            .expect("failed to run `R CMD config --version`");
+        assert!(r_version.status.success());
+        use std::io::BufRead as _;
+        let r_version_line = r_version
+            .stdout
+            .lines()
+            .next()
+            .expect("there were no outputs from `R CMD config`")
+            .expect("failed to read the line with R version");
+        let raw_r_version = r_version_line
+            .split(':')
+            .nth(1)
+            .unwrap()
+            .trim()
+            // ignore commit
+            // only capture the first the major.minor.patch part of the version
+            .split_ascii_whitespace()
+            .next()
+            .unwrap();
+        let raw_r_version: Vec<u32> = raw_r_version
+            .split('.')
+            .map(|x| x.parse().unwrap())
+            .collect();
+        assert!(
+            raw_r_version.len() >= 3,
+            "R version was not detected properly"
+        );
+        major = raw_r_version[0];
+        minor = raw_r_version[1];
+        patch = raw_r_version[2];
+    }
+    let major = major;
+    let minor = minor;
+    let patch = patch;
 
     println!("cargo:r_version_major={}", major); // Becomes DEP_R_R_VERSION_MAJOR
     println!("cargo:r_version_minor={}", minor); // Becomes DEP_R_R_VERSION_MINOR


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Ports the `build-no-r` CI job from the 0.8 release line (#1107) to main: builds `tests/extendrtests/src/rust` on a runner with no R on PATH and no `R_HOME`, so the R-less build path (docs.rs, rust-analyzer without R) keeps coverage.
- Cherry-picks the `tests/extendrtests/src/rust/build.rs` fix from the 0.8 line that defaults the R version to 4.5.1 when R is not found; main's copy still panicked on `R CMD config --version`.
- Path filters cover the four extendr crates, the test crate, and the workflow file itself, since R detection lives in the crates' build scripts.
- Stacked on #1108 (the `extendr-ffi` fallback fix); without it the job cannot pass. Base is set to that branch and will retarget to main when it merges.

## Test plan
- [x] Local reproduction of the job (R stripped from PATH, `R_HOME` unset): `cargo build` of the test crate succeeds with both fixes
- [ ] `build-no-r` green on this PR

---
_Drafted by Claude (claude-fable-5). Reviewed by the author._

</details>
